### PR TITLE
Add cancellation to IScheduler

### DIFF
--- a/src/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
+++ b/src/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
@@ -47,7 +47,7 @@ namespace Google.Api.Gax.Grpc
                         {
                             throw;
                         }
-                        await scheduler.Delay(actualDelay);
+                        await scheduler.Delay(actualDelay, callSettings.CancellationToken.GetValueOrDefault());
                         retryDelay = retrySettings.RetryBackoff.NextDelay(retryDelay);
                         callTimeout = retrySettings.TimeoutBackoff.NextDelay(callTimeout);
                     }
@@ -86,7 +86,7 @@ namespace Google.Api.Gax.Grpc
                         {
                             throw;
                         }
-                        scheduler.Sleep(actualDelay);
+                        scheduler.Sleep(actualDelay, callSettings.CancellationToken.GetValueOrDefault());
                         retryDelay = retrySettings.RetryBackoff.NextDelay(retryDelay);
                         callTimeout = retrySettings.TimeoutBackoff.NextDelay(callTimeout);
                     }

--- a/src/Google.Api.Gax.Grpc/ChannelPool.cs
+++ b/src/Google.Api.Gax.Grpc/ChannelPool.cs
@@ -89,18 +89,8 @@ namespace Google.Api.Gax.Grpc
         public Channel GetChannel(ServiceEndpoint endpoint)
         {
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
-            try
-            {
-                var credentials = _lazyScopedDefaultChannelCredentials.Value.Result;
-                return GetChannel(endpoint, credentials);
-            }
-            catch (AggregateException e)
-            {
-                // Unwrap the first exception, a bit like await would.
-                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
-                // but let's handle it relatively gracefully.
-                throw e.InnerExceptions.FirstOrDefault() ?? e;
-            }
+            var credentials = _lazyScopedDefaultChannelCredentials.Value.ResultWithUnwrappedExceptions();
+            return GetChannel(endpoint, credentials);
         }
 
         /// <summary>

--- a/src/Google.Api.Gax/ScopedCredentialProvider.cs
+++ b/src/Google.Api.Gax/ScopedCredentialProvider.cs
@@ -47,25 +47,11 @@ namespace Google.Api.Gax
         /// in which case the default application credentials will be used.</param>
         /// <returns>A task representing the asynchronous operation. The result of the task
         /// is the scoped credentials.</returns>
-        public GoogleCredential GetCredentials(GoogleCredential credentials)
-        {
-            if (credentials != null)
-            {
-                return ApplyScopes(credentials);
-            }
-            try
-            {
+        public GoogleCredential GetCredentials(GoogleCredential credentials) =>
+            credentials == null
                 // No need to apply scopes here - they're already applied.
-                return _lazyScopedDefaultCredentials.Value.Result;
-            }
-            catch (AggregateException e)
-            {
-                // Unwrap the first exception, a bit like await would.
-                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
-                // but let's handle it relatively gracefully.
-                throw e.InnerExceptions.FirstOrDefault() ?? e;
-            }
-        }
+                ? _lazyScopedDefaultCredentials.Value.ResultWithUnwrappedExceptions()
+                : ApplyScopes(credentials);
 
         /// <summary>
         /// Asynchronously returns credentials with the scopes applied if required.

--- a/src/Google.Api.Gax/SystemScheduler.cs
+++ b/src/Google.Api.Gax/SystemScheduler.cs
@@ -1,12 +1,18 @@
-﻿using System;
+﻿/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Api.Gax
 {
     /// <summary>
-    /// Singleton implementation of <see cref="IScheduler"/> which uses <see cref="Task.Delay(TimeSpan)"/>
-    /// and <see cref="Task.Run(Action)"/> internally.
+    /// Singleton implementation of <see cref="IScheduler"/> which uses <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.
     /// </summary>
     public sealed class SystemScheduler : IScheduler
     {
@@ -18,9 +24,6 @@ namespace Google.Api.Gax
         private SystemScheduler() {}
 
         /// <inheritdoc />
-        public Task Delay(TimeSpan timeSpan) => Task.Delay(timeSpan);
-
-        /// <inheritdoc />
-        public void Sleep(TimeSpan timeSpan) => Thread.Sleep(timeSpan);
+        public Task Delay(TimeSpan timeSpan, CancellationToken cancellationToken) => Task.Delay(timeSpan, cancellationToken);
     }
 }

--- a/src/Google.Api.Gax/TaskExtensions.cs
+++ b/src/Google.Api.Gax/TaskExtensions.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// Extension methods for tasks.
+    /// </summary>
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Synchronously waits for the given task to complete, and returns the result.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <typeparam name="T">The result type of the task</typeparam>
+        /// <param name="task">The task to wait for.</param>
+        /// <returns>The result of the completed task.</returns>
+        internal static T ResultWithUnwrappedExceptions<T>(this Task<T> task)
+        {
+            task.WaitWithUnwrappedExceptions();
+            return task.Result;
+        }
+
+        /// <summary>
+        /// Synchronously waits for the given task to complete.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <param name="task">The task to wait for.</param>
+        internal static void WaitWithUnwrappedExceptions(this Task task)
+        {
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
+                // but let's handle it relatively gracefully.
+                throw e.InnerExceptions.FirstOrDefault() ?? e;
+            }
+
+        }
+    }
+}

