### PR TITLE
Change how we find projects to package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,9 +71,9 @@ dotnet test -f netcoreapp1.0 $DOTNET_TEST_ARGS test/Google.Api.Gax.Rest.Tests
 
 echo Packing
 
-# Assume each packagable project contains something like "version": "1.0.0-*"
-# and no other projects do.
-for package in `$FIND . -name project.json | xargs grep -le 'version.*-\*' | sed 's/\/project.json//g'`
+# Assume each packagable project has a version property exactly two spaces in.
+# This is nasty, but we can do something better after moving to csproj
+for package in $($FIND . -name project.json | xargs grep -le '^  \"version\"' | sed 's/\/project.json//g')
 do
   dotnet pack --no-build $DOTNET_BUILD_ARGS $package
 done


### PR DESCRIPTION
This is pretty nasty, but as we're hoping to overhaul the build
system soon anyway, it's okay for now.