### PR TITLE
Xamarin.Android: add support

### DIFF
--- a/src/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/src/Google.Api.Gax/Google.Api.Gax.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <Title>Google API Extensions</Title>
     <Description>Support classes for Google API client libraries</Description>
+    <Version>2.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR allows the nuget package Google.Cloud.Speech.V1 to be used on the Xamarin.Android platform.

It relates to PR https://github.com/grpc/grpc/pull/15969