### PR TITLE
Add Date Extensions

### DIFF
--- a/Gax.sln
+++ b/Gax.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.Grpc.Testing
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.PlatformIntegrationTests", "test\Google.Api.Gax.PlatformIntegrationTests\Google.Api.Gax.PlatformIntegrationTests.csproj", "{7BFC4F8F-86F2-420C-9A44-2A90A44774F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Api.CommonProtos.Tests", "test\Google.Api.CommonProtos.Tests\Google.Api.CommonProtos.Tests.csproj", "{7839A366-B685-475E-AB76-E2DC8A7D8C44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,8 +77,15 @@ Global
 		{7BFC4F8F-86F2-420C-9A44-2A90A44774F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BFC4F8F-86F2-420C-9A44-2A90A44774F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BFC4F8F-86F2-420C-9A44-2A90A44774F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EBC5AB6A-DE79-42BA-9D86-43789F17A749}
 	EndGlobalSection
 EndGlobal

--- a/src/Google.Api.CommonProtos/TypeExtensions/Date.cs
+++ b/src/Google.Api.CommonProtos/TypeExtensions/Date.cs
@@ -1,0 +1,96 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Type
+{
+    public partial class Date
+    {
+        /// <summary>
+        /// Converts <see cref="Date"/> to <see cref="DateTime"/>.
+        /// </summary>
+        /// <returns>The converted <see cref="DateTime"/> with time at midnight and <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Unspecified"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="Year"/>, <see cref="Month"/>, and/or <see cref="Day"/> are not within the valid range.</exception>
+        public DateTime ToDateTime()
+        {
+            try
+            {
+                return new DateTime(Year, Month, Day);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new InvalidOperationException($"Cannot convert to {nameof(DateTime)} because {nameof(Year)}, {nameof(Month)}, and/or {nameof(Day)} must be within the valid range for a {nameof(DateTime)}.");
+            }
+        }
+
+        /// <summary>
+        /// Converts <see cref="Date"/> to <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <returns>The converted <see cref="DateTimeOffset"/> with time at midnight, <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Unspecified"/>, and an <see cref="DateTimeOffset.Offset"/> of <see cref="TimeSpan.Zero"/>.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="Year"/>, <see cref="Month"/>, and/or <see cref="Day"/> are not within the valid range.</exception>        
+        public DateTimeOffset ToDateTimeOffset()
+        {
+            try
+            {
+                return new DateTimeOffset(Year, Month, Day, 0, 0, 0, TimeSpan.Zero);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new InvalidOperationException($"Cannot convert to {nameof(DateTimeOffset)} because {nameof(Year)}, {nameof(Month)}, and/or {nameof(Day)} must be within the valid range for a {nameof(DateTimeOffset)}.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Date"/> instance from the <see cref="DateTime.Date"/> part of <see cref="DateTime"/>.
+        /// </summary>     
+        /// <param name="dateTimeToConvert">The <see cref="DateTime"/> instance being converted.</param>
+        /// <returns>The created <see cref="Date"/>.</returns>
+        public static Date FromDateTime(DateTime dateTimeToConvert) =>
+            new Date
+            {
+                Year = dateTimeToConvert.Year,
+                Month = dateTimeToConvert.Month,
+                Day = dateTimeToConvert.Day
+            };
+
+        /// <summary>
+        /// Creates a <see cref="Date"/> instance from the <see cref="DateTimeOffset.Date"/> part of <see cref="DateTimeOffset"/>.
+        /// </summary>  
+        /// <param name="dateTimeOffsetToConvert">The <see cref="DateTimeOffset"/> instance being converted.</param>
+        /// <returns>The created <see cref="Date"/>.</returns>
+        public static Date FromDateTimeOffset(DateTimeOffset dateTimeOffsetToConvert) =>
+            new Date
+            {
+                Year = dateTimeOffsetToConvert.Year,
+                Month = dateTimeOffsetToConvert.Month,
+                Day = dateTimeOffsetToConvert.Day
+            };
+    }
+
+    /// <summary>
+    /// Extension methods built for <see cref="Date"/>.
+    /// </summary>
+    public static class DateExtensions
+    {
+        /// <summary>
+        /// Converts the <see cref="DateTime.Date"/> part of <see cref="DateTime"/> to <see cref="Date"/>.
+        /// </summary>
+        /// <param name="dateTimeToConvert">The <see cref="DateTime"/> instance being converted.</param>
+        /// <returns>The <see cref="Date"/>.</returns>
+        public static Date ToDate(this DateTime dateTimeToConvert) =>
+            Date.FromDateTime(dateTimeToConvert);
+
+        /// <summary>
+        /// Converts the <see cref="DateTimeOffset.Date"/> part of <see cref="DateTimeOffset"/> to <see cref="Date"/>.
+        /// </summary>
+        /// <param name="dateTimeOffsetToConvert">The <see cref="DateTimeOffset"/> instance being converted.</param>
+        /// <returns>The converted <see cref="Date"/>.</returns>
+        public static Date ToDate(this DateTimeOffset dateTimeOffsetToConvert) =>
+            Date.FromDateTimeOffset(dateTimeOffsetToConvert);
+    }
+}

--- a/test/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
+++ b/test/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\CommonProjectProperties.xml" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Google.Api.CommonProtos\Google.Api.CommonProtos.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\StripDesktopOnNonWindows.xml" />
+
+</Project>

--- a/test/Google.Api.CommonProtos.Tests/TypeExtensions/DateTests.cs
+++ b/test/Google.Api.CommonProtos.Tests/TypeExtensions/DateTests.cs
@@ -1,0 +1,148 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Type;
+using System;
+using Xunit;
+
+namespace Google.Api.CommonProtos.Tests.TypeExtensions
+{
+    public class DateTests
+    {
+        public class InvalidDateTheoryData : TheoryData<int, int, int>
+        {
+            public InvalidDateTheoryData()
+            {
+                // In the order of Year, Month, Day.
+                Add(-1, -1, -1);
+                Add(0, 0, 0);
+                Add(0, 4, 28);
+                Add(2018, 0, 28);
+                Add(2018, 4, 0);
+                Add(10000, 4, 28);
+                Add(2018, 13, 28);
+                Add(2018, 4, 32);
+            }
+        }
+
+        public class ValidDateTheoryData : TheoryData<int, int, int>
+        {
+            public ValidDateTheoryData()
+            {
+                // In the order of Year, Month, Day.
+                Add(0001, 1, 1);
+                Add(2000, 2, 29);
+                Add(2018, 4, 28);
+                Add(9999, 12, 31);
+            }
+        }
+
+        [Fact]
+        public void ToDateTimeThrowsInvalidOperationExceptionWhenDateIsNotInitialized()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new Date().ToDateTime());
+        }
+
+        [Theory, ClassData(typeof(InvalidDateTheoryData))]
+        public void ToDateTimeThrowsInvalidOperationExceptionWhenDateIsInvalidState(int year, int month, int day)
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new Date
+                {
+                    Year = year,
+                    Month = month,
+                    Day = day
+                }.ToDateTime());
+        }
+
+        [Fact]
+        public void ToDateTimeOffsetThrowsInvalidOperationExceptionWhenDateIsNotInitialized()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new Date().ToDateTimeOffset());
+        }
+
+        [Theory, ClassData(typeof(InvalidDateTheoryData))]
+        public void ToDateTimeOffsetThrowsInvalidOperationExceptionWhenDateIsInvalidState(int year, int month, int day)
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new Date
+                {
+                    Year = year,
+                    Month = month,
+                    Day = day
+                }.ToDateTimeOffset());
+        }
+
+        [Theory, ClassData(typeof(ValidDateTheoryData))]
+        public void IsConvertedToDateTime(int year, int month, int day)
+        {
+            var subjectUnderTest = new Date
+            {
+                Year = year,
+                Month = month,
+                Day = day
+            };
+            var actualDateTime = subjectUnderTest.ToDateTime();
+            Assert.Equal(year, actualDateTime.Year);
+            Assert.Equal(month, actualDateTime.Month);
+            Assert.Equal(day, actualDateTime.Day);
+            Assert.Equal(0, actualDateTime.Hour);
+            Assert.Equal(0, actualDateTime.Minute);
+            Assert.Equal(0, actualDateTime.Second);
+            Assert.Equal(0, actualDateTime.Millisecond);
+            Assert.Equal(DateTimeKind.Unspecified, actualDateTime.Kind);
+        }
+
+        [Theory, ClassData(typeof(ValidDateTheoryData))]
+        public void IsConvertedToDateTimeOffset(int year, int month, int day)
+        {
+            var subjectUnderTest = new Date
+            {
+                Year = year,
+                Month = month,
+                Day = day
+            };
+            var actualDateTimeOffset = subjectUnderTest.ToDateTimeOffset();
+            Assert.Equal(year, actualDateTimeOffset.Year);
+            Assert.Equal(month, actualDateTimeOffset.Month);
+            Assert.Equal(day, actualDateTimeOffset.Day);
+            Assert.Equal(0, actualDateTimeOffset.Hour);
+            Assert.Equal(0, actualDateTimeOffset.Minute);
+            Assert.Equal(0, actualDateTimeOffset.Second);
+            Assert.Equal(0, actualDateTimeOffset.Millisecond);
+            Assert.Equal(TimeSpan.Zero, actualDateTimeOffset.TimeOfDay);
+            Assert.Equal(TimeSpan.Zero, actualDateTimeOffset.Offset);
+            Assert.Equal(DateTimeKind.Unspecified, actualDateTimeOffset.DateTime.Kind);
+        }
+
+        [Theory, ClassData(typeof(ValidDateTheoryData))]
+        public void IsConvertedToDateFromDateTime(int year, int month, int day)
+        {
+            var subjectUnderTest = new DateTime(year, month, day);
+            var actualDate = subjectUnderTest.ToDate();
+            Assert.Equal(year, actualDate.Year);
+            Assert.Equal(month, actualDate.Month);
+            Assert.Equal(day, actualDate.Day);
+        }
+
+        [Theory, ClassData(typeof(ValidDateTheoryData))]
+        public void IsConvertedToDateFromDateTimeOffset(int year, int month, int day)
+        {
+            var someHours = 2;
+            var someMinutes = 59;
+            var someSeconds = 30;
+            var someTimeSpan = TimeSpan.Zero;
+            var subjectUnderTest = new DateTimeOffset(year, month, day, someHours, someMinutes, someSeconds, someTimeSpan);
+            var actualDate = subjectUnderTest.ToDate();
+            Assert.Equal(year, actualDate.Year);
+            Assert.Equal(month, actualDate.Month);
+            Assert.Equal(day, actualDate.Day);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces extensions for `Google.Type.Date`, which is part of [our](https://www.namely.com/) proposal in https://github.com/googleapis/gax-dotnet/issues/250. We are starting off with Date extensions to use as a foundation and baseline for our further PR(s) coming. While we tried to be as consistent with the existing code base we definitely appreciate feedback and guidance.

**File Structure:**
```
+-- src/Google.Api.CommonProtos
|   +-- Type
|      +-- Date.cs
|   +-- TypeExtensions
|      +-- Date.cs (new)
+-- test/Google.Api.CommonProtos.Tests (new)
|   +-- TypeExtensions
|      +-- DateTests.cs
```

**src/Google.Api.CommonProtos/TypeExtensions/Date.cs:**

Added partial class: `Date.cs` extending `Google.Type.Date` with the following methods:

- `ToDateTime()` 
- `ToDateTimeOffset()` 
- `CreateDate(Datetime)` (static factory method built into Date)
- `CreateDate(DateTimeOffset)` (static factory method built into Date) 

Added `DateExtensions` class:

- `ToDate()` calls `CreateDate(Datetime)` under the hood
- `ToDate()` calls `CreateDate(DateTimeOffset)` under the hood
