### PR TITLE
Introduce a clock abstraction, so we don't need to rely on DateTime.U…

### DIFF
--- a/src/Google.Api.Gax/Api/Gax/IClock.cs
+++ b/src/Google.Api.Gax/Api/Gax/IClock.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// An abstraction of the ability to determine the current date and time.
+    /// </summary>
+    /// <remarks>
+    /// This interface primarily exists for testing purposes, allowing test code to
+    /// isolate itself from the system clock. In production, the <see cref="SystemClock"/>
+    /// implementation is by far the most likely one to be used, and the only one provided
+    /// within this library. Code that uses a clock should generally be designed to allow it
+    /// to be optionally specified, defaulting to <see cref="SystemClock.Instance"/>.
+    /// </remarks>
+    public interface IClock
+    {
+        /// <summary>
+        /// Returns the current date and time in UTC, with a kind of <see cref="DateTimeKind.Utc"/>.
+        /// </summary>
+        /// <returns>A <see cref="DateTime"/> representing the current date and time in UTC.</returns>
+        DateTime GetCurrentDateTimeUtc();
+    }
+}

--- a/src/Google.Api.Gax/Api/Gax/SystemClock.cs
+++ b/src/Google.Api.Gax/Api/Gax/SystemClock.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+ 
+ using System;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// A singleton implementation of <see cref="IClock"/> which delegates to the BCL
+    /// <see cref="DateTime.UtcNow"/> property.
+    /// </summary>
+    public sealed class SystemClock : IClock
+    {
+        /// <summary>
+        /// Retrieves the singleton instance of this type.
+        /// </summary>
+        public static IClock Instance { get; } = new SystemClock();
+
+        private SystemClock()
+        {
+        }
+
+        /// <summary>
+        /// Returns the current date and time in UTC, using <see cref="DateTime.UtcNow"/>.
+        /// </summary>
+        /// <returns>The current date and time in UTC.</returns>
+        public DateTime GetCurrentDateTimeUtc() => DateTime.UtcNow;
+    }
+}


### PR DESCRIPTION
…tcNow directly

The GetCurrentDateTimeUtc name is unwieldy, but:
- It should be a method not a property, as Eric Lippert describes in http://ericlippert.com/2014/05/19/when-should-i-write-a-property/
- The name needs to indicate that it's UTC
- The noun part of the name might as well use DateTime as that's what it returns

We could consider using DateTimeOffset instead, although the offset would always be zero.

(In Noda Time 2.0 this is GetCurrentInstant, which is cleaner... but we really need to work with the BCL here...)