### PR TITLE
Update to using the latest Google.Apis

### DIFF
--- a/src/Google.Api.Gax.Grpc/project.json
+++ b/src/Google.Api.Gax.Grpc/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
 
   "packOptions": {
     "title": "Google grPC API Extensions",
@@ -18,7 +18,7 @@
 
   "dependencies": {
     "Google.Api.Gax": { "target": "project" },
-    "Google.Apis.Auth": "1.18.0",
+    "Google.Apis.Auth": "1.20.0",
     "Google.Protobuf": "3.0.0",
     "Google.Protobuf.Tools": { "version": "3.0.0", "type": "build" },
     "Grpc.Auth": "1.0.1",

--- a/src/Google.Api.Gax.Rest/project.json
+++ b/src/Google.Api.Gax.Rest/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
 
   "packOptions": {
     "title": "Google REST API Extensions",
@@ -18,8 +18,8 @@
 
   "dependencies": {
     "Google.Api.Gax": { "target": "project" },
-    "Google.Apis.Auth": "1.18.0",
-    "Google.Apis": "1.18.0"
+    "Google.Apis.Auth": "1.20.0",
+    "Google.Apis": "1.20.0"
   },
   "frameworks": {
     "net45": { },

--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
 
   "packOptions": {
     "title": "Google API Extensions",
@@ -17,7 +17,7 @@
   },
 
   "dependencies": {
-    "Google.Apis.Auth": "1.18.0",
+    "Google.Apis.Auth": "1.20.0",
     "System.Interactive.Async": "3.1.1"
   },
   "frameworks": {

--- a/testing/Google.Api.Gax.Grpc.Testing/project.json
+++ b/testing/Google.Api.Gax.Grpc.Testing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
 
   "packOptions": {
     "title": "Testing support for Google.Api.Gax",

--- a/testing/Google.Api.Gax.Testing/project.json
+++ b/testing/Google.Api.Gax.Testing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta05-*",
+  "version": "1.0.0-beta06-*",
 
   "packOptions": {
     "title": "Testing support for Google.Api.Gax",


### PR DESCRIPTION
(This removes the problematic BouncyCastle dependency.)

Updated the published version to beta06 as well, so I can do
a release immediately afterwards.

Note that the CommonProtos package is unaffected (and stays at
beta05).