### PR TITLE
Permit empty string values for version headers

### DIFF
--- a/src/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/src/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -30,14 +30,14 @@ namespace Google.Api.Gax
         /// Appends the given name/version string to the list.
         /// </summary>
         /// <param name="name">The name. Must not be null or empty, or contain a space or a slash.</param>
-        /// <param name="version">The version. Must not be null or empty, or contain a space or a slash.</param>
+        /// <param name="version">The version. Must not be null, or contain a space or a slash.</param>
         public VersionHeaderBuilder AppendVersion(string name, string version)
         {
             GaxPreconditions.CheckNotNull(name, nameof(name));
             GaxPreconditions.CheckNotNull(version, nameof(version));
-            // Deliberate duplication as we may want to have different constraints.
+            // Names can't be empty, but versions can. (We use the empty string to indicate an unknown version.)
             GaxPreconditions.CheckArgument(name.Length > 0 && !name.Contains(' ') && !name.Contains('/'), nameof(name), $"Invalid name: {name}");
-            GaxPreconditions.CheckArgument(version.Length > 0 && !version.Contains(' ') && !version.Contains('/'), nameof(version), $"Invalid version: {version}");
+            GaxPreconditions.CheckArgument(!version.Contains(' ') && !version.Contains('/'), nameof(version), $"Invalid version: {version}");
             GaxPreconditions.CheckArgument(!_names.Contains(name), nameof(name), "Names in version headers must be unique");
             _names.Add(name);
             _values.Add(version);

--- a/test/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
+++ b/test/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
@@ -29,11 +29,15 @@ namespace Google.Api.Gax.Tests
 #endif
         }
 
-        [Fact]
-        public void AppendVersion()
+        [Theory]
+        [InlineData("foo", "1.2.3-bar", "foo/1.2.3-bar")]
+        [InlineData("foo", "", "foo/")]
+        public void AppendVersion(string name, string version, string expected)
         {
-            Assert.Equal("foo/1.2.3-bar",
-                new VersionHeaderBuilder().AppendVersion("foo", "1.2.3-bar").ToString());
+            var builder = new VersionHeaderBuilder();
+            builder.AppendVersion(name, version);
+            var actual = builder.ToString();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -84,7 +88,6 @@ namespace Google.Api.Gax.Tests
         }
 
         [Theory]
-        [InlineData("")]
         [InlineData("x y")]
         [InlineData("x/y")]
         public void InvalidVersion(string version)


### PR DESCRIPTION
This is the intention expressed already when FormatVersion(null) is
called, but we were overly strict in validation.

This is an alternative to #260.