### PR TITLE
Update dependencies

### DIFF
--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -30,7 +30,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.Thread": "4.0.0",
+        "NETStandard.Library": "1.6.1",
         "Microsoft.Extensions.PlatformAbstractions": "1.1.0"
       }
     }

--- a/test/Google.Api.Gax.Rest.Tests/project.json
+++ b/test/Google.Api.Gax.Rest.Tests/project.json
@@ -11,11 +11,7 @@
     "keyFile": "../../Gax.snk"
   },
   "frameworks": {
-    "net451": {
-      "dependencies": {
-        "System.Net.Http": "4.0.0"
-      }
-    },
+    "net451": { },
     "netcoreapp1.0": {
       "imports": "netcore50",
       "dependencies": {


### PR DESCRIPTION
Google.Api.Gax - and therefore everything downstream of it - now depends on NETStandard.Library.
See http://stackoverflow.com/questions/42946951 for background.

Additionally, Google.Api.Gax.Rest depends on System.Net.Http, so we don't need
to restate the dependency in Google.Api.Gax.Rest.Tests