--- a/test/Google.Api.Gax.Grpc.Tests/RetryTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/RetryTest.cs
@@ -271,7 +271,7 @@ namespace Google.Api.Gax.Grpc.Tests
             {
                 CallTimes.Add(scheduler.Clock.GetCurrentDateTimeUtc());
                 CallSettingsReceived.Add(callSettings);
-                scheduler.Sleep(callDuration);
+                scheduler.Delay(callDuration).Wait();
                 if (failuresToReturn > 0)
                 {
                     failuresToReturn--;

--- a/test/Google.Api.Gax.Tests/PollingTest.cs
+++ b/test/Google.Api.Gax.Tests/PollingTest.cs
@@ -7,6 +7,7 @@
 
 using Google.Api.Gax.Testing;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace Google.Api.Gax.Tests
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
             pollSource.Scheduler.Run(() =>
             {
-                var result = pollSource.PollRepeatedly(pollSettings);
+                var result = pollSource.PollRepeatedly(pollSettings, CancellationToken.None);
                 Assert.Equal(5, result);
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
             });
@@ -34,9 +35,23 @@ namespace Google.Api.Gax.Tests
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
             pollSource.Scheduler.Run(() =>
             {
-                Assert.Throws<TimeoutException>(() => pollSource.PollRepeatedly(pollSettings));
+                Assert.Throws<TimeoutException>(() => pollSource.PollRepeatedly(pollSettings, CancellationToken.None));
                 // We give up at t=4 because the next call would be after the expiration.
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
+            });
+        }
+
+        [Fact]
+        public void PollToCompletion_Cancellation()
+        {
+            var cts = new CancellationTokenSource();
+            var pollSource = new PollSource(TimeSpan.FromSeconds(4), 5);
+            var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
+            pollSource.Scheduler.ScheduleCancellation(TimeSpan.FromSeconds(3), cts);
+            pollSource.Scheduler.Run(() =>
+            {
+                Assert.Throws<TaskCanceledException>(() => pollSource.PollRepeatedly(pollSettings, cts.Token));
+                Assert.Equal(TimeSpan.FromSeconds(3), pollSource.RunningTime);
             });
         }
 
@@ -47,7 +62,7 @@ namespace Google.Api.Gax.Tests
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
             await pollSource.Scheduler.RunAsync(async () =>
             {
-                var result = await pollSource.PollRepeatedlyAsync(pollSettings);
+                var result = await pollSource.PollRepeatedlyAsync(pollSettings, CancellationToken.None);
                 Assert.Equal(5, result);
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
             });
@@ -60,9 +75,23 @@ namespace Google.Api.Gax.Tests
             var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
             await pollSource.Scheduler.RunAsync(async () =>
             {
-                await Assert.ThrowsAsync<TimeoutException>(() => pollSource.PollRepeatedlyAsync(pollSettings));
+                await Assert.ThrowsAsync<TimeoutException>(() => pollSource.PollRepeatedlyAsync(pollSettings, CancellationToken.None));
                 // We give up at t=4 because the next call would be after the expiration.
                 Assert.Equal(TimeSpan.FromSeconds(4), pollSource.RunningTime);
+            });
+        }
+
+        [Fact]
+        public async Task PollToCompletionAsync_Cancellation()
+        {
+            var cts = new CancellationTokenSource();
+            var pollSource = new PollSource(TimeSpan.FromSeconds(4), 5);
+            var pollSettings = new PollSettings(Expiration.FromTimeout(TimeSpan.FromSeconds(5)), TimeSpan.FromSeconds(2));
+            pollSource.Scheduler.ScheduleCancellation(TimeSpan.FromSeconds(3), cts);
+            await pollSource.Scheduler.RunAsync(async () =>
+            {
+                await Assert.ThrowsAsync<TaskCanceledException>(() => pollSource.PollRepeatedlyAsync(pollSettings, cts.Token));
+                Assert.Equal(TimeSpan.FromSeconds(3), pollSource.RunningTime);
             });
         }
 
@@ -89,11 +118,11 @@ namespace Google.Api.Gax.Tests
             // Simple predicate for whether an integer is positive.
             private static bool IsPositive(int input) => input > 0;
 
-            internal int PollRepeatedly(PollSettings pollSettings)
-                => Polling.PollRepeatedly(Poll, IsPositive, Clock, Scheduler, pollSettings);
+            internal int PollRepeatedly(PollSettings pollSettings, CancellationToken cancellationToken)
+                => Polling.PollRepeatedly(Poll, IsPositive, Clock, Scheduler, pollSettings, cancellationToken);
 
-            internal Task<int> PollRepeatedlyAsync(PollSettings pollSettings)
-                => Polling.PollRepeatedlyAsync(PollAsync, IsPositive, Clock, Scheduler, pollSettings);
+            internal Task<int> PollRepeatedlyAsync(PollSettings pollSettings, CancellationToken cancellationToken)
+                => Polling.PollRepeatedlyAsync(PollAsync, IsPositive, Clock, Scheduler, pollSettings, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
At the same time, the synchronous Sleep method has been removed from
IScheduler, and implemented as an extension method (with a
cancellation token).

Fixes #84.