### PR TITLE
Enable easy faking of ApiCall<,>.

### DIFF
--- a/src/Google.Api.Gax/AssemblyInfo.cs
+++ b/src/Google.Api.Gax/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Google.Api.Gax.Testing,PublicKey=0024000004800000940000000602000000240000525341310004000001000100bfa2d20e82583e5f3a47efa518d8a7cda58d6e1b61f51ed3de3900f238fb01e0ca95b3ed1c68147e4865a336b252f070d5207e653c9014d271fc829c18981d1c80d418d300545c3ad0e1ff4d77c596177dbfe0a588fff57306f1d6ba655de3cfa520ad777ea73bb7a92fd6027071c94bb12d5871fcd076299de0502bca12e3aa")]

--- a/testing/Google.Api.Gax.Testing/FakeApiCall.cs
+++ b/testing/Google.Api.Gax.Testing/FakeApiCall.cs
@@ -1,0 +1,76 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf;
+using Grpc.Core;
+using System;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Testing
+{
+    /// <summary>
+    /// Helper class to use when faking services; enables <see cref="ApiCall{TRequest, TResponse}"/> objects
+    /// to be created without gRPC 
+    /// </summary>
+    public static class FakeApiCall
+    {
+        /// <summary>
+        /// Creates an API call from the given async/sync functions.
+        /// </summary>
+        /// <typeparam name="TRequest">Request type</typeparam>
+        /// <typeparam name="TResponse">Response type</typeparam>
+        /// <param name="asyncCall">Function to call for async requests</param>
+        /// <param name="syncCall">Function to call for sync requests</param>
+        /// <param name="baseCallSettings">The default call settings. May be null.</param>
+        /// <param name="clock">The clock to use; defaults to a new <see cref="FakeClock"/>.</param>
+        /// <returns>The new API call.</returns>
+        public static ApiCall<TRequest, TResponse> Create<TRequest, TResponse>(
+            Func<TRequest, CallOptions, Task<TResponse>> asyncCall,
+            Func<TRequest, CallOptions, TResponse> syncCall,
+            CallSettings baseCallSettings = null,
+            IClock clock = null)
+            where TRequest : class, IMessage<TRequest>
+            where TResponse : class, IMessage<TResponse>
+        {
+            clock = clock ?? new FakeClock();
+            baseCallSettings = baseCallSettings ?? new CallSettings();
+            return new ApiCall<TRequest, TResponse>(
+                asyncCall.MapArg((CallSettings cs) => cs.ToCallOptions(clock)),
+                syncCall.MapArg((CallSettings cs) => cs.ToCallOptions(clock)),
+                baseCallSettings);
+        }
+
+        /// <summary>
+        /// Creates an API call from a synchronous function, which is just called synchronously for
+        /// asynchronous requests.
+        /// </summary>
+        /// <remarks>
+        /// For asynchronous requests, the synchronous function is called but within an async
+        /// context; exceptions will still be reported back via the returned task, but the call will
+        /// complete synchronously.
+        /// </remarks>
+        /// <typeparam name="TRequest">Request type</typeparam>
+        /// <typeparam name="TResponse">Response type</typeparam>
+        /// <param name="syncCall">Function to call for sync requests</param>
+        /// <param name="baseCallSettings">The default call settings. May be null.</param>
+        /// <param name="clock">The clock to use; defaults to a new <see cref="FakeClock"/>.</param>
+        /// <returns>The new API call.</returns>
+        public static ApiCall<TRequest, TResponse> Create<TRequest, TResponse>(
+            Func<TRequest, CallOptions, TResponse> syncCall,
+            CallSettings baseCallSettings = null,
+            IClock clock = null)
+            where TRequest : class, IMessage<TRequest>
+            where TResponse : class, IMessage<TResponse> =>
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            // Not using Task.OfResult as we want the faulted-task behaviour for exceptions.
+            Create(async (request, response) => syncCall(request, response),
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+                syncCall,
+                baseCallSettings,
+                clock);
+    }
+}


### PR DESCRIPTION
This could make it reasonably easy to bypass gRPC if we wanted to, constructing a FooClientImpl with appropriate API calls but no gRPC client. Something for later consideration.

Fixes #77.