### PR TITLE
Make ServiceSettingsBase.VersionHeaderBuilder internal for now

### DIFF
--- a/src/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
+++ b/src/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
@@ -45,7 +45,7 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// A builder for x-goog-api-client version headers. Additional library versions can be appended via this property.
         /// </summary>
-        public VersionHeaderBuilder VersionHeaderBuilder { get; }
+        internal VersionHeaderBuilder VersionHeaderBuilder { get; }
 
         internal string VersionHeader => VersionHeaderBuilder.ToString();
 


### PR DESCRIPTION
There's ongoing discussion about how widely x-goog-api-client should
be used. We can make it public later when this has been decided.