### PR TITLE
Normalize to a single release version for GAX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ _site
 packages
 tmp
 googleapis
+
+# Created by build.sh
+nuget

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -1,0 +1,10 @@
+<Project>
+  <!-- 
+    - Single place to put the release version number. This is imported
+    - in both testing/* and src/*. We may eventually want to have
+    - divergent versions, but for the moment this keeps things simpler.
+    -->
+  <PropertyGroup>
+    <VersionPrefix>2.0.0</VersionPrefix>
+  </PropertyGroup>
+</Project>

--- a/src/CommonProjectProperties.xml
+++ b/src/CommonProjectProperties.xml
@@ -21,4 +21,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/googleapis/gax-dotnet</RepositoryUrl>
   </PropertyGroup>
+
+  <Import Project="..\ReleaseVersion.xml" />
 </Project>

--- a/src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/src/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/src/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/src/Google.Api.Gax/Google.Api.Gax.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
   </PropertyGroup>
 

--- a/testing/CommonProjectProperties.xml
+++ b/testing/CommonProjectProperties.xml
@@ -21,4 +21,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/googleapis/gax-dotnet</RepositoryUrl>
   </PropertyGroup>
+
+  <Import Project="..\ReleaseVersion.xml" />
 </Project>

--- a/testing/Google.Api.Gax.Grpc.Testing/Google.Api.Gax.Grpc.Testing.csproj
+++ b/testing/Google.Api.Gax.Grpc.Testing/Google.Api.Gax.Grpc.Testing.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>
 

--- a/testing/Google.Api.Gax.Testing/Google.Api.Gax.Testing.csproj
+++ b/testing/Google.Api.Gax.Testing/Google.Api.Gax.Testing.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\CommonProjectProperties.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
This makes it much simpler to update the version number.