### PR TITLE
Make FakeScheduler less flaky

### DIFF
--- a/test/Google.Api.Gax.Tests/AssemblyInfo.cs
+++ b/test/Google.Api.Gax.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Google.Api.Gax.Tests/PollingTest.cs
+++ b/test/Google.Api.Gax.Tests/PollingTest.cs
@@ -24,7 +24,6 @@ namespace Google.Api.Gax.Tests
                 var result = pollSource.PollRepeatedly(pollSettings);
                 Assert.Equal(5, result);
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
-                return 0; // TODO: Remove the need for this, by improving FakeScheduler.
             });
         }
 
@@ -38,37 +37,32 @@ namespace Google.Api.Gax.Tests
                 Assert.Throws<TimeoutException>(() => pollSource.PollRepeatedly(pollSettings));
                 // We give up at t=4 because the next call would be after the expiration.
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
-                return 0; // TODO: Remove the need for this, by improving FakeScheduler.
             });
         }
 
-        // FIXME: These tests being non-async is all kinds of wrong...
         [Fact]
-        public void PollToCompletionAsync_Success()
+        public async Task PollToCompletionAsync_Success()
         {
             var pollSource = new PollSource(TimeSpan.FromSeconds(3), 5);
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
-            pollSource.Scheduler.Run(() =>
+            await pollSource.Scheduler.RunAsync(async () =>
             {
-                var result = pollSource.PollRepeatedlyAsync(pollSettings).Result;
+                var result = await pollSource.PollRepeatedlyAsync(pollSettings);
                 Assert.Equal(5, result);
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
-                return 0; // TODO: Remove the need for this, by improving FakeScheduler.
             });
         }
 
         [Fact]
-        public void PollToCompletionAsync_Timeout()
+        public async Task PollToCompletionAsync_Timeout()
         {
             var pollSource = new PollSource(TimeSpan.FromSeconds(10), 5);
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
-            pollSource.Scheduler.Run(() =>
+            await pollSource.Scheduler.RunAsync(async () =>
             {
-                var aggregate = Assert.Throws<AggregateException>(() => pollSource.PollRepeatedlyAsync(pollSettings).Result);
-                Assert.IsType<TimeoutException>(aggregate.InnerException);
+                await Assert.ThrowsAsync<TimeoutException>(() => pollSource.PollRepeatedlyAsync(pollSettings));
                 // We give up at t=4 because the next call would be after the expiration.
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
-                return 0; // TODO: Remove the need for this, by improving FakeScheduler.
             });
         }
 


### PR DESCRIPTION
We now don't have the flaky "pause" at various points. This does mean that any scheduled actions can easily overlap each other in real time, but it's hard to fix that without flakiness. If it becomes an issue, we can add a configurable pause.

The API is now consistent and more clearly documented, and
has a couple of "guard" methods to prevent Run being called
accidentally instead of RunAsync. (I found I consistently made that
error.)