### PR TITLE
Unwrap AggregateException when using a synchronous method in ChannelPool

### DIFF
--- a/src/Google.Api.Gax/ChannelPool.cs
+++ b/src/Google.Api.Gax/ChannelPool.cs
@@ -63,8 +63,18 @@ namespace Google.Api.Gax
         public Channel GetChannel(ServiceEndpoint endpoint)
         {
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
-            var credentials = s_lazyDefaultChannelCredentials.Value.Result;
-            return GetChannel(endpoint, credentials);
+            try
+            {
+                var credentials = s_lazyDefaultChannelCredentials.Value.Result;
+                return GetChannel(endpoint, credentials);
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
+                // but let's handle it relatively gracefully.
+                throw e.InnerExceptions.FirstOrDefault() ?? e;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This will fix https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/206