### PR TITLE
Make response metadata accessible via a callback.

### DIFF
--- a/src/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
+++ b/src/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
@@ -97,6 +97,24 @@ namespace Google.Api.Gax.Grpc
             settings.MergedWith(CallSettings.FromHeader(name, value));
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public static CallSettings WithResponseMetadataHandler(this CallSettings settings, Action<Metadata> handler) =>
+            settings.MergedWith(CallSettings.FromResponseMetadataHandler(handler));
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="handler"></param>
+        /// <returns></returns>
+        public static CallSettings WithTrailingMetadataHandler(this CallSettings settings, Action<Metadata> handler) =>
+            settings.MergedWith(CallSettings.FromTrailingMetadataHandler(handler));
+
+        /// <summary>
         /// Returns a <see cref="CallSettings"/> which will have an effective deadline of at least <paramref name="deadline"/>.
         /// If <paramref name="settings"/> already observes an earlier deadline (with respect to <paramref name="clock"/>),
         /// or if <paramref name="deadline"/> is null, the original settings will be returned.

--- a/test/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
@@ -337,5 +337,53 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Same(backoffSettings, result.Timing.Retry.TimeoutBackoff);
             Assert.Equal(token, result.CancellationToken);
         }
+
+        [Fact]
+        public void WithResponseMetadataHandler_OnlyHandler()
+        {
+            Metadata setByHandler = null;
+            var settings = ((CallSettings) null).WithResponseMetadataHandler(m => setByHandler = m);
+            var metadata = new Metadata();
+            settings.ResponseMetadataHandler(metadata);
+            Assert.Same(metadata, setByHandler);
+        }
+
+        [Fact]
+        public void WithTrailingMetadataHandler_OnlyHandler()
+        {
+            Metadata setByHandler = null;
+            var settings = ((CallSettings) null).WithTrailingMetadataHandler(m => setByHandler = m);
+            var metadata = new Metadata();
+            settings.TrailingMetadataHandler(metadata);
+            Assert.Same(metadata, setByHandler);
+        }
+
+        [Fact]
+        public void WithResponseMetadataHandler_MultipleHandlers()
+        {
+            Metadata setByHandler1 = null;
+            Metadata setByHandler2 = null;
+            var settings = ((CallSettings) null)
+                .WithResponseMetadataHandler(m => setByHandler1 = m)
+                .WithResponseMetadataHandler(m => setByHandler2 = m);
+            var metadata = new Metadata();
+            settings.ResponseMetadataHandler(metadata);
+            Assert.Same(metadata, setByHandler1);
+            Assert.Same(metadata, setByHandler2);
+        }
+
+        [Fact]
+        public void WithTrailingMetadataHandler_MultipleHandlers()
+        {
+            Metadata setByHandler1 = null;
+            Metadata setByHandler2 = null;
+            var settings = ((CallSettings) null)
+                .WithTrailingMetadataHandler(m => setByHandler1 = m)
+                .WithTrailingMetadataHandler(m => setByHandler2 = m);
+            var metadata = new Metadata();
+            settings.TrailingMetadataHandler(metadata);
+            Assert.Same(metadata, setByHandler1);
+            Assert.Same(metadata, setByHandler2);
+        }
     }
 }

--- a/test/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
@@ -159,5 +159,43 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Equal(CallSettings.FieldMaskHeader, metadata[0].Key);
             Assert.Equal("foo", metadata[0].Value);
         }
+
+        [Fact]
+        public void FromResponseMetadataHandler()
+        {
+            Action<Metadata> handler = metadata => { };
+            var settings = CallSettings.FromResponseMetadataHandler(handler);
+            Assert.Same(handler, settings.ResponseMetadataHandler);
+        }
+
+        [Fact]
+        public void FromTrailingMetadataHandler()
+        {
+            Action<Metadata> handler = metadata => { };
+            var settings = CallSettings.FromTrailingMetadataHandler(handler);
+            Assert.Same(handler, settings.TrailingMetadataHandler);
+        }
+
+        [Fact]
+        public void MergeResponseMetadataHandlers()
+        {
+            Action<Metadata> handler1 = metadata => { };
+            Action<Metadata> handler2 = metadata => { };
+            var settings = CallSettings.Merge(
+                CallSettings.FromResponseMetadataHandler(handler1),
+                CallSettings.FromResponseMetadataHandler(handler2));
+            Assert.Equal(handler1 + handler2, settings.ResponseMetadataHandler);
+        }
+
+        [Fact]
+        public void MergeTrailingMetadataHandlers()
+        {
+            Action<Metadata> handler1 = metadata => { };
+            Action<Metadata> handler2 = metadata => { };
+            var settings = CallSettings.Merge(
+                CallSettings.FromTrailingMetadataHandler(handler1),
+                CallSettings.FromTrailingMetadataHandler(handler2));
+            Assert.Equal(handler1 + handler2, settings.TrailingMetadataHandler);
+        }
     }
 }


### PR DESCRIPTION
First commit is from #214 - skip that. I won't merge this PR as-is, but I'd like feedback on the second commit.