### PR TITLE
Add(IEnumerable<T>) method to ResourceNameList

### DIFF
--- a/src/Google.Api.Gax/ResourceNameList.cs
+++ b/src/Google.Api.Gax/ResourceNameList.cs
@@ -52,6 +52,19 @@ namespace Google.Api.Gax
         /// <inheritdoc />
         public void Add(TName item) => _underlyingList.Add(_nameToString(item));
 
+        /// <summary>
+        /// Adds all items to this list.
+        /// </summary>
+        /// <param name="items">The items to add to this list.</param>
+        public void Add(IEnumerable<TName> items)
+        {
+            GaxPreconditions.CheckNotNull(items, nameof(items));
+            foreach (TName item in items)
+            {
+                Add(item);
+            }
+        }
+
         /// <inheritdoc />
         public void Clear() => _underlyingList.Clear();
 

--- a/test/Google.Api.Gax.Tests/ResourceNameListTest.cs
+++ b/test/Google.Api.Gax.Tests/ResourceNameListTest.cs
@@ -51,10 +51,26 @@ namespace Google.Api.Gax.Tests
         }
 
         [Fact]
+        public void AddRange()
+        {
+            var list = List("a", "b");
+            var resourceList = ResourceList(list);
+            resourceList.Add(new[] { new UnknownResourceName("c"), new UnknownResourceName("d") });
+            Assert.Equal(List("a", "b", "c", "d"), list);
+        }
+
+        [Fact]
         public void Add_NullElement()
         {
             var resourceList = ResourceList(List());
-            Assert.Throws<ArgumentNullException>(() => resourceList.Add(null));
+            Assert.Throws<ArgumentNullException>(() => resourceList.Add((UnknownResourceName)null));
+        }
+
+        [Fact]
+        public void AddRange_NullEnumerable()
+        {
+            var resourceList = ResourceList(List());
+            Assert.Throws<ArgumentNullException>(() => resourceList.Add((IEnumerable<UnknownResourceName>)null));
         }
 
         [Fact]


### PR DESCRIPTION
To allow adding an enumerable of items using object initializer syntax.