### PR TITLE
Expose TaskExtensions publicly

### DIFF
--- a/src/Google.Api.Gax/TaskExtensions.cs
+++ b/src/Google.Api.Gax/TaskExtensions.cs
@@ -6,7 +6,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -15,7 +14,7 @@ namespace Google.Api.Gax
     /// <summary>
     /// Extension methods for tasks.
     /// </summary>
-    internal static class TaskExtensions
+    public static class TaskExtensions
     {
         /// <summary>
         /// Synchronously waits for the given task to complete, and returns the result.
@@ -24,7 +23,7 @@ namespace Google.Api.Gax
         /// <typeparam name="T">The result type of the task</typeparam>
         /// <param name="task">The task to wait for.</param>
         /// <returns>The result of the completed task.</returns>
-        internal static T ResultWithUnwrappedExceptions<T>(this Task<T> task)
+        public static T ResultWithUnwrappedExceptions<T>(this Task<T> task)
         {
             task.WaitWithUnwrappedExceptions();
             return task.Result;
@@ -35,7 +34,7 @@ namespace Google.Api.Gax
         /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
         /// </summary>
         /// <param name="task">The task to wait for.</param>
-        internal static void WaitWithUnwrappedExceptions(this Task task)
+        public static void WaitWithUnwrappedExceptions(this Task task)
         {
             try
             {

--- a/test/Google.Api.Gax.Tests/TaskExtensionsTest.cs
+++ b/test/Google.Api.Gax.Tests/TaskExtensionsTest.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Tests
+{
+    public class TaskExtensionsTest
+    {
+        [Fact]
+        public void ResultWithUnwrappedException_Faulted()
+        {
+            var exception = new IOException("Bang");
+            var task = TaskFromException<int>(exception);
+            var thrown = Assert.Throws<IOException>(() => task.ResultWithUnwrappedExceptions());
+            Assert.Same(exception, thrown);
+        }
+
+        [Fact]
+        public void WaitWithUnwrappedException_Faulted()
+        {
+            var exception = new IOException("Bang");
+            var task = TaskFromException<int>(exception);
+            var thrown = Assert.Throws<IOException>(() => task.WaitWithUnwrappedExceptions());
+            Assert.Same(exception, thrown);
+
+        }
+
+        [Fact]
+        public void ResultWithUnwrappedException_Completed()
+        {
+            var task = Task.FromResult(10);
+            Assert.Equal(10, task.ResultWithUnwrappedExceptions());
+        }
+
+        [Fact]
+        public void WaitWithUnwrappedException_Completed()
+        {
+            var task = Task.FromResult(10);
+            task.WaitWithUnwrappedExceptions();
+        }
+
+        // Task.FromException doesn't exist in .NET 4.5.1 :(
+        private static Task<T> TaskFromException<T>(Exception e)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            tcs.SetException(e);
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
This will allow us to use the methods from wrapper APIs, e.g. when loading images/speech synchronously.