### PR TITLE
Add a user agent helper to the REST version of GAX

### DIFF
--- a/src/Google.Api.Gax.Rest/UserAgentHelper.cs
+++ b/src/Google.Api.Gax.Rest/UserAgentHelper.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Google.Api.Gax.Rest
+{
+    /// <summary>
+    /// Common code used for building user agents in REST libraries.
+    /// </summary>
+    public static class UserAgentHelper
+    {
+        /// <summary>
+        /// Formats a user agent suitable for REST client libraries.
+        /// </summary>
+        /// <param name="type">The type to extract the version number from.</param>
+        /// <returns>A user agent value.</returns>
+        public static string GetDefaultUserAgent(Type type) => $"gcloud-dotnet/{FormatAssemblyVersion(type)}";
+
+        private static string FormatAssemblyVersion(System.Type type)
+        {
+            // Prefer AssemblyInformationalVersion, then AssemblyFileVersion,
+            // then AssemblyVersion.
+
+            var assembly = type.GetTypeInfo().Assembly;
+            var info = assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().FirstOrDefault()?.InformationalVersion;
+            if (info != null)
+            {
+                return info;
+            }
+            var file = assembly.GetCustomAttributes<AssemblyFileVersionAttribute>().FirstOrDefault()?.Version;
+            if (file != null)
+            {
+                return string.Join(".", file.Split('.').Take(3));
+            }
+            var version = assembly.GetName().Version;
+            return $"{version.Major}.{version.Minor}.{version.Build}";
+        }
+    }
+}

--- a/test/Google.Api.Gax.Rest.Tests/UserAgentHelperTest.cs
+++ b/test/Google.Api.Gax.Rest.Tests/UserAgentHelperTest.cs
@@ -1,0 +1,21 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Xunit;
+
+namespace Google.Api.Gax.Rest.Tests
+{
+    public class UserAgentHelperTest
+    {
+        [Fact]
+        public void GetDefaultUserAgent()
+        {
+            // Always 1.0.0, because we don't declare a version nubmer in project.json for tests.
+            Assert.Equal("gcloud-dotnet/1.0.0", UserAgentHelper.GetDefaultUserAgent(typeof(UserAgentHelperTest)));
+        }
+    }
+}


### PR DESCRIPTION
This avoids us baking logic into multiple libraries
(Storage+Bigquery).

(After merging this, I'll promote the resulting myget build, and use it in the libraries...)