### PR TITLE
Generate XML docs

### DIFF
--- a/src/Google.Api.CommonProtos/project.json
+++ b/src/Google.Api.CommonProtos/project.json
@@ -12,7 +12,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../Gax.snk"
+    "keyFile": "../../Gax.snk",
+    "xmlDoc": true
   },
   "dependencies": {
     "Google.Protobuf": "3.0.0",

--- a/src/Google.Api.Gax.Rest/FixedSizePage.cs
+++ b/src/Google.Api.Gax.Rest/FixedSizePage.cs
@@ -10,19 +10,33 @@ using System.Collections.Generic;
 
 namespace Google.Api.Gax.Rest
 {
+    /// <summary>
+    /// A page of resources which will only have fewer results than requested if
+    /// there is no more data to fetch.
+    /// </summary>
+    /// <typeparam name="TResource">The type of resource within the page.</typeparam>
     public sealed class FixedSizePage<TResource> : IEnumerable<TResource>
     {
         private readonly IEnumerable<TResource> _resources;
+
+        /// <inheritdoc />
         public string NextPageToken { get; }
 
+        /// <summary>
+        /// Constructs a fixed-size page from the given resource sequence and page token.
+        /// </summary>
+        /// <param name="resources">The resources in the page.</param>
+        /// <param name="nextPageToken">The next page token.</param>
         public FixedSizePage(IEnumerable<TResource> resources, string nextPageToken)
         {
             _resources = resources;
             NextPageToken = nextPageToken;
         }
 
+        /// <inheritdoc />
         public IEnumerator<TResource> GetEnumerator() => _resources.GetEnumerator();
 
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Google.Api.Gax.Rest/IPageManager.cs
+++ b/src/Google.Api.Gax.Rest/IPageManager.cs
@@ -20,11 +20,41 @@ namespace Google.Api.Gax.Rest
             manager.GetResources(response) ?? Enumerable.Empty<TResource>();
     }
 
+    /// <summary>
+    /// Interface describing the relationship between requests, responses and resources for
+    /// page streaming.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    /// <typeparam name="TResource">The resource type.</typeparam>
     public interface IPageManager<TRequest, TResponse, TResource>
     {
+        /// <summary>
+        /// Applies the given page size to the given request.
+        /// </summary>
+        /// <param name="request">The request to modify.</param>
+        /// <param name="pageSize">The page size for the next remote call.</param>
         void SetPageSize(TRequest request, int pageSize);
+
+        /// <summary>
+        /// Applies the given page token to the given request.
+        /// </summary>
+        /// <param name="request">The request to modify.</param>
+        /// <param name="pageToken">The page token for the next remote call.</param>
         void SetPageToken(TRequest request, string pageToken);
+
+        /// <summary>
+        /// Extracts resources from a response.
+        /// </summary>
+        /// <param name="response">The response containing the resources.</param>
+        /// <returns>The resources in the response, or <c>null</c> if it contains no resources.</returns>
         IEnumerable<TResource> GetResources(TResponse response);
+
+        /// <summary>
+        /// Extracts the next page token from a response.
+        /// </summary>
+        /// <param name="response">The response to extract the next page token from.</param>
+        /// <returns>The next page token, or <c>null</c> if this is the final page of results.</returns>
         string GetNextPageToken(TResponse response);
     }
 }

--- a/src/Google.Api.Gax.Rest/PageStreamingAsync.cs
+++ b/src/Google.Api.Gax.Rest/PageStreamingAsync.cs
@@ -77,6 +77,7 @@ namespace Google.Api.Gax.Rest
         /// Advance to the next page in the sequence, requesting the specified page size.
         /// </summary>
         /// <param name="pageSize">The number of resources to include in the next page.</param>
+        /// <param name="cancellationToken">A cancellation token for the asynchronous operation.</param>
         /// <returns>A task with a result of <c>true</c> if the enumerator was successfully advanced to the next element or
         /// <c>false</c> if the enumerator has passed the end of the collection.</returns>
         Task<bool> MoveNext(int pageSize, CancellationToken cancellationToken);

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -8,11 +8,12 @@
     "owners": [ "googleapis-packages" ],
     "projectUrl": "htttps://github.com/googleapis/gax-dotnet",
     "licenseUrl": "https://developers.google.com/open-source/licenses/bsd",
-    "tags": [ "Google" ],
+    "tags": [ "Google" ]
   },
 
   "buildOptions": {
-    "keyFile": "../../Gax.snk"
+    "keyFile": "../../Gax.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/src/Google.Api.Gax/ApiCall.cs
+++ b/src/Google.Api.Gax/ApiCall.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Google.Api.Gax
 {
-    public static class ApiCall
+    internal static class ApiCall
     {
         internal static ApiCall<TRequest, TResponse> Create<TRequest, TResponse>(
             Func<TRequest, CallOptions, AsyncUnaryCall<TResponse>> asyncGrpcCall,
@@ -29,6 +29,12 @@ namespace Google.Api.Gax
         }
     }
 
+    /// <summary>
+    /// Bridge between an RPC method (with synchronous and asynchronous variants) and higher level
+    /// abstractions, applying call settings as required.
+    /// </summary>
+    /// <typeparam name="TRequest">RPC request type</typeparam>
+    /// <typeparam name="TResponse">RPC response type</typeparam>
     public sealed class ApiCall<TRequest, TResponse>
         where TRequest : class, IMessage<TRequest>
         where TResponse : class, IMessage<TResponse>
@@ -55,9 +61,24 @@ namespace Google.Api.Gax
             return fn(callSettings);
         }
 
+        /// <summary>
+        /// Performs an RPC call asynchronously.
+        /// </summary>
+        /// <param name="request">The RPC request.</param>
+        /// <param name="perCallCallSettings">The call settings to apply to this specific call,
+        /// overriding defaults where necessary.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the completed task
+        /// will be the RPC response.</returns>
         public Task<TResponse> Async(TRequest request, CallSettings perCallCallSettings) =>
             Call(request, perCallCallSettings, callSettings => _asyncCall(request, callSettings));
 
+        /// <summary>
+        /// Performs an RPC call synchronously.
+        /// </summary>
+        /// <param name="request">The RPC request.</param>
+        /// <param name="perCallCallSettings">The call settings to apply to this specific call,
+        /// overriding defaults where necessary.</param>
+        /// <returns>The RPC response.</returns>
         public TResponse Sync(TRequest request, CallSettings perCallCallSettings) =>
             Call(request, perCallCallSettings, callSettings => _syncCall(request, callSettings));
 

--- a/src/Google.Api.Gax/CallSettings.cs
+++ b/src/Google.Api.Gax/CallSettings.cs
@@ -15,6 +15,9 @@ namespace Google.Api.Gax
     /// </summary>
     public sealed class CallSettings
     {
+        /// <summary>
+        /// Constructs an instance with no settings applied.
+        /// </summary>
         public CallSettings() { }
 
         internal CallSettings(CallSettings other)
@@ -32,7 +35,6 @@ namespace Google.Api.Gax
         /// <summary>
         /// Headers to send at the beginning of the call.
         /// </summary>
-        //public Metadata Headers
         public Metadata Headers { get; set; }
 
         /// <summary>

--- a/src/Google.Api.Gax/CallTiming.cs
+++ b/src/Google.Api.Gax/CallTiming.cs
@@ -81,7 +81,11 @@ namespace Google.Api.Gax
         /// </summary>
         public CallTimingType Type =>
             Retry != null ? CallTimingType.Retry : CallTimingType.Expiration;
-
+        
+        /// <summary>
+        /// Creates a deep clone of this object.
+        /// </summary>
+        /// <returns>A clone of this <see cref="CallTiming"/>.</returns>
         public CallTiming Clone() => new CallTiming(Retry?.Clone(), Expiration);
     }
 

--- a/src/Google.Api.Gax/ClientHelper.cs
+++ b/src/Google.Api.Gax/ClientHelper.cs
@@ -53,7 +53,8 @@ namespace Google.Api.Gax
         /// <typeparam name="TResponse">Response type, which must be a protobuf message.</typeparam>
         /// <param name="asyncGrpcCall">The underlying synchronous gRPC call.</param>
         /// <param name="syncGrpcCall">The underlying asynchronous gRPC call.</param>
-        /// <returns></returns>
+        /// <param name="perMethodCallSettings">The default method call settings.</param>
+        /// <returns>An API call to proxy to the RPC calls</returns>
         public ApiCall<TRequest, TResponse> BuildApiCall<TRequest, TResponse>(
             Func<TRequest, CallOptions, AsyncUnaryCall<TResponse>> asyncGrpcCall,
             Func<TRequest, CallOptions, TResponse> syncGrpcCall,

--- a/src/Google.Api.Gax/FixedSizePage.cs
+++ b/src/Google.Api.Gax/FixedSizePage.cs
@@ -10,19 +10,33 @@ using System.Collections.Generic;
 
 namespace Google.Api.Gax
 {
+    /// <summary>
+    /// A page of resources which will only have fewer results than requested if
+    /// there is no more data to fetch.
+    /// </summary>
+    /// <typeparam name="TResource">The type of resource within the page.</typeparam>
     public sealed class FixedSizePage<TResource> : IPageResponse<TResource>
     {
         private readonly IEnumerable<TResource> _resources;
+
+        /// <inheritdoc />
         public string NextPageToken { get; }
 
+        /// <summary>
+        /// Constructs a fixed-size page from the given resource sequence and page token.
+        /// </summary>
+        /// <param name="resources">The resources in the page.</param>
+        /// <param name="nextPageToken">The next page token.</param>
         public FixedSizePage(IEnumerable<TResource> resources, string nextPageToken)
         {
             _resources = resources;
             NextPageToken = nextPageToken;
         }
 
+        /// <inheritdoc />
         public IEnumerator<TResource> GetEnumerator() => _resources.GetEnumerator();
 
+        /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/Google.Api.Gax/PageStreamingAsync.cs
+++ b/src/Google.Api.Gax/PageStreamingAsync.cs
@@ -77,6 +77,7 @@ namespace Google.Api.Gax
         /// Advance to the next page in the sequence, requesting the specified page size.
         /// </summary>
         /// <param name="pageSize">The number of resources to include in the next page.</param>
+        /// <param name="cancellationToken">A cancellation token for the asynchronous operation.</param>
         /// <returns>A task with a result of <c>true</c> if the enumerator was successfully advanced to the next element or
         /// <c>false</c> if the enumerator has passed the end of the collection.</returns>
         Task<bool> MoveNext(int pageSize, CancellationToken cancellationToken);

--- a/src/Google.Api.Gax/PathTemplate.cs
+++ b/src/Google.Api.Gax/PathTemplate.cs
@@ -158,6 +158,7 @@ namespace Google.Api.Gax
         /// <summary>
         /// Returns a string representation of the template with parameters replaced by resource IDs.
         /// </summary>
+        /// <param name="serviceName">The name of the service, for full resource names. May be null, to produce a relative resource name.</param>
         /// <param name="resourceIds">Resource IDs to interpolate the template with. Expected to have been validated already.</param>
         internal string ReplaceParameters(string serviceName, string[] resourceIds)
         {

--- a/src/Google.Api.Gax/ResourceMismatchException.cs
+++ b/src/Google.Api.Gax/ResourceMismatchException.cs
@@ -15,6 +15,10 @@ namespace Google.Api.Gax
     /// </summary>
     public class ResourceMismatchException : Exception
     {
+        /// <summary>
+        /// Constructs a new instance of the exception.
+        /// </summary>
+        /// <param name="message">The error message for the exception.</param>
         public ResourceMismatchException(string message) : base(message)
         {
         }

--- a/src/Google.Api.Gax/RetrySettings.cs
+++ b/src/Google.Api.Gax/RetrySettings.cs
@@ -33,6 +33,9 @@ namespace Google.Api.Gax
         /// </remarks>
         public BackoffSettings TimeoutBackoff { get; set; }
 
+        /// <summary>
+        /// The total expiration, across all retries.
+        /// </summary>
         public Expiration TotalExpiration { get; set; }
 
         /// <summary>

--- a/src/Google.Api.Gax/ServiceEndpoint.cs
+++ b/src/Google.Api.Gax/ServiceEndpoint.cs
@@ -73,7 +73,7 @@ namespace Google.Api.Gax
         /// <summary>
         /// Determines equality between this endpoint and <paramref name="other"/>.
         /// </summary>
-        /// <param name="obj">The object to compare with this one.</param>
+        /// <param name="other">The object to compare with this one.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is a <see cref="ServiceEndpoint"/>
         /// with the same host and port; <c>false</c> otherwise.</returns>
         public bool Equals(ServiceEndpoint other) => other != null && other.Host == Host && other.Port == Port;

--- a/src/Google.Api.Gax/SystemScheduler.cs
+++ b/src/Google.Api.Gax/SystemScheduler.cs
@@ -5,19 +5,25 @@ using System.Threading.Tasks;
 namespace Google.Api.Gax
 {
     /// <summary>
-    /// Singleton implementation of <see cref="IScheduler"/> which uses <see cref="Task.Delay"/>
-    /// and <see cref="Task.Run"/> internally.
+    /// Singleton implementation of <see cref="IScheduler"/> which uses <see cref="Task.Delay(TimeSpan)"/>
+    /// and <see cref="Task.Run(Action)"/> internally.
     /// </summary>
     public sealed class SystemScheduler : IScheduler
     {
+        /// <summary>
+        /// Retrieves the singleton instance.
+        /// </summary>
         public static SystemScheduler Instance { get; } = new SystemScheduler();
 
         private SystemScheduler() {}
 
+        /// <inheritdoc />
         public Task Delay(TimeSpan timeSpan) => Task.Delay(timeSpan);
 
+        /// <inheritdoc />
         public void Sleep(TimeSpan timeSpan) => Thread.Sleep(timeSpan);
 
+        /// <inheritdoc />
         public Task Schedule(Action action, TimeSpan timeSpan) =>
             Task.Run(async () =>
             {

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -12,7 +12,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../Gax.snk"
+    "keyFile": "../../Gax.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {

--- a/testing/Google.Api.Gax.Testing/FakeClock.cs
+++ b/testing/Google.Api.Gax.Testing/FakeClock.cs
@@ -52,9 +52,6 @@ namespace Google.Api.Gax.Testing
         /// <summary>
         /// Advances the clock to the given time.
         /// </summary>
-        /// <remarks>
-        /// This will raise the <see cref="TimeChanged"/> event, synchronously.
-        /// </remarks>
         /// <param name="dateTime">The time to advance to.</param>
         public void AdvanceTo(DateTime dateTime)
         {
@@ -64,9 +61,6 @@ namespace Google.Api.Gax.Testing
         /// <summary>
         /// Advances the clock by the given number of ticks.
         /// </summary>
-        /// <remarks>
-        /// This will raise the <see cref="TimeChanged"/> event, synchronously.
-        /// </remarks>
         /// <param name="ticks">Ticks to advance the clock by.</param>
         public void Advance(long ticks)
         {

--- a/testing/Google.Api.Gax.Testing/project.json
+++ b/testing/Google.Api.Gax.Testing/project.json
@@ -12,7 +12,8 @@
   },
 
   "buildOptions": {
-    "keyFile": "../../Gax.snk"
+    "keyFile": "../../Gax.snk",
+    "xmlDoc": true
   },
 
   "dependencies": {


### PR DESCRIPTION
This just adds `"xmlDoc": true` to all the relevant project.json files, then fixes up the code so that everything is actually documented.

The only code change is to make `ApiCall` internal, given that a static class with no public members isn't really useful.

This fixes #87.