### PR TITLE
Make ChannelPool apply scopes where appropriate

### DIFF
--- a/test/Google.Api.Gax.IntegrationTests/ChannelPoolTest.cs
+++ b/test/Google.Api.Gax.IntegrationTests/ChannelPoolTest.cs
@@ -5,6 +5,8 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 using Grpc.Core;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,10 +14,12 @@ namespace Google.Api.Gax.IntegrationTests
 {
     public class ChannelPoolTest
     {
+        private static readonly IEnumerable<string> EmptyScopes = Enumerable.Empty<string>();
+
         [Fact]
         public void SameEndpoint_SameChannel()
         {
-            var pool = new ChannelPool();
+            var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(fixture.Endpoint);
@@ -27,7 +31,7 @@ namespace Google.Api.Gax.IntegrationTests
         [Fact]
         public void DifferentEndpoint_DifferentChannel()
         {
-            var pool = new ChannelPool();
+            var pool = new ChannelPool(EmptyScopes);
             using (TestServiceFixture fixture1 = new TestServiceFixture(), fixture2 = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(fixture1.Endpoint);
@@ -39,7 +43,7 @@ namespace Google.Api.Gax.IntegrationTests
         [Fact]
         public async Task ShutdownAsync_ShutsDownChannel()
         {
-            var pool = new ChannelPool();
+            var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
                 var channel = pool.GetChannel(fixture.Endpoint);
@@ -52,7 +56,7 @@ namespace Google.Api.Gax.IntegrationTests
         [Fact]
         public void ShutdownAsync_EmptiesPool()
         {
-            var pool = new ChannelPool();
+            var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(fixture.Endpoint);


### PR DESCRIPTION
This is a PR which would be part of addressing
https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/294
if it turns out the fix really should be in our libraries.

This is a breaking change - it requires support in the code generator as well, and we'd need to be careful not to release the GAX package separately, as anyone upgrading to that without upgrading the other packages would be broken. That *could* be addressed by adding a parameterless constructor here, but that feels a bit of a hack.
