### PR TITLE
Make it easier to specify a FieldMask for CallSettings

### DIFF
--- a/src/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/src/Google.Api.Gax.Grpc/CallSettings.cs
@@ -16,6 +16,8 @@ namespace Google.Api.Gax.Grpc
     /// </summary>
     public sealed class CallSettings
     {
+        internal const string FieldMaskHeader = "x-goog-fieldmask";
+
         /// <summary>
         /// Constructs an instance with the specified settings.
         /// </summary>
@@ -154,5 +156,24 @@ namespace Google.Api.Gax.Grpc
             GaxPreconditions.CheckNotNull(value, nameof(value));
             return FromHeaderMutation(metadata => metadata.Add(name, value));
         }
+
+        /// <summary>
+        /// Creates a <see cref="CallSettings"/> that will include a field mask in the request, to
+        /// limit which fields are returned in the response.
+        /// </summary>
+        /// <remarks>
+        /// The precise effect on the request is not guaranteed: it may be through a header or a side-channel,
+        /// for example. Likewise the effect of combining multiple settings containing field masks is not specified.
+        /// </remarks>
+        /// <param name="fieldMask">The field mask for the request. Must not be null.</param>
+        /// <returns>A new instance.</returns>
+        public static CallSettings FromFieldMask(string fieldMask)
+        {
+            GaxPreconditions.CheckNotNull(fieldMask, nameof(fieldMask));
+            return FromHeaderMutation(metadata => metadata.Add(FieldMaskHeader, fieldMask));
+        }
+
+        // TODO: Accept a Google.Protobuf.FieldMask when we're convinced it's useful and we know
+        // exactly what to do with it.
     }
 }

--- a/test/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
@@ -139,5 +139,16 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Equal("name", metadata[0].Key);
             Assert.Equal("value", metadata[0].Value);
         }
+
+        // Note: this test may well need to change, e.g. if we start to use a side channel.
+        [Fact]
+        public void FromFieldMask()
+        {
+            var settings = CallSettings.FromFieldMask("foo");
+            var metadata = new Metadata();
+            settings.HeaderMutation(metadata);
+            Assert.Equal(CallSettings.FieldMaskHeader, metadata[0].Key);
+            Assert.Equal("foo", metadata[0].Value);
+        }
     }
 }


### PR DESCRIPTION
(The user doesn't need to know the right header.)

Fixes #189 (although we may want more later.)