### PR TITLE
Fix the default for unknown versions to "0.0.0"

### DIFF
--- a/src/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/src/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -83,7 +83,7 @@ namespace Google.Api.Gax
         private static string FormatVersion(Version version) =>
             version != null ?
             $"{version.Major}.{version.Minor}.{(version.Build != -1 ? version.Build : 0)}" :
-            ""; // Empty string means "unknown"
+            "0.0.0"; // Reasonable semantic version for "unknown"
 
         /// <inheritdoc />
         public override string ToString() => string.Join(" ", _names.Zip(_values, (name, value) => $"{name}/{value}"));


### PR DESCRIPTION
Previously when creating a version header for a type/framework that
didn't have a version, we'd default to a value of ""... which would
then be rejected by AppendVersion. 0.0.0 is a reasonable semantic
version for "unknown".

This is an alternative to #260.