### PR TITLE
Retry again

### DIFF
--- a/src/Google.Api.Gax/ApiCallRetryExtensions.cs
+++ b/src/Google.Api.Gax/ApiCallRetryExtensions.cs
@@ -23,12 +23,12 @@ namespace Google.Api.Gax
             IClock clock, IScheduler scheduler) =>
             async (request, callSettings) =>
             {
-                if (callSettings.RetrySettings == null)
+                RetrySettings retrySettings = callSettings.CallTiming?.Retry;
+                if (retrySettings == null)
                 {
                     return await fn(request, callSettings);
                 }
-                RetrySettings retrySettings = callSettings.RetrySettings;
-                DateTime? overallDeadline = callSettings.Expiration.CalculateDeadline(clock);
+                DateTime? overallDeadline = retrySettings.TotalExpiration.CalculateDeadline(clock);
                 TimeSpan retryDelay = retrySettings.RetryBackoff.Delay;
                 TimeSpan callTimeout = retrySettings.TimeoutBackoff.Delay;
                 // May not need to clone, not yet quite sure...
@@ -38,7 +38,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.Expiration = Expiration.FromDeadline(combinedDeadline);
+                    attemptCallSettings.CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
                     try
                     {
                         return await fn(request, attemptCallSettings);
@@ -64,12 +64,12 @@ namespace Google.Api.Gax
             IClock clock, IScheduler scheduler) =>
             (request, callSettings) =>
             {
-                if (callSettings.RetrySettings == null)
+                RetrySettings retrySettings = callSettings.CallTiming?.Retry;
+                if (retrySettings == null)
                 {
                     return fn(request, callSettings);
                 }
-                RetrySettings retrySettings = callSettings.RetrySettings;
-                DateTime? overallDeadline = callSettings.Expiration.CalculateDeadline(clock);
+                DateTime? overallDeadline = retrySettings.TotalExpiration.CalculateDeadline(clock);
                 TimeSpan retryDelay = retrySettings.RetryBackoff.Delay;
                 TimeSpan callTimeout = retrySettings.TimeoutBackoff.Delay;
                 // May not need to clone, not yet quite sure...
@@ -79,7 +79,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.Expiration = Expiration.FromDeadline(combinedDeadline);
+                    attemptCallSettings.CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
                     try
                     {
                         return fn(request, attemptCallSettings);

--- a/src/Google.Api.Gax/ApiCallRetryExtensions.cs
+++ b/src/Google.Api.Gax/ApiCallRetryExtensions.cs
@@ -23,7 +23,7 @@ namespace Google.Api.Gax
             IClock clock, IScheduler scheduler) =>
             async (request, callSettings) =>
             {
-                RetrySettings retrySettings = callSettings.CallTiming?.Retry;
+                RetrySettings retrySettings = callSettings.Timing?.Retry;
                 if (retrySettings == null)
                 {
                     return await fn(request, callSettings);
@@ -38,7 +38,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
+                    attemptCallSettings.Timing = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
                     try
                     {
                         return await fn(request, attemptCallSettings);
@@ -64,7 +64,7 @@ namespace Google.Api.Gax
             IClock clock, IScheduler scheduler) =>
             (request, callSettings) =>
             {
-                RetrySettings retrySettings = callSettings.CallTiming?.Retry;
+                RetrySettings retrySettings = callSettings.Timing?.Retry;
                 if (retrySettings == null)
                 {
                     return fn(request, callSettings);
@@ -79,7 +79,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
+                    attemptCallSettings.Timing = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
                     try
                     {
                         return fn(request, attemptCallSettings);

--- a/src/Google.Api.Gax/ApiCallRetryExtensions.cs
+++ b/src/Google.Api.Gax/ApiCallRetryExtensions.cs
@@ -38,7 +38,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.Timing = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
+                    attemptCallSettings.Timing = CallTiming.FromDeadline(combinedDeadline);
                     try
                     {
                         return await fn(request, attemptCallSettings);
@@ -79,7 +79,7 @@ namespace Google.Api.Gax
                     DateTime attemptDeadline = clock.GetCurrentDateTimeUtc() + callTimeout;
                     // Note: this handles a null total deadline due to "<" returning false if overallDeadline is null.
                     DateTime combinedDeadline = overallDeadline < attemptDeadline ? overallDeadline.Value : attemptDeadline;
-                    attemptCallSettings.Timing = CallTiming.FromExpiration(Expiration.FromDeadline(combinedDeadline));
+                    attemptCallSettings.Timing = CallTiming.FromDeadline(combinedDeadline);
                     try
                     {
                         return fn(request, attemptCallSettings);

--- a/src/Google.Api.Gax/CallSettings.cs
+++ b/src/Google.Api.Gax/CallSettings.cs
@@ -22,12 +22,13 @@ namespace Google.Api.Gax
             if (other != null)
             {
                 Headers = other.Headers?.Clone();
-                Expiration = other.Expiration;
+                //Expiration = other.Expiration;
                 CancellationToken = other.CancellationToken;
                 WriteOptions = other.WriteOptions;
                 PropagationToken = other.PropagationToken;
                 Credentials = other.Credentials;
-                RetrySettings = other.RetrySettings?.Clone();
+                //RetrySettings = other.RetrySettings?.Clone();
+                CallTiming = other.CallTiming?.Clone();
             }
         }
         /// <summary>
@@ -35,11 +36,6 @@ namespace Google.Api.Gax
         /// </summary>
         //public Metadata Headers
         public Metadata Headers { get; set; }
-
-        /// <summary>
-        /// Call expiration.
-        /// </summary>
-        public Expiration Expiration { get; set; }
 
         /// <summary>
         /// Cancellation token that can be used for cancelling the call.
@@ -61,15 +57,7 @@ namespace Google.Api.Gax
         /// </summary>
         public CallCredentials Credentials { get; set; }
 
-        private RetrySettings _retrySettings;
-        /// <summary>
-        /// <see cref="RetrySettings"/> to use, or null for no retry.
-        /// </summary>
-        public RetrySettings RetrySettings
-        {
-            get { return _retrySettings; }
-            set { _retrySettings = value?.Validate(nameof(value)); }
-        }
+        public CallTiming CallTiming { get; set; }
 
         /// <summary>
         /// Creates a clone of this object, with all the same property values.
@@ -98,12 +86,13 @@ namespace Google.Api.Gax
             // Should a merge of Headers be additive, instead of overridding?
             // If additive, how to remove headers during an override?
             Headers = other.Headers ?? Headers;
-            Expiration = other.Expiration ?? Expiration;
+            //Expiration = other.Expiration ?? Expiration;
             CancellationToken = other.CancellationToken ?? CancellationToken;
             WriteOptions = other.WriteOptions ?? WriteOptions;
             PropagationToken = other.PropagationToken ?? PropagationToken;
             Credentials = other.Credentials ?? Credentials;
-            RetrySettings = other.RetrySettings ?? RetrySettings;
+            //RetrySettings = other.RetrySettings ?? RetrySettings;
+            CallTiming = other.CallTiming ?? CallTiming;
             return this;
         }
 
@@ -114,7 +103,7 @@ namespace Google.Api.Gax
         /// <returns>A <see cref="CallOptions"/> configured from this <see cref="CallSettings"/>.</returns>
         internal CallOptions ToCallOptions(IClock clock) => new CallOptions(
             headers: Headers,
-            deadline: Expiration.CalculateDeadline(clock),
+            deadline: CallTiming.CalculateDeadline(clock),
             cancellationToken: CancellationToken ?? default(CancellationToken),
             writeOptions: WriteOptions,
             propagationToken: PropagationToken,

--- a/src/Google.Api.Gax/CallSettings.cs
+++ b/src/Google.Api.Gax/CallSettings.cs
@@ -90,12 +90,10 @@ namespace Google.Api.Gax
             // Should a merge of Headers be additive, instead of overridding?
             // If additive, how to remove headers during an override?
             Headers = other.Headers ?? Headers;
-            //Expiration = other.Expiration ?? Expiration;
             CancellationToken = other.CancellationToken ?? CancellationToken;
             WriteOptions = other.WriteOptions ?? WriteOptions;
             PropagationToken = other.PropagationToken ?? PropagationToken;
             Credentials = other.Credentials ?? Credentials;
-            //RetrySettings = other.RetrySettings ?? RetrySettings;
             Timing = other.Timing ?? Timing;
             return this;
         }

--- a/src/Google.Api.Gax/CallSettings.cs
+++ b/src/Google.Api.Gax/CallSettings.cs
@@ -22,13 +22,11 @@ namespace Google.Api.Gax
             if (other != null)
             {
                 Headers = other.Headers?.Clone();
-                //Expiration = other.Expiration;
                 CancellationToken = other.CancellationToken;
                 WriteOptions = other.WriteOptions;
                 PropagationToken = other.PropagationToken;
                 Credentials = other.Credentials;
-                //RetrySettings = other.RetrySettings?.Clone();
-                CallTiming = other.CallTiming?.Clone();
+                Timing = other.Timing?.Clone();
             }
         }
         /// <summary>
@@ -57,7 +55,13 @@ namespace Google.Api.Gax
         /// </summary>
         public CallCredentials Credentials { get; set; }
 
-        public CallTiming CallTiming { get; set; }
+        /// <summary>
+        /// Timing to use for the call.
+        /// </summary>
+        /// <remarks>
+        /// Allows selecting between retry and simple expiration.
+        /// </remarks>
+        public CallTiming Timing { get; set; }
 
         /// <summary>
         /// Creates a clone of this object, with all the same property values.
@@ -92,7 +96,7 @@ namespace Google.Api.Gax
             PropagationToken = other.PropagationToken ?? PropagationToken;
             Credentials = other.Credentials ?? Credentials;
             //RetrySettings = other.RetrySettings ?? RetrySettings;
-            CallTiming = other.CallTiming ?? CallTiming;
+            Timing = other.Timing ?? Timing;
             return this;
         }
 
@@ -103,7 +107,7 @@ namespace Google.Api.Gax
         /// <returns>A <see cref="CallOptions"/> configured from this <see cref="CallSettings"/>.</returns>
         internal CallOptions ToCallOptions(IClock clock) => new CallOptions(
             headers: Headers,
-            deadline: CallTiming.CalculateDeadline(clock),
+            deadline: Timing.CalculateDeadline(clock),
             cancellationToken: CancellationToken ?? default(CancellationToken),
             writeOptions: WriteOptions,
             propagationToken: PropagationToken,

--- a/src/Google.Api.Gax/CallSettings.cs
+++ b/src/Google.Api.Gax/CallSettings.cs
@@ -56,7 +56,7 @@ namespace Google.Api.Gax
         public CallCredentials Credentials { get; set; }
 
         /// <summary>
-        /// Timing to use for the call.
+        /// <see cref="CallTiming"/> to use, or null for default retry/expiration behavior.
         /// </summary>
         /// <remarks>
         /// Allows selecting between retry and simple expiration.

--- a/src/Google.Api.Gax/CallTiming.cs
+++ b/src/Google.Api.Gax/CallTiming.cs
@@ -32,9 +32,25 @@ namespace Google.Api.Gax
         /// Create a <see cref="CallTiming"/> with a simple expiration; no retry.
         /// </summary>
         /// <param name="expiration">The <see cref="Google.Api.Gax.Expiration"/> for a call without retry.</param>
-        /// <returns>A <see cref="CallTiming"/> with the specified expiration, without retry.</returns>
+        /// <returns>A <see cref="CallTiming"/> with the specified expiration; without retry.</returns>
         public static CallTiming FromExpiration(Expiration expiration) =>
             new CallTiming(null, GaxPreconditions.CheckNotNull(expiration, nameof(expiration)));
+
+        /// <summary>
+        /// Create a <see cref="CallTiming"/> with a simple timeout; no retry.
+        /// </summary>
+        /// <param name="timeout">The relative timeout for a call without retry.</param>
+        /// <returns>A <see cref="CallTiming"/> with the specified timeout; without retry.</returns>
+        public static CallTiming FromTimeout(TimeSpan timeout) =>
+            FromExpiration(Expiration.FromTimeout(timeout));
+
+        /// <summary>
+        /// Create a <see cref="CallTiming"/> with a simple deadline; no retry.
+        /// </summary>
+        /// <param name="deadline">The absolute deadline for a call without retry.</param>
+        /// <returns>A <see cref="CallTiming"/> with the specified deadline; without retry.</returns>
+        public static CallTiming FromDeadline(DateTime deadline) =>
+            FromExpiration(Expiration.FromDeadline(deadline));
 
         private CallTiming(RetrySettings retry, Expiration expiration)
         {

--- a/src/Google.Api.Gax/CallTiming.cs
+++ b/src/Google.Api.Gax/CallTiming.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax
+{
+    public enum CallTimingType
+    {
+        /// <summary>
+        /// Call uses retry, specified with a <see cref="RetrySettings"/>.
+        /// </summary>
+        Retry,
+
+        /// <summary>
+        /// Call does not use retry; call expiration is specified with an <see cref="Google.Api.Gax.Expiration"/> .
+        /// </summary>
+        Expiration,
+    }
+
+    public sealed class CallTiming
+    {
+        /// <summary>
+        /// Create a <see cref="CallTiming"/> with retry.
+        /// </summary>
+        /// <param name="retry">The <see cref="RetrySettings"/> for a call.</param>
+        /// <returns>A <see cref="CallTiming"/> with the specified retry settings.</returns>
+        public static CallTiming FromRetry(RetrySettings retry) =>
+            new CallTiming(GaxPreconditions.CheckNotNull(retry, nameof(retry)).Validate(nameof(retry)), null);
+
+        /// <summary>
+        /// Create a <see cref="CallTiming"/> with a simple expiration; no retry.
+        /// </summary>
+        /// <param name="expiration">The <see cref="Google.Api.Gax.Expiration"/> for a call without retry.</param>
+        /// <returns>A <see cref="CallTiming"/> with the specified expiration, without retry.</returns>
+        public static CallTiming FromExpiration(Expiration expiration) =>
+            new CallTiming(null, GaxPreconditions.CheckNotNull(expiration, nameof(expiration)));
+
+        private CallTiming(RetrySettings retry, Expiration expiration)
+        {
+            Retry = retry;
+            Expiration = expiration;
+        }
+
+        /// <summary>
+        /// If not null, the <see cref="RetrySettings"/> specifying how retry is performed
+        /// for this call.
+        /// </summary>
+        public RetrySettings Retry { get; }
+
+        /// <summary>
+        /// If not null, the <see cref="Expiration"/> specifying when this call expires
+        /// (with no retry).
+        /// </summary>
+        public Expiration Expiration { get; }
+
+        /// <summary>
+        /// What <see cref="CallTimingType"/> is contained in this <see cref="CallTiming"/>.
+        /// </summary>
+        public CallTimingType Type =>
+            Retry != null ? CallTimingType.Retry : CallTimingType.Expiration;
+
+        public CallTiming Clone() => new CallTiming(Retry?.Clone(), Expiration);
+    }
+
+    internal static class CallTimingExtensions
+    {
+        /// <summary>
+        /// Calculate a deadline from a <see cref="CallTiming"/> and a <see cref="IClock"/>.
+        /// </summary>
+        /// <param name="callTiming"><see cref="CallTiming"/>, may be null.</param>
+        /// <param name="clock"><see cref="IClock"/> to use for deadline calculation.</param>
+        /// <returns>The calculated absolute deadline, or null is no deadline should be used.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="callTiming"/> uses retry. Only a simple expiration is valid
+        /// for calculating a deadline.
+        /// </exception>
+        internal static DateTime? CalculateDeadline(this CallTiming callTiming, IClock clock)
+        {
+            if (callTiming == null)
+            {
+                return null;
+            }
+            if (callTiming.Type != CallTimingType.Expiration)
+            {
+                throw new InvalidOperationException("Cannot calculate deadline from retry.");
+            }
+            return callTiming.Expiration.CalculateDeadline(clock);
+        }
+    }
+}

--- a/src/Google.Api.Gax/CallTiming.cs
+++ b/src/Google.Api.Gax/CallTiming.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace Google.Api.Gax
 {
+    /// <summary>
+    /// The type of <see cref="CallTiming"/>; retry or expiration (no retry).
+    /// </summary>
     public enum CallTimingType
     {
         /// <summary>
@@ -18,6 +21,9 @@ namespace Google.Api.Gax
         Expiration,
     }
 
+    /// <summary>
+    /// An RPC simple expiration; or retry settings.
+    /// </summary>
     public sealed class CallTiming
     {
         /// <summary>

--- a/src/Google.Api.Gax/Expiration.cs
+++ b/src/Google.Api.Gax/Expiration.cs
@@ -98,6 +98,7 @@ namespace Google.Api.Gax
         /// <returns>The calculated absolute deadline, or null if no deadline should be used.</returns>
         internal static DateTime? CalculateDeadline(this Expiration expiration, IClock clock)
         {
+            GaxPreconditions.CheckNotNull(clock, nameof(clock));
             if (expiration == null)
             {
                 return null;

--- a/src/Google.Api.Gax/RetrySettings.cs
+++ b/src/Google.Api.Gax/RetrySettings.cs
@@ -33,6 +33,8 @@ namespace Google.Api.Gax
         /// </remarks>
         public BackoffSettings TimeoutBackoff { get; set; }
 
+        public Expiration TotalExpiration { get; set; }
+
         /// <summary>
         /// A predicate to determine whether or not a particular exception should cause the operation to be retried.
         /// Usually this is simply a matter of checking the status codes.
@@ -61,6 +63,7 @@ namespace Google.Api.Gax
             {
                 RetryBackoff = RetryBackoff?.Clone(),
                 TimeoutBackoff = TimeoutBackoff?.Clone(),
+                TotalExpiration = TotalExpiration,
                 DelayJitter = DelayJitter,
                 RetryFilter = RetryFilter
             };

--- a/test/Google.Api.Gax.Tests/CallSettingsTest.cs
+++ b/test/Google.Api.Gax.Tests/CallSettingsTest.cs
@@ -21,7 +21,7 @@ namespace Google.Api.Gax.Tests
         {
             var callSettings = new CallSettings();
             Assert.Null(callSettings.Headers);
-            Assert.Null(callSettings.CallTiming);
+            Assert.Null(callSettings.Timing);
             Assert.Null(callSettings.CancellationToken);
             Assert.Null(callSettings.WriteOptions);
             Assert.Null(callSettings.PropagationToken);
@@ -34,7 +34,7 @@ namespace Google.Api.Gax.Tests
             var callSettings = new CallSettings
             {
                 Headers = new Metadata { new Metadata.Entry("1", "one") },
-                CallTiming = CallTiming.FromExpiration(Expiration.None),
+                Timing = CallTiming.FromExpiration(Expiration.None),
                 CancellationToken = CancellationToken.None,
                 WriteOptions = new WriteOptions(WriteFlags.NoCompress),
                 PropagationToken = null, // Not possible to create/mock
@@ -45,7 +45,7 @@ namespace Google.Api.Gax.Tests
             Assert.NotSame(callSettings.Headers, clone.Headers);
             Assert.Equal(callSettings.Headers, clone.Headers);
             Assert.NotNull(clone.Headers);
-            Assert.Same(callSettings.CallTiming.Expiration, clone.CallTiming.Expiration);
+            Assert.Same(callSettings.Timing.Expiration, clone.Timing.Expiration);
             Assert.Equal(callSettings.CancellationToken, clone.CancellationToken);
             Assert.Same(callSettings.WriteOptions, clone.WriteOptions);
             Assert.Same(callSettings.PropagationToken, clone.PropagationToken);
@@ -76,7 +76,7 @@ namespace Google.Api.Gax.Tests
             var clock = new FakeClock();
             var timeout = TimeSpan.FromSeconds(1);
             var callSettings = new CallSettings {
-                CallTiming = CallTiming.FromExpiration(Expiration.FromTimeout(timeout))
+                Timing = CallTiming.FromExpiration(Expiration.FromTimeout(timeout))
             };
             var options = callSettings.ToCallOptions(clock);
             // Value should be exact, as we control time precisely.
@@ -89,7 +89,7 @@ namespace Google.Api.Gax.Tests
             var deadline = new DateTime(2015, 6, 19, 5, 2, 3, DateTimeKind.Utc);
             var mockClock = new Mock<IClock>();
             var callSettings = new CallSettings {
-                CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(deadline))
+                Timing = CallTiming.FromExpiration(Expiration.FromDeadline(deadline))
             };
             var options = callSettings.ToCallOptions(mockClock.Object);
             // Value should be exact, as we control time precisely.
@@ -103,7 +103,7 @@ namespace Google.Api.Gax.Tests
             var mockClock = new Mock<IClock>();
             var callSettings = new CallSettings
             {
-                CallTiming = CallTiming.FromRetry(new RetrySettings
+                Timing = CallTiming.FromRetry(new RetrySettings
                 {
                     RetryBackoff = new BackoffSettings(),
                     TimeoutBackoff = new BackoffSettings(),
@@ -119,7 +119,7 @@ namespace Google.Api.Gax.Tests
             var callSettings = new CallSettings
             {
                 Headers = new Metadata { new Metadata.Entry("1", "one") },
-                CallTiming = CallTiming.FromExpiration(Expiration.None),
+                Timing = CallTiming.FromExpiration(Expiration.None),
                 CancellationToken = new CancellationTokenSource().Token,
                 WriteOptions = new WriteOptions(WriteFlags.NoCompress),
                 PropagationToken = null, // Not possible to create/mock

--- a/test/Google.Api.Gax.Tests/CallSettingsTest.cs
+++ b/test/Google.Api.Gax.Tests/CallSettingsTest.cs
@@ -21,7 +21,7 @@ namespace Google.Api.Gax.Tests
         {
             var callSettings = new CallSettings();
             Assert.Null(callSettings.Headers);
-            Assert.Null(callSettings.Expiration);
+            Assert.Null(callSettings.CallTiming);
             Assert.Null(callSettings.CancellationToken);
             Assert.Null(callSettings.WriteOptions);
             Assert.Null(callSettings.PropagationToken);
@@ -34,7 +34,7 @@ namespace Google.Api.Gax.Tests
             var callSettings = new CallSettings
             {
                 Headers = new Metadata { new Metadata.Entry("1", "one") },
-                Expiration = Expiration.None,
+                CallTiming = CallTiming.FromExpiration(Expiration.None),
                 CancellationToken = CancellationToken.None,
                 WriteOptions = new WriteOptions(WriteFlags.NoCompress),
                 PropagationToken = null, // Not possible to create/mock
@@ -45,7 +45,7 @@ namespace Google.Api.Gax.Tests
             Assert.NotSame(callSettings.Headers, clone.Headers);
             Assert.Equal(callSettings.Headers, clone.Headers);
             Assert.NotNull(clone.Headers);
-            Assert.Same(callSettings.Expiration, clone.Expiration);
+            Assert.Same(callSettings.CallTiming.Expiration, clone.CallTiming.Expiration);
             Assert.Equal(callSettings.CancellationToken, clone.CancellationToken);
             Assert.Same(callSettings.WriteOptions, clone.WriteOptions);
             Assert.Same(callSettings.PropagationToken, clone.PropagationToken);
@@ -61,7 +61,7 @@ namespace Google.Api.Gax.Tests
         }
 
         [Fact]
-        public void ToCallOptions_ExpirationNull()
+        public void ToCallOptions_CallTimingNull()
         {
             var mockClock = new Mock<IClock>();
             CallSettings callSettings = new CallSettings();
@@ -71,26 +71,46 @@ namespace Google.Api.Gax.Tests
         }
 
         [Fact]
-        public void ToCallOptions_ExpirationTimeout()
+        public void ToCallOptions_CallTimingExpirationTimeout()
         {
             var clock = new FakeClock();
             var timeout = TimeSpan.FromSeconds(1);
-            var callSettings = new CallSettings { Expiration = Expiration.FromTimeout(timeout) };
+            var callSettings = new CallSettings {
+                CallTiming = CallTiming.FromExpiration(Expiration.FromTimeout(timeout))
+            };
             var options = callSettings.ToCallOptions(clock);
             // Value should be exact, as we control time precisely.
             Assert.Equal(options.Deadline.Value, clock.GetCurrentDateTimeUtc() + timeout);
         }
 
         [Fact]
-        public void ToCallOptions_ExpirationDeadline()
+        public void ToCallOptions_CallTimingExpirationDeadline()
         {
             var deadline = new DateTime(2015, 6, 19, 5, 2, 3, DateTimeKind.Utc);
             var mockClock = new Mock<IClock>();
-            var callSettings = new CallSettings { Expiration = Expiration.FromDeadline(deadline) };
+            var callSettings = new CallSettings {
+                CallTiming = CallTiming.FromExpiration(Expiration.FromDeadline(deadline))
+            };
             var options = callSettings.ToCallOptions(mockClock.Object);
             // Value should be exact, as we control time precisely.
             Assert.Equal(options.Deadline.Value, deadline);
             mockClock.Verify(c => c.GetCurrentDateTimeUtc(), Times.Never);
+        }
+
+        [Fact]
+        public void ToCallOptions_CallTimingRetry()
+        {
+            var mockClock = new Mock<IClock>();
+            var callSettings = new CallSettings
+            {
+                CallTiming = CallTiming.FromRetry(new RetrySettings
+                {
+                    RetryBackoff = new BackoffSettings(),
+                    TimeoutBackoff = new BackoffSettings(),
+                })
+            };
+            Assert.Throws<InvalidOperationException>(() =>
+                callSettings.ToCallOptions(mockClock.Object));
         }
 
         [Fact]
@@ -99,7 +119,7 @@ namespace Google.Api.Gax.Tests
             var callSettings = new CallSettings
             {
                 Headers = new Metadata { new Metadata.Entry("1", "one") },
-                Expiration = Expiration.None,
+                CallTiming = CallTiming.FromExpiration(Expiration.None),
                 CancellationToken = new CancellationTokenSource().Token,
                 WriteOptions = new WriteOptions(WriteFlags.NoCompress),
                 PropagationToken = null, // Not possible to create/mock

--- a/test/Google.Api.Gax.Tests/CallSettingsTest.cs
+++ b/test/Google.Api.Gax.Tests/CallSettingsTest.cs
@@ -116,6 +116,7 @@ namespace Google.Api.Gax.Tests
         [Fact]
         public void ToCallOptions_All()
         {
+            var mockClock = new Mock<IClock>();
             var callSettings = new CallSettings
             {
                 Headers = new Metadata { new Metadata.Entry("1", "one") },
@@ -125,7 +126,7 @@ namespace Google.Api.Gax.Tests
                 PropagationToken = null, // Not possible to create/mock
                 Credentials = null, // Not possible to create/mock
             };
-            var options = callSettings.ToCallOptions(null);
+            var options = callSettings.ToCallOptions(mockClock.Object);
             Assert.Same(callSettings.Headers, options.Headers);
             Assert.Null(options.Deadline);
             Assert.Equal(callSettings.CancellationToken, options.CancellationToken);

--- a/test/Google.Api.Gax.Tests/RetrySettingsTest.cs
+++ b/test/Google.Api.Gax.Tests/RetrySettingsTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Tests
+{
+    public class RetrySettingsTest
+    {
+        [Fact]
+        public void InvalidWithoutRetryBackoff()
+        {
+            var retrySettings = new RetrySettings
+            {
+                TimeoutBackoff = new BackoffSettings()
+            };
+            Assert.Throws<ArgumentException>(() =>
+                retrySettings.Validate(""));
+        }
+
+        [Fact]
+        public void InvalidWithoutTimeoutBackoff()
+        {
+            var retrySettings = new RetrySettings
+            {
+                RetryBackoff = new BackoffSettings()
+            };
+            Assert.Throws<ArgumentException>(() =>
+                retrySettings.Validate(""));
+        }
+
+        [Fact]
+        public void Validity()
+        {
+            var retrySettings = new RetrySettings
+            {
+                TimeoutBackoff = new BackoffSettings(),
+                RetryBackoff = new BackoffSettings(),
+            };
+            // Test passes if this doesn't throw
+            retrySettings.Validate("");
+        }
+
+        class DummyJitter : RetrySettings.IJitter
+        {
+            public TimeSpan GetDelay(TimeSpan maxDelay) => TimeSpan.Zero;
+        }
+
+        [Fact]
+        public void Clone()
+        {
+            var retrySettings = new RetrySettings
+            {
+                TimeoutBackoff = new BackoffSettings { DelayMultiplier = 1.0 },
+                RetryBackoff = new BackoffSettings { DelayMultiplier = 2.0 },
+                TotalExpiration = Expiration.None,
+                RetryFilter = x => false,
+                DelayJitter = new DummyJitter()
+            };
+            var clone = retrySettings.Clone();
+            Assert.Equal(retrySettings.TimeoutBackoff.DelayMultiplier, clone.TimeoutBackoff.DelayMultiplier);
+            Assert.Equal(retrySettings.RetryBackoff.DelayMultiplier, clone.RetryBackoff.DelayMultiplier);
+            Assert.Same(retrySettings.TotalExpiration, clone.TotalExpiration);
+            Assert.Same(retrySettings.RetryFilter, clone.RetryFilter);
+            Assert.Same(retrySettings.DelayJitter, clone.DelayJitter);
+        }
+    }
+}

--- a/test/Google.Api.Gax.Tests/RetryTest.cs
+++ b/test/Google.Api.Gax.Tests/RetryTest.cs
@@ -73,7 +73,7 @@ namespace Google.Api.Gax.Tests
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    CallTiming = CallTiming.FromRetry(retrySettings)
+                    Timing = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = name }, callSettings);
@@ -111,7 +111,7 @@ namespace Google.Api.Gax.Tests
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    CallTiming = CallTiming.FromRetry(retrySettings)
+                    Timing = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = name }, callSettings);
@@ -155,7 +155,7 @@ namespace Google.Api.Gax.Tests
             {
                 // Expiration makes it fail while waiting to make third call
                 var callSettings = new CallSettings {
-                    CallTiming = CallTiming.FromRetry(retrySettings)
+                    Timing = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -198,7 +198,7 @@ namespace Google.Api.Gax.Tests
                 // Call 2: t=1800, deadline=3800 (2000+1800), completes at 2100
                 // Call 3, t=3600, deadline=4500 (would be 7600, but overall deadline truncates), completes at 3900 (with success)
                 var callSettings = new CallSettings {
-                    CallTiming = CallTiming.FromRetry(retrySettings)
+                    Timing = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -237,7 +237,7 @@ namespace Google.Api.Gax.Tests
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    CallTiming = CallTiming.FromRetry(retrySettings)
+                    Timing = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = server.Callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -302,7 +302,7 @@ namespace Google.Api.Gax.Tests
             public void AssertDeadlines(params long[] ticks)
             {
                 // Note that this effectively asserts we always end up with a CallSettings with a deadline.
-                Assert.Equal(ticks, CallSettingsReceived.Select(cs => cs.CallTiming.Expiration.Deadline.Value.Ticks).ToArray());
+                Assert.Equal(ticks, CallSettingsReceived.Select(cs => cs.Timing.Expiration.Deadline.Value.Ticks).ToArray());
             }
         }
     }

--- a/test/Google.Api.Gax.Tests/RetryTest.cs
+++ b/test/Google.Api.Gax.Tests/RetryTest.cs
@@ -66,14 +66,14 @@ namespace Google.Api.Gax.Tests
             {
                 RetryBackoff = DoublingBackoff,
                 TimeoutBackoff = ConstantBackoff,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1)),
                 DelayJitter = RetrySettings.NoJitter
             };
 
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    RetrySettings = retrySettings,
-                    Expiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1))
+                    CallTiming = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = name }, callSettings);
@@ -104,14 +104,14 @@ namespace Google.Api.Gax.Tests
             {
                 RetryBackoff = DoublingBackoff,
                 TimeoutBackoff = ConstantBackoff,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1)),
                 DelayJitter = RetrySettings.NoJitter
             };
 
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    RetrySettings = retrySettings,
-                    Expiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1))
+                    CallTiming = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = name }, callSettings);
@@ -147,6 +147,7 @@ namespace Google.Api.Gax.Tests
             {
                 RetryBackoff = DoublingBackoff,
                 TimeoutBackoff = ConstantBackoff,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromTicks(2500)),
                 DelayJitter = RetrySettings.NoJitter
             };
 
@@ -154,8 +155,7 @@ namespace Google.Api.Gax.Tests
             {
                 // Expiration makes it fail while waiting to make third call
                 var callSettings = new CallSettings {
-                    RetrySettings = retrySettings,
-                    Expiration = Expiration.FromTimeout(TimeSpan.FromTicks(2500))
+                    CallTiming = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -187,6 +187,7 @@ namespace Google.Api.Gax.Tests
             {
                 RetryBackoff = ConstantBackoff, // 1500 ticks always
                 TimeoutBackoff = DoublingBackoff, // 1000, then 2000, then 4000
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromTicks(4500)),
                 DelayJitter = RetrySettings.NoJitter
             };
 
@@ -197,8 +198,7 @@ namespace Google.Api.Gax.Tests
                 // Call 2: t=1800, deadline=3800 (2000+1800), completes at 2100
                 // Call 3, t=3600, deadline=4500 (would be 7600, but overall deadline truncates), completes at 3900 (with success)
                 var callSettings = new CallSettings {
-                    RetrySettings = retrySettings,
-                    Expiration = Expiration.FromTimeout(TimeSpan.FromTicks(4500))
+                    CallTiming = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -230,14 +230,14 @@ namespace Google.Api.Gax.Tests
                 RetryBackoff = ConstantBackoff,
                 TimeoutBackoff = ConstantBackoff,
                 DelayJitter = RetrySettings.NoJitter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1)),
                 RetryFilter = RetrySettings.FilterForStatusCodes(filterCodes)
             };
 
             var rpcTask = scheduler.Run(() =>
             {
                 var callSettings = new CallSettings {
-                    RetrySettings = retrySettings,
-                    Expiration = Expiration.FromTimeout(TimeSpan.FromSeconds(1))
+                    CallTiming = CallTiming.FromRetry(retrySettings)
                 };
                 var retryingCallable = server.Callable.WithRetry(scheduler.Clock, scheduler);
                 return Call(async, retryingCallable, new SimpleRequest { Name = "irrelevant" }, callSettings);
@@ -302,7 +302,7 @@ namespace Google.Api.Gax.Tests
             public void AssertDeadlines(params long[] ticks)
             {
                 // Note that this effectively asserts we always end up with a CallSettings with a deadline.
-                Assert.Equal(ticks, CallSettingsReceived.Select(cs => cs.Expiration.Deadline.Value.Ticks).ToArray());
+                Assert.Equal(ticks, CallSettingsReceived.Select(cs => cs.CallTiming.Expiration.Deadline.Value.Ticks).ToArray());
             }
         }
     }


### PR DESCRIPTION
"Retry" and "Simple expiration" of RPCs made clearer, with a new CallTimings settings class.