### PR TITLE
Method to create a new set of settings with an earlier deadline.

### DIFF
--- a/src/Google.Api.Gax.Grpc/RetrySettings.cs
+++ b/src/Google.Api.Gax.Grpc/RetrySettings.cs
@@ -18,12 +18,12 @@ namespace Google.Api.Gax.Grpc
     public sealed class RetrySettings
     {
         /// <summary>
-        /// The backoff policy for the time between retries.
+        /// The backoff policy for the time between retries. This is never null.
         /// </summary>
         public BackoffSettings RetryBackoff { get; }
 
         /// <summary>
-        /// The backoff policy for timeouts of retries.
+        /// The backoff policy for timeouts of retries. This is never null.
         /// </summary>
         /// <remarks>
         /// This allows an increasing timeout, initially requesting a fast call,
@@ -33,7 +33,7 @@ namespace Google.Api.Gax.Grpc
         public BackoffSettings TimeoutBackoff { get; }
 
         /// <summary>
-        /// The total expiration, across all retries.
+        /// The total expiration, across all retries. This is never null.
         /// </summary>
         public Expiration TotalExpiration { get; }
 
@@ -159,6 +159,13 @@ namespace Google.Api.Gax.Grpc
             // TODO: Take a copy? Optimize for common cases?
             return ex => statusCodes.Contains(ex.Status.StatusCode);
         }
+
+        /// <summary>
+        /// Builds a new RetrySettings which is identical to this one, but with the given expiration.
+        /// </summary>
+        /// <param name="expiration">New expiration</param>
+        internal RetrySettings WithTotalExpiration(Expiration expiration) =>
+            new RetrySettings(RetryBackoff, TimeoutBackoff, expiration, RetryFilter, DelayJitter);
 
         private sealed class RandomJitterImpl : IJitter
         {

--- a/test/Google.Api.Gax.Grpc.Tests/RetrySettingsTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/RetrySettingsTest.cs
@@ -24,5 +24,22 @@ namespace Google.Api.Gax.Grpc.Tests
             var settings = new RetrySettings(s_sampleBackoff, s_sampleBackoff, Expiration.None, null);
             settings = new RetrySettings(s_sampleBackoff, s_sampleBackoff, Expiration.None, null, null);
         }
+
+        [Fact]
+        public void WithNewExpiration()
+        {
+            var retryBackoff = new BackoffSettings(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+            var timeoutBackoff = new BackoffSettings(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+            var original = new RetrySettings(retryBackoff, timeoutBackoff, Expiration.FromTimeout(TimeSpan.FromSeconds(5)),
+                e => false, RetrySettings.NoJitter);
+            var newExpiration = Expiration.FromDeadline(DateTime.UtcNow);
+            var newSettings = original.WithTotalExpiration(newExpiration);
+
+            Assert.Same(original.RetryBackoff, newSettings.RetryBackoff);
+            Assert.Same(original.TimeoutBackoff, newSettings.TimeoutBackoff);
+            Assert.Same(original.RetryFilter, newSettings.RetryFilter);
+            Assert.Same(original.DelayJitter, newSettings.DelayJitter);
+            Assert.Same(newExpiration, newSettings.TotalExpiration);
+        }
     }
 }


### PR DESCRIPTION
This will be used from polling code which needs to take into account
an overall deadline from PollSettings along with an existing
CallSettings.

Currently no tests - I'll amend this commit to add them when we've settled on the design. I want at least one test hitting each case :)