### PR TITLE
Update dependency versions

### DIFF
--- a/src/Google.Api.Gax.Grpc/project.json
+++ b/src/Google.Api.Gax.Grpc/project.json
@@ -18,13 +18,12 @@
 
   "dependencies": {
     "Google.Api.Gax": { "target": "project" },
-    "Google.Apis.Auth": "1.16.0",
+    "Google.Apis.Auth": "1.18.0",
     "Google.Protobuf": "3.0.0",
     "Google.Protobuf.Tools": { "version": "3.0.0", "type": "build" },
-    "Grpc.Auth": "1.0.1-pre1",
-    "Grpc.Core": "1.0.1-pre1",
-    "Grpc.Tools": { "version": "1.0.0", "type": "build" },
-    "System.Interactive.Async": "3.0.0"
+    "Grpc.Auth": "1.0.1",
+    "Grpc.Core": "1.0.1",
+    "Grpc.Tools": { "version": "1.0.0", "type": "build" }
   },
   "frameworks": {
     "net45": { },

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -18,9 +18,8 @@
 
   "dependencies": {
     "Google.Api.Gax": { "target": "project" },
-    "Google.Apis.Auth": "1.16.0",
-    "Google.Apis": "1.16.0",
-    "System.Interactive.Async": "3.0.0"
+    "Google.Apis.Auth": "1.18.0",
+    "Google.Apis": "1.18.0"
   },
   "frameworks": {
     "net45": { },

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -17,7 +17,7 @@
   },
 
   "dependencies": {
-    "System.Interactive.Async": "3.0.0"
+    "System.Interactive.Async": "3.1.0-rc2"
   },
   "frameworks": {
     "net45": {},

--- a/test/Google.Api.Gax.Grpc.IntegrationTests/project.json
+++ b/test/Google.Api.Gax.Grpc.IntegrationTests/project.json
@@ -6,8 +6,6 @@
     "Google.Api.Gax": { "target": "project" },
     "Google.Api.Gax.Grpc": { "target": "project" },
     "Google.Api.Gax.Testing": { "target": "project" },
-    "System.Interactive.Async": "3.0.0",
-    "Grpc.Core": "1.0.1-pre1",
     "Moq": "4.6.36-alpha"
   },
   "testRunner": "xunit",

--- a/test/Google.Api.Gax.Grpc.Tests/project.json
+++ b/test/Google.Api.Gax.Grpc.Tests/project.json
@@ -5,8 +5,7 @@
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Api.Gax.Grpc": { "target": "project" },
     "Google.Api.Gax.Testing": { "target": "project" },
-    "Moq": "4.6.36-alpha",
-    "System.Interactive.Async": "3.0.0"
+    "Moq": "4.6.36-alpha"
   },
   "testRunner": "xunit",
   "buildOptions": {

--- a/test/Google.Api.Gax.Rest.Tests/project.json
+++ b/test/Google.Api.Gax.Rest.Tests/project.json
@@ -4,8 +4,7 @@
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Api.Gax.Rest": { "target": "project" },
-    "Moq": "4.6.36-alpha",
-    "System.Interactive.Async": "3.0.0"
+    "Moq": "4.6.36-alpha"
   },
   "testRunner": "xunit",
   "buildOptions": {

--- a/test/Google.Api.Gax.Tests/project.json
+++ b/test/Google.Api.Gax.Tests/project.json
@@ -5,8 +5,7 @@
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Google.Api.Gax": { "target": "project" },
     "Google.Api.Gax.Testing": { "target": "project" },
-    "Moq": "4.6.36-alpha",
-    "System.Interactive.Async": "3.0.0"
+    "Moq": "4.6.36-alpha"
   },
   "testRunner": "xunit",
   "buildOptions": {


### PR DESCRIPTION
- Update gRPC to 1.0.1
- Update System.Interactive.Async to 3.1.0-rc2
- Remove dependencies we didn't really need (due to transitive
  dependencies) so that we have fewer places to update in future.

This fixes #103.