### PR TITLE
Include -* suffix on project versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ then
   DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix $PRERELEASETAG"
 elif [ -z "$NOVERSIONSUFFIX" ]
 then
-  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix not-for-release"  
+  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix dont-release"  
 fi
 
 echo CLI args: $DOTNET_BUILD_ARGS

--- a/src/Google.Api.CommonProtos/project.json
+++ b/src/Google.Api.CommonProtos/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01",
+  "version": "1.0.0-beta01-*",
 
   "packOptions": {
     "title": "Google API Common Protos",

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01",
+  "version": "1.0.0-beta01-*",
 
   "packOptions": {
     "title": "Google REST API Extensions",

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01",
+  "version": "1.0.0-beta01-*",
 
   "packOptions": {
     "title": "Google API Extensions",

--- a/testing/Google.Api.Gax.Testing/project.json
+++ b/testing/Google.Api.Gax.Testing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01",
+  "version": "1.0.0-beta01-*",
 
   "packOptions": {
     "title": "Testing support for Google.Api.Gax",


### PR DESCRIPTION
This is so we can pick up the CI release number etc.

This was the intention to start with, and it's what we already have in the other repo.