### PR TITLE
Upgrade Newtonsoft.Json from v9.0.1 -> v10.0.1

### DIFF
--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -18,9 +18,8 @@
 
   "dependencies": {
     "Google.Apis.Auth": "1.22.0",
-    "System.Interactive.Async": "3.1.1"
-    // Required for parsing uint64 instanceId in metadata server JSON
-    //"Newtonsoft.Json": "9.0.2-beta2"
+    "System.Interactive.Async": "3.1.1",
+    "Newtonsoft.Json": "10.0.1"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
This is required because v9 mishandles u64 numbers greater than i64.max when decoding
Fixes #155