### PR TITLE
Update version numbers ready for a beta02 release.

### DIFF
--- a/src/Google.Api.CommonProtos/project.json
+++ b/src/Google.Api.CommonProtos/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
 
   "packOptions": {
     "title": "Google API Common Protos",

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
 
   "packOptions": {
     "title": "Google REST API Extensions",
@@ -16,8 +16,8 @@
   },
 
   "dependencies": {
-    "Google.Apis.Auth": "1.15.0",
-    "Google.Apis": "1.15.0",
+    "Google.Apis.Auth": "1.16.0",
+    "Google.Apis": "1.16.0",
     "System.Interactive.Async": "3.0.0"
   },
   "frameworks": {

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
 
   "packOptions": {
     "title": "Google API Extensions",
@@ -16,7 +16,7 @@
   },
 
   "dependencies": {
-    "Google.Apis.Auth": "1.15.0",
+    "Google.Apis.Auth": "1.16.0",
     "Google.Protobuf": "3.0.0",
     "Google.Protobuf.Tools": { "version": "3.0.0", "type": "build" },
     "Grpc.Auth": "1.0.0",

--- a/testing/Google.Api.Gax.Testing/project.json
+++ b/testing/Google.Api.Gax.Testing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta01-*",
+  "version": "1.0.0-beta02-*",
 
   "packOptions": {
     "title": "Testing support for Google.Api.Gax",


### PR DESCRIPTION
Dependencies are changed to 1.16 to avoid unnecessary binding redirects in some cases.

(Once this is in, I'll create and publish the release, then update google-cloud-dotnet libraries in a separate PR.)
