### PR TITLE
Make GAX use Grpc 0.13.1, which has better native extension handling

### DIFF
--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -13,9 +13,8 @@
   "dependencies": {
     "Google.Apis.Auth": "1.11.0",
     "Google.Protobuf": "3.0.0-beta2",
-    "Grpc.Auth": "0.13.0",
-    "Grpc.Core": "0.13.0",
-    "grpc.native.csharp": "0.13.0",
+    "Grpc.Auth": "0.13.1",
+    "Grpc.Core": "0.13.1",
     "Ix-Async": "1.2.5"
   },
   "frameworks": {


### PR DESCRIPTION
The direct dependency on the native library is unnecessary because Grpc.Core depends on it already.