### PR TITLE
Expose a mutable version header builder in ServiceSettingsBase

### DIFF
--- a/src/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
+++ b/src/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
@@ -21,13 +21,12 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         protected ServiceSettingsBase()
         {
-            VersionHeader = new VersionHeaderBuilder()
+            VersionHeaderBuilder = new VersionHeaderBuilder()
                 .AppendDotNetEnvironment()
                 .AppendAssemblyVersion("gccl", GetType())
                 .AppendAssemblyVersion("gapic", GetType())
                 .AppendAssemblyVersion("gax", typeof(CallSettings))
-                .AppendAssemblyVersion("grpc", typeof(Channel))
-                .ToString();
+                .AppendAssemblyVersion("grpc", typeof(Channel));
         }
 
         /// <summary>
@@ -40,10 +39,15 @@ namespace Google.Api.Gax.Grpc
             CallSettings = existing.CallSettings;
             Clock = existing.Clock;
             Scheduler = existing.Scheduler;
-            VersionHeader = existing.VersionHeader;
+            VersionHeaderBuilder = existing.VersionHeaderBuilder.Clone();
         }
 
-        internal string VersionHeader { get; }
+        /// <summary>
+        /// A builder for x-goog-api-client version headers. Additional library versions can be appended via this property.
+        /// </summary>
+        public VersionHeaderBuilder VersionHeaderBuilder { get; }
+
+        internal string VersionHeader => VersionHeaderBuilder.ToString();
 
         /// <summary>
         /// If not null, <see cref="CallSettings"/> that are applied to every RPC performed by the client.

--- a/test/Google.Api.Gax.Grpc.Tests/ServiceSettingsBaseTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/ServiceSettingsBaseTest.cs
@@ -6,7 +6,6 @@
  */
 
 using Moq;
-using System;
 using System.Threading;
 using Xunit;
 
@@ -47,6 +46,10 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Same(callSettings, clonedSettings.CallSettings);
             Assert.Equal(settings.VersionHeader, clonedSettings.VersionHeader);
             Assert.Equal(clock.Object, clonedSettings.Clock);
+
+            // The version header builder really is cloned...
+            clonedSettings.VersionHeaderBuilder.AppendVersion("x", "1.0.0");
+            Assert.NotEqual(settings.VersionHeader, clonedSettings.VersionHeader);
         }
 
         [Fact]

--- a/test/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
+++ b/test/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
@@ -5,6 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
+using System;
 using Xunit;
 
 namespace Google.Api.Gax.Tests
@@ -20,11 +21,11 @@ namespace Google.Api.Gax.Tests
         [Fact]
         public void AppendDotNetEnvironment_AddsDotNetEntry()
         {
-            string VersionHeader = new VersionHeaderBuilder().AppendDotNetEnvironment().ToString();
+            string versionHeader = new VersionHeaderBuilder().AppendDotNetEnvironment().ToString();
 #if NETCOREAPP1_0
-            Assert.StartsWith("gl-dotnet/1.", VersionHeader);
+            Assert.StartsWith("gl-dotnet/1.", versionHeader);
 #else
-            Assert.StartsWith("gl-dotnet/4.", VersionHeader);
+            Assert.StartsWith("gl-dotnet/4.", versionHeader);
 #endif
         }
 
@@ -50,6 +51,46 @@ namespace Google.Api.Gax.Tests
         {
             Assert.StartsWith("foo/1.0.0",
                 new VersionHeaderBuilder().AppendAssemblyVersion("foo", GetType()).ToString());
+        }
+
+        [Fact]
+        public void NamesAreUnique()
+        {
+            var builder = new VersionHeaderBuilder();
+            builder.AppendVersion("name", "1.0.0");
+            Assert.Throws<ArgumentException>(() => builder.AppendVersion("name", "2.0.0"));
+        }
+
+        [Fact]
+        public void Clone()
+        {
+            var builder1 = new VersionHeaderBuilder();
+            builder1.AppendVersion("x", "1.0.0");
+            var builder2 = builder1.Clone();
+            builder1.AppendVersion("y", "2.0.0");
+            builder2.AppendVersion("z", "3.0.0");
+            Assert.Equal("x/1.0.0 y/2.0.0", builder1.ToString());
+            Assert.Equal("x/1.0.0 z/3.0.0", builder2.ToString());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("x y")]
+        [InlineData("x/y")]
+        public void InvalidName(string name)
+        {
+            var builder = new VersionHeaderBuilder();
+            Assert.Throws<ArgumentException>(() => builder.AppendVersion(name, "1.0.0"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("x y")]
+        [InlineData("x/y")]
+        public void InvalidVersion(string version)
+        {
+            var builder = new VersionHeaderBuilder();
+            Assert.Throws<ArgumentException>(() => builder.AppendVersion("name", version));
         }
     }
 }


### PR DESCRIPTION
This allows clients to add their own library versions.

Additionally, VersionHeaderBuilder now ensures that names are unique,
and that neither names nor versions include " " or "/", both of
which are used as separators.