### PR TITLE
Fix version of System.Net.Http on net45

### DIFF
--- a/src/Google.Api.Gax/project.json
+++ b/src/Google.Api.Gax/project.json
@@ -24,7 +24,7 @@
   "frameworks": {
     "net45": {
       "dependencies": {
-        "System.Net.Http": "4.3.0"
+        "System.Net.Http": "4.0.0"
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
This now builds with no warnings.