### PR TITLE
Add common resource names

### DIFF
--- a/src/Google.Api.Gax/ResourceNames/BillingAccountName.cs
+++ b/src/Google.Api.Gax/ResourceNames/BillingAccountName.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * Copyright 2018 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax.ResourceNames
+{
+    /// <summary>
+    /// Resource name for the 'billing account' resource which is widespread across Google Cloud Platform.
+    /// While most resource names are generated on a per-API basis, many APIs use a billing account resource, and it's
+    /// useful to be able to pass values from one API to another.
+    /// </summary>
+    public sealed partial class BillingAccountName : IResourceName, IEquatable<BillingAccountName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("billingAccounts/{billing_account}");
+
+        /// <summary>
+        /// Parses the given billing account resource name in string form into a new
+        /// <see cref="BillingAccountName"/> instance.
+        /// </summary>
+        /// <param name="BillingAccountName">The billing account resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="BillingAccountName"/> if successful.</returns>
+        public static BillingAccountName Parse(string BillingAccountName)
+        {
+            GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
+            TemplatedResourceName resourceName = s_template.ParseName(BillingAccountName);
+            return new BillingAccountName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given billing account resource name in string form into a new
+        /// <see cref="BillingAccountName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="BillingAccountName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="BillingAccountName">The billing account resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="BillingAccountName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string BillingAccountName, out BillingAccountName result)
+        {
+            GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(BillingAccountName, out resourceName))
+            {
+                result = new BillingAccountName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="BillingAccountName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
+        public BillingAccountName(string billingAccountId)
+        {
+            BillingAccountId = GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+        }
+
+        /// <summary>
+        /// The billingAccount ID. Never <c>null</c>.
+        /// </summary>
+        public string BillingAccountId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(BillingAccountId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as BillingAccountName);
+
+        /// <inheritdoc />
+        public bool Equals(BillingAccountName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(BillingAccountName a, BillingAccountName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(BillingAccountName a, BillingAccountName b) => !(a == b);
+    }
+}

--- a/src/Google.Api.Gax/ResourceNames/FolderName.cs
+++ b/src/Google.Api.Gax/ResourceNames/FolderName.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * Copyright 2018 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax.ResourceNames
+{
+    /// <summary>
+    /// Resource name for the 'folder' resource which is widespread across Google Cloud Platform.
+    /// While most resource names are generated on a per-API basis, many APIs use a folder resource, and it's
+    /// useful to be able to pass values from one API to another.
+    /// </summary>
+    public sealed partial class FolderName : IResourceName, IEquatable<FolderName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("folders/{folder}");
+
+        /// <summary>
+        /// Parses the given folder resource name in string form into a new
+        /// <see cref="FolderName"/> instance.
+        /// </summary>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="FolderName"/> if successful.</returns>
+        public static FolderName Parse(string folderName)
+        {
+            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            TemplatedResourceName resourceName = s_template.ParseName(folderName);
+            return new FolderName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given folder resource name in string form into a new
+        /// <see cref="FolderName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="folderName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="FolderName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string folderName, out FolderName result)
+        {
+            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(folderName, out resourceName))
+            {
+                result = new FolderName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="FolderName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
+        public FolderName(string folderId)
+        {
+            FolderId = GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+        }
+
+        /// <summary>
+        /// The folder ID. Never <c>null</c>.
+        /// </summary>
+        public string FolderId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(FolderId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as FolderName);
+
+        /// <inheritdoc />
+        public bool Equals(FolderName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(FolderName a, FolderName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(FolderName a, FolderName b) => !(a == b);
+    }
+}

--- a/src/Google.Api.Gax/ResourceNames/OrganizationName.cs
+++ b/src/Google.Api.Gax/ResourceNames/OrganizationName.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * Copyright 2018 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax.ResourceNames
+{
+    /// <summary>
+    /// Resource name for the 'organization' resource which is widespread across Google Cloud Platform.
+    /// While most resource names are generated on a per-API basis, many APIs use an organization resource, and it's
+    /// useful to be able to pass values from one API to another.
+    /// </summary>
+    public sealed partial class OrganizationName : IResourceName, IEquatable<OrganizationName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("organizations/{organization}");
+
+        /// <summary>
+        /// Parses the given organization resource name in string form into a new
+        /// <see cref="OrganizationName"/> instance.
+        /// </summary>
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="OrganizationName"/> if successful.</returns>
+        public static OrganizationName Parse(string organizationName)
+        {
+            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            TemplatedResourceName resourceName = s_template.ParseName(organizationName);
+            return new OrganizationName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given organization resource name in string form into a new
+        /// <see cref="OrganizationName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="s::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="OrganizationName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string organizationName, out OrganizationName result)
+        {
+            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(organizationName, out resourceName))
+            {
+                result = new OrganizationName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="OrganizationName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
+        public OrganizationName(string organizationId)
+        {
+            OrganizationId = GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+        }
+
+        /// <summary>
+        /// The organization ID. Never <c>null</c>.
+        /// </summary>
+        public string OrganizationId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(OrganizationId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as OrganizationName);
+
+        /// <inheritdoc />
+        public bool Equals(OrganizationName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(OrganizationName a, OrganizationName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(OrganizationName a, OrganizationName b) => !(a == b);
+    }
+}

--- a/src/Google.Api.Gax/ResourceNames/ProjectName.cs
+++ b/src/Google.Api.Gax/ResourceNames/ProjectName.cs
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax.ResourceNames
+{
+    /// <summary>
+    /// Resource name for the 'project' resource which is widespread across Google Cloud Platform.
+    /// While most resource names are generated on a per-API basis, many APIs use a project resource, and it's
+    /// useful to be able to pass values from one API to another.
+    /// </summary>
+    public sealed partial class ProjectName : IResourceName, IEquatable<ProjectName>
+    {
+        private static readonly PathTemplate s_template = new PathTemplate("projects/{project}");
+
+        /// <summary>
+        /// Parses the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
+        public static ProjectName Parse(string projectName)
+        {
+            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            TemplatedResourceName resourceName = s_template.ParseName(projectName);
+            return new ProjectName(resourceName[0]);
+        }
+
+        /// <summary>
+        /// Tries to parse the given project resource name in string form into a new
+        /// <see cref="ProjectName"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// as this would usually indicate a programming error rather than a data error.
+        /// </remarks>
+        /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="result">When this method returns, the parsed <see cref="ProjectName"/>,
+        /// or <c>null</c> if parsing fails.</param>
+        /// <returns><c>true</c> if the name was parsed succssfully; <c>false</c> otherwise.</returns>
+        public static bool TryParse(string projectName, out ProjectName result)
+        {
+            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            TemplatedResourceName resourceName;
+            if (s_template.TryParseName(projectName, out resourceName))
+            {
+                result = new ProjectName(resourceName[0]);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
+        /// from its component parts.
+        /// </summary>
+        /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
+        public ProjectName(string projectId)
+        {
+            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+        }
+
+        /// <summary>
+        /// The project ID. Never <c>null</c>.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <inheritdoc />
+        public ResourceNameKind Kind => ResourceNameKind.Simple;
+
+        /// <inheritdoc />
+        public override string ToString() => s_template.Expand(ProjectId);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => ToString().GetHashCode();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as ProjectName);
+
+        /// <inheritdoc />
+        public bool Equals(ProjectName other) => ToString() == other?.ToString();
+
+        /// <inheritdoc />
+        public static bool operator ==(ProjectName a, ProjectName b) => ReferenceEquals(a, b) || (a?.Equals(b) ?? false);
+
+        /// <inheritdoc />
+        public static bool operator !=(ProjectName a, ProjectName b) => !(a == b);
+    }
+}


### PR DESCRIPTION
These are resource names used in multiple Google Cloud APIs. Having
a single type for each resource name makes it simpler to write use
the output of one API as the input to another.

These classes are the existing generated ones, with a modified comment (and namespace aliasing removed).