### PR TITLE
Initial docfx support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 obj
 bin
 project.lock.json
+
+# Used by docfx as the conventional output directory.
+# (We could put this under obj if that became simpler; see
+# docfx.json.)
+_site

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,27 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/project.json" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": "src"
+        }
+      ],
+      "dest": "obj/api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "cwd": "obj/api",
+        "dest": "api"
+      },
+    ],
+    "globalMetadata": {
+      "_appTitle": "GAX: Google API Extensions"
+    },
+    "dest": "_site"
+  }
+}

--- a/src/Google.Api.Gax/Api/Gax/BundleComposer.cs
+++ b/src/Google.Api.Gax/Api/Gax/BundleComposer.cs
@@ -14,7 +14,7 @@ using System.Linq;
 namespace Google.Api.Gax
 {
     /// <summary>
-    /// Describes operations used by a <see cref="Bundler"/> to combine requests together and split a
+    /// Describes operations used by a <see cref="Bundler{,}"/> to combine requests together and split a
     /// single response into its components to reply to the original requests.
     /// </summary>
     /// <remarks>This type is almost never needed by manually written code.


### PR DESCRIPTION
Enough to at least let us build and view documentation; whether we add articles here (vs in a language-neutral repo) is an open question.