### PR TITLE
Update System.Interactive.Async to 3.1.1

### DIFF
--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -18,7 +18,7 @@
 
   "dependencies": {
     "Google.Apis.Auth": "1.18.0",
-    "System.Interactive.Async": "3.1.0"
+    "System.Interactive.Async": "3.1.1"
   },
   "frameworks": {
     "net45": {},


### PR DESCRIPTION
This avoids taking a dependency on NETStandard.Library when
using net45.