### PR TITLE
Propagate handlers in CallSettings extension methods

### DIFF
--- a/src/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
+++ b/src/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
@@ -62,7 +62,8 @@ namespace Google.Api.Gax.Grpc
                 ? CallSettings.FromCallCredentials(credentials)
                 : new CallSettings(settings.CancellationToken, credentials,
                     settings.Timing, settings.HeaderMutation,
-                    settings.WriteOptions, settings.PropagationToken);
+                    settings.WriteOptions, settings.PropagationToken,
+                    settings.ResponseMetadataHandler, settings.TrailingMetadataHandler);
 
         /// <summary>
         /// Returns a new <see cref="CallSettings"/> with the specified call timing,
@@ -82,7 +83,8 @@ namespace Google.Api.Gax.Grpc
                 ? CallSettings.FromCallTiming(timing)
                 : new CallSettings(settings.CancellationToken, settings.Credentials,
                     timing, settings.HeaderMutation,
-                    settings.WriteOptions, settings.PropagationToken);
+                    settings.WriteOptions, settings.PropagationToken,
+                    settings.ResponseMetadataHandler, settings.TrailingMetadataHandler);
 
         /// <summary>
         /// Returns a new <see cref="CallSettings"/> with the specified header,


### PR DESCRIPTION
I've validated manually that these are the last calls which misuse
the shorter constructor. Thoughts about how to avoid similar
problems in the future would be welcome.