### PR TITLE
Make BackoffSettings.NextDelay public and apply a minimum value

### DIFF
--- a/src/Google.Api.Gax.Grpc/BackoffSettings.cs
+++ b/src/Google.Api.Gax.Grpc/BackoffSettings.cs
@@ -64,12 +64,17 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// Works out the next delay from the current one, based on the multiplier and maximum.
         /// </summary>
-        internal TimeSpan NextDelay(TimeSpan currentDelay)
+        /// <param name="currentDelay">The current delay to use as a basis for the next one.</param>
+        /// <returns>The next delay to use, which is always at least <see cref="Delay"/> and at most <see cref="MaxDelay"/>.</returns>
+        public TimeSpan NextDelay(TimeSpan currentDelay)
         {
             checked
             {
                 TimeSpan next = new TimeSpan((long) (currentDelay.Ticks * DelayMultiplier));
-                return next < MaxDelay ? next : MaxDelay;
+                return
+                    next < Delay ? Delay :        // Lower bound capping
+                    next > MaxDelay ? MaxDelay :  // Upper bound capping
+                    next;
             }
         }
     }

--- a/test/Google.Api.Gax.Grpc.Tests/BackoffSettingsTest.cs
+++ b/test/Google.Api.Gax.Grpc.Tests/BackoffSettingsTest.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class BackoffSettingsTest
+    {
+        [Theory]
+        [InlineData(0.0, 1.0)]
+        [InlineData(0.75, 1.5)]
+        [InlineData(1.0, 2.0)]
+        [InlineData(2.0, 4.0)]
+        [InlineData(4.0, 5.0)]
+        public void NextDelay(double current, double expectedNext)
+        {
+            var settings = new BackoffSettings(
+                delay: TimeSpan.FromSeconds(1.0),
+                maxDelay: TimeSpan.FromSeconds(5.0),
+                delayMultiplier: 2.0);
+
+            var expected = TimeSpan.FromSeconds(expectedNext);
+            var actual = settings.NextDelay(TimeSpan.FromSeconds(current));
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
This will reduce duplication in google-cloud-dotnet.

cc @evildour