### PR TITLE
Stage 1 of GAX migration

### DIFF
--- a/src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0-beta01</VersionPrefix>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>
 
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Auth" Version="1.2.0" />
     <PackageReference Include="Grpc.Core" Version="1.2.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.25.0" />
   </ItemGroup>
 
   <Import Project="..\..\StripDesktopOnNonWindows.xml" />

--- a/src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0-beta01</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
   </PropertyGroup>
 
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.25.0" />
   </ItemGroup>
 
   <Import Project="..\..\StripDesktopOnNonWindows.xml" />

--- a/src/Google.Api.Gax.Rest/ScopedCredentialProvider.cs
+++ b/src/Google.Api.Gax.Rest/ScopedCredentialProvider.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Google.Api.Gax
+namespace Google.Api.Gax.Rest
 {
     /// <summary>
     /// Simple factory of scoped credentials, which caches a scoped version of the

--- a/src/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/src/Google.Api.Gax/Google.Api.Gax.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0-beta01</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
   </PropertyGroup>
 
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.25.0" />
     <PackageReference Include="System.Interactive.Async" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>

--- a/test/Google.Api.Gax.Rest.Tests/ScopedCredentialProviderTest.cs
+++ b/test/Google.Api.Gax.Rest.Tests/ScopedCredentialProviderTest.cs
@@ -12,7 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Google.Api.Gax.IntegrationTests
+namespace Google.Api.Gax.Rest.Tests
 {
     // Note: we can't easily test the default credentials part here, as that relies
     // on environment variables etc. (We could potentially set the environment variable


### PR DESCRIPTION
- Move ScopedCredentialProvider to Google.Api.Gax.Rest
- Remove Google.Apis.Auth dependency from Google.Api.Gax, and
  add it to Google.Api.Gax.{Rest,Grpc} instead. It will eventually
  be dropped from the Grpc flavour
- Bump all version numbers to 2.0