### PR TITLE
Update Platform documentation

### DIFF
--- a/src/Google.Api.Gax/Platform.cs
+++ b/src/Google.Api.Gax/Platform.cs
@@ -495,7 +495,7 @@ namespace Google.Api.Gax
         public static Task<Platform> InstanceAsync() => s_instance.Value;
 
         /// <summary>
-        /// Get execution platform information. This may block for up to one second.
+        /// Get execution platform information. This may block briefly while network operations are in progress.
         /// </summary>
         /// <returns>Execution platform information.</returns>
         public static Platform Instance() => InstanceAsync().Result;


### PR DESCRIPTION
Just noticed we still document that it can take up to a second to detect the platform - it's now up to 2 seconds, but I don't want to be pinned down too much.

(This is in a branch rather than my fork as I did a live edit - will delete the branch afterwards.)