### PR TITLE
Update package and dependency versions

### DIFF
--- a/src/Google.Api.CommonProtos/project.json
+++ b/src/Google.Api.CommonProtos/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "title": "Google API Common Protos",
   "description": "Common Protocol Buffer messages for Google APIs",
   "authors": [ "Google Inc." ],

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "title": "Google REST API Extensions",
   "description": "Additional support classes for Google REST API client libraries",
   "authors": [ "Google Inc." ],
@@ -11,8 +11,8 @@
     "keyFile": "../../Gax.snk"
   },
   "dependencies": {
-    "Google.Apis.Auth": "1.13.0",
-    "Google.Apis": "1.13.0",
+    "Google.Apis.Auth": "1.14.0",
+    "Google.Apis": "1.14.0",
     "Ix-Async": "1.2.5"
   },
   "frameworks": {

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.1.0-*",
+  "version": "1.0.0-*",
   "title": "Google API Extensions",
   "description": "Support classes for Google API client libraries",
   "authors": [ "Google Inc." ],
@@ -11,7 +11,7 @@
     "keyFile": "../../Gax.snk"
   },
   "dependencies": {
-    "Google.Apis.Auth": "1.13.0",
+    "Google.Apis.Auth": "1.14.0",
     "Google.Protobuf": "3.0.0-beta3",
     "Grpc.Auth": "0.15.0",
     "Grpc.Core": "0.15.0",


### PR DESCRIPTION
This is not for 1.0.0 GA, but initially 1.0.0-beta1.
Continuous integration will create 1.0.0-CI00070 builds etc.