### PR TITLE
Add a ScopedCredentialProvider

### DIFF
--- a/src/Google.Api.Gax/ScopedCredentialProvider.cs
+++ b/src/Google.Api.Gax/ScopedCredentialProvider.cs
@@ -1,0 +1,95 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+using Google.Apis.Auth.OAuth2;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// Simple factory of scoped credentials, which caches a scoped version of the
+    /// default application credentials to avoid repeated authentication.
+    /// </summary>
+    public sealed class ScopedCredentialProvider
+    {
+        /// <summary>
+        /// Lazily-created task to retrieve the default application channel credentials. Once completed, this
+        /// task can be used whenever channel credentials are required. The returned task always runs in the
+        /// thread pool, so its result can be used synchronously from synchronous methods without risk of deadlock.
+        /// The same channel credentials are used by all pools. The field is initialized in the constructor, as it uses
+        /// _scopes, and you can't refer to an instance field within an instance field initializer.
+        /// </summary>
+        private readonly Lazy<Task<GoogleCredential>> _lazyScopedDefaultCredentials;
+        private readonly List<string> _scopes;
+
+        /// <summary>
+        /// Creates a channel pool which will apply the specified scopes to the credentials if they require any.
+        /// </summary>
+        /// <param name="scopes">The scopes to apply. Must not be null, and must not contain null references. May be empty.</param>
+        public ScopedCredentialProvider(IEnumerable<string> scopes)
+        {
+            // Always take a copy of the provided scopes, then check the copy doesn't contain any nulls.
+            _scopes = GaxPreconditions.CheckNotNull(scopes, nameof(scopes)).ToList();
+            GaxPreconditions.CheckArgument(!_scopes.Any(x => x == null), nameof(scopes), "Scopes must not contain any null references");
+            _lazyScopedDefaultCredentials = new Lazy<Task<GoogleCredential>>(() => Task.Run(CreateDefaultCredentialsUncached));
+        }
+
+        /// <summary>
+        /// Returns credentials with the scopes applied if required.
+        /// </summary>
+        /// <param name="credentials">Existing credentials, if any. This may be null,
+        /// in which case the default application credentials will be used.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task
+        /// is the scoped credentials.</returns>
+        public GoogleCredential GetCredentials(GoogleCredential credentials)
+        {
+            if (credentials != null)
+            {
+                return ApplyScopes(credentials);
+            }
+            try
+            {
+                // No need to apply scopes here - they're already applied.
+                return _lazyScopedDefaultCredentials.Value.Result;
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
+                // but let's handle it relatively gracefully.
+                throw e.InnerExceptions.FirstOrDefault() ?? e;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously returns credentials with the scopes applied if required.
+        /// </summary>
+        /// <param name="credentials">Existing credentials, if any. This may be null,
+        /// in which case the default application credentials will be used.</param>
+        /// <returns>A task representing the asynchronous operation. The result of the task
+        /// is the scoped credentials.</returns>
+        public Task<GoogleCredential> GetCredentialsAsync(GoogleCredential credentials) =>
+            credentials == null
+                ? _lazyScopedDefaultCredentials.Value
+                : Task.FromResult(ApplyScopes(credentials));
+
+        private async Task<GoogleCredential> CreateDefaultCredentialsUncached()
+        {
+            var credentials = await GoogleCredential.GetApplicationDefaultAsync();
+            return ApplyScopes(credentials);
+        }
+
+        private GoogleCredential ApplyScopes(GoogleCredential original)
+        {
+            return original.IsCreateScopedRequired && _scopes.Count > 0
+                ? original.CreateScoped(_scopes)
+                : original;
+        }
+    }
+}

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -17,6 +17,7 @@
   },
 
   "dependencies": {
+    "Google.Apis.Auth": "1.18.0",
     "System.Interactive.Async": "3.1.0"
   },
   "frameworks": {

--- a/test/Google.Api.Gax.Tests/ScopedCredentialProviderTest.cs
+++ b/test/Google.Api.Gax.Tests/ScopedCredentialProviderTest.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Apis.Auth.OAuth2;
+using Newtonsoft.Json;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.IntegrationTests
+{
+    // Note: we can't easily test the default credentials part here, as that relies
+    // on environment variables etc. (We could potentially set the environment variable
+    // within the test, but we'd quickly get into ordering issues etc.)
+    public class ScopedCredentialProviderTest
+    {
+        // This is a valid PKCS8 private key, but it isn't used for anything in the real world.
+        // It was generated purely for the sake of this test, so that we could generate server
+        // account credentials which *look* valid.
+        private static readonly string s_samplePrivateKey =
+@"-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAwxUlt4jqmcFg45Ke
+xjUM8fV+NN+a3OHSONasKwOLoDxQSZlGsWMifQUYBvhHM9qhG+sagW2HVYy1bV1X
+43rphQIDAQABAkEAmqsRlEpBdlYTc1qz94HoGY4B2fnO1oFUIyxQpGnTMd48zPAu
+R0KHbx+2oG2EFgu+lFtO05xtnKqBQEChs/oZoQIhAO58ArcePssfbyuLKDCy21z/
+1kbm72ltNH8Av8lAnBNPAiEA0WkYTIhgsSUHh1gfNfqX0YeswWYsSQ/CSdeeI4Xr
+0OsCIHj8sOP1lCW4bM3KazlJg8BKioqt3ge+P0OvPZz8CjJBAiBCQS0F8dQd1+hk
+4vWk/28PRQzcd7YlO44uDMEk3hc5FwIgEC3IjYC5eSpfphW0VATvHiFoFYxpYzzk
+j5XmfIZhC9k =
+-----END PRIVATE KEY-----".Replace("\r", "").Replace("\n", "");
+
+        [Fact]
+        public void GetCredentials_EmptyScopes_NoOp()
+        {
+            var provider = new ScopedCredentialProvider(new string[0]);
+            var originalCredentials = CreateServiceCredentials();
+            var provided = provider.GetCredentials(originalCredentials);
+            Assert.Same(originalCredentials, provided);
+        }
+
+        [Fact]
+        public void GetCredentials_ScopesApplied()
+        {
+            var provider = new ScopedCredentialProvider(new[] { "abc" });
+            var originalCredentials = CreateServiceCredentials();
+            var provided = provider.GetCredentials(originalCredentials);
+            // Can't actually test the scopes...
+            Assert.NotSame(originalCredentials, provided);
+        }
+
+        [Fact]
+        public async Task GetCredentialsAsync_EmptyScopes_NoOp()
+        {
+            var provider = new ScopedCredentialProvider(new string[0]);
+            var originalCredentials = CreateServiceCredentials();
+            var provided = await provider.GetCredentialsAsync(originalCredentials);
+            Assert.Same(originalCredentials, provided);
+        }
+
+        [Fact]
+        public async Task GetCredentialsAsync_ScopesApplied()
+        {
+            var provider = new ScopedCredentialProvider(new[] { "abc" });
+            var originalCredentials = CreateServiceCredentials();
+            var provided = await provider.GetCredentialsAsync(originalCredentials);
+            // Can't actually test the scopes...
+            Assert.NotSame(originalCredentials, provided);
+        }
+
+        private GoogleCredential CreateServiceCredentials()
+        {
+            var parameters = new JsonCredentialParameters
+            {
+                Type = JsonCredentialParameters.ServiceAccountCredentialType,
+                ClientEmail = "noone@example.com",
+                PrivateKey = s_samplePrivateKey
+            };
+            string json = JsonConvert.SerializeObject(parameters);
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            return GoogleCredential.FromStream(stream);
+        }
+    }
+}


### PR DESCRIPTION
This caches the scoped credentials for the default application
credentials, to avoid a new auth token being requested each time.

It would be nice to use this within ChannelPool, but because there's
the extra transformation of creating ChannelCredentials, and because
the Lazy<T> is of a task, it doesn't quite work out. Making it work
would probably require more new code than the removed redundancy...

Background: we want this for Storage and Bigquery so that creating new clients regularly doesn't have as much overhead. It will also make the code simpler in each of those projects.