### PR TITLE
Introduce Google.Api.Gax.Grpc.Gcp package

### DIFF
--- a/Gax.sln
+++ b/Gax.sln
@@ -25,7 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.Grpc.Testing
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.PlatformIntegrationTests", "test\Google.Api.Gax.PlatformIntegrationTests\Google.Api.Gax.PlatformIntegrationTests.csproj", "{7BFC4F8F-86F2-420C-9A44-2A90A44774F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Api.CommonProtos.Tests", "test\Google.Api.CommonProtos.Tests\Google.Api.CommonProtos.Tests.csproj", "{7839A366-B685-475E-AB76-E2DC8A7D8C44}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.CommonProtos.Tests", "test\Google.Api.CommonProtos.Tests\Google.Api.CommonProtos.Tests.csproj", "{7839A366-B685-475E-AB76-E2DC8A7D8C44}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.Grpc.Gcp", "src\Google.Api.Gax.Grpc.Gcp\Google.Api.Gax.Grpc.Gcp.csproj", "{966C1852-164C-4162-B727-04782706D787}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Google.Api.Gax.Grpc.Gcp.IntegrationTests", "test\Google.Api.Gax.Grpc.Gcp.IntegrationTests\Google.Api.Gax.Grpc.Gcp.IntegrationTests.csproj", "{E4272960-930B-451C-975D-AE70C1FC463D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +85,14 @@ Global
 		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7839A366-B685-475E-AB76-E2DC8A7D8C44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{966C1852-164C-4162-B727-04782706D787}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{966C1852-164C-4162-B727-04782706D787}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{966C1852-164C-4162-B727-04782706D787}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{966C1852-164C-4162-B727-04782706D787}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4272960-930B-451C-975D-AE70C1FC463D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4272960-930B-451C-975D-AE70C1FC463D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4272960-930B-451C-975D-AE70C1FC463D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4272960-930B-451C-975D-AE70C1FC463D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Google.Api.Gax.Grpc.Gcp/DefaultChannelCredentialsCache.cs
+++ b/src/Google.Api.Gax.Grpc.Gcp/DefaultChannelCredentialsCache.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Apis.Auth.OAuth2;
+using Grpc.Auth;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc.Gcp
+{
+    // TODO: Move this into Google.Api.Gax.Grpc and make it public? We could then avoid the duplication
+    // between this and code in Google.Api.Gax.Grpc.ChannelPool.
+
+    /// <summary>
+    /// Caches the application default channel credentials, applying a specified set of scopes if they require any.
+    /// </summary>
+    internal sealed class DefaultChannelCredentialsCache
+    {
+        private readonly IEnumerable<string> _scopes;
+
+        /// <summary>
+        /// Lazily-created task to retrieve the default application channel credentials. Once completed, this
+        /// task can be used whenever channel credentials are required. The returned task always runs in the
+        /// thread pool, so its result can be used synchronously from synchronous methods without risk of deadlock.
+        /// The same channel credentials are used by all pools. The field is initialized in the constructor, as it uses
+        /// _scopes, and you can't refer to an instance field within an instance field initializer.
+        /// </summary>
+        private readonly Lazy<Task<ChannelCredentials>> _lazyScopedDefaultChannelCredentials;
+
+        /// <summary>
+        /// Creates a cache which will apply the specified scopes to the default application credentials
+        /// if they require any.
+        /// </summary>
+        /// <param name="scopes">The scopes to apply. Must not be null, and must not contain null references. May be empty.</param>
+        internal DefaultChannelCredentialsCache(IEnumerable<string> scopes)
+        {
+            // Always take a copy of the provided scopes, then check the copy doesn't contain any nulls.
+            _scopes = GaxPreconditions.CheckNotNull(scopes, nameof(scopes)).ToList();
+            GaxPreconditions.CheckArgument(!_scopes.Any(x => x == null), nameof(scopes), "Scopes must not contain any null references");
+            // In theory, we don't actually need to store the scopes as field in this class. We could capture a local variable here.
+            // However, it won't be any more efficient, and having the scopes easily available when debugging could be handy.
+            _lazyScopedDefaultChannelCredentials =
+                new Lazy<Task<ChannelCredentials>>(() => Task.Run(async () =>
+                {
+                    var appDefaultCredentials = await GoogleCredential.GetApplicationDefaultAsync().ConfigureAwait(false);
+                    if (appDefaultCredentials.IsCreateScopedRequired)
+                    {
+                        appDefaultCredentials = appDefaultCredentials.CreateScoped(_scopes);
+                    }
+                    return appDefaultCredentials.ToChannelCredentials();
+                }));
+        }
+
+        internal ChannelCredentials GetCredentials() =>
+            GetCredentialsAsync().ResultWithUnwrappedExceptions();
+
+        internal Task<ChannelCredentials> GetCredentialsAsync() =>
+            _lazyScopedDefaultChannelCredentials.Value;
+    }
+}

--- a/src/Google.Api.Gax.Grpc.Gcp/EqualityHelpers.cs
+++ b/src/Google.Api.Gax.Grpc.Gcp/EqualityHelpers.cs
@@ -1,0 +1,125 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Api.Gax.Grpc.Gcp
+{
+    // TODO: These are copied from Firestore utilities. If we make them public, they can be reused there.
+    //       Just make sure we have everything Firestore needs here if we do decide to do that.
+    internal static class EqualityHelpers
+    {
+        private const int HashInitialValue = 3581;
+
+        /// <summary>
+        /// Checks if two lists are equal, in an ordering-sensitive manner.
+        /// </summary>
+        internal static bool ListsEqual<T>(IReadOnlyList<T> left, IReadOnlyList<T> right)
+            where T : IEquatable<T>
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+            {
+                return false;
+            }
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+            for (int i = 0; i < left.Count; i++)
+            {
+                if (!left[i].Equals(right[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Computes an ordering-sensitive hash code for a list.
+        /// </summary>
+        internal static int GetListHashCode<T>(IReadOnlyList<T> list, IEqualityComparer<T> comparer)
+        {
+            if (list == null)
+            {
+                return 0;
+            }
+            unchecked
+            {
+                int hash = HashInitialValue;
+                int count = list.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    hash = (hash << 5) + hash + comparer.GetHashCode(list[i]);
+                }
+                return hash;
+            }
+        }
+
+        // Hash code convenience methods using DJB2 constants.
+        // Alternatives would be generic methods that call GetHashCode directly.
+        // Only necessary overloads are present; more can be added.
+        internal static int CombineHashCodes(int hash1, int hash2)
+        {
+            unchecked
+            {
+                int hash = HashInitialValue;
+                hash = (hash << 5) + hash + hash1;
+                hash = (hash << 5) + hash + hash2;
+                return hash;
+            }
+        }
+
+        internal static int CombineHashCodes(int hash1, int hash2, int hash3)
+        {
+            unchecked
+            {
+                int hash = HashInitialValue;
+                hash = (hash << 5) + hash + hash1;
+                hash = (hash << 5) + hash + hash2;
+                hash = (hash << 5) + hash + hash3;
+                return hash;
+            }
+        }
+
+        internal static int CombineHashCodes(int hash1, int hash2, int hash3, int hash4)
+        {
+            unchecked
+            {
+                int hash = HashInitialValue;
+                hash = (hash << 5) + hash + hash1;
+                hash = (hash << 5) + hash + hash2;
+                hash = (hash << 5) + hash + hash3;
+                hash = (hash << 5) + hash + hash4;
+                return hash;
+            }
+        }
+
+        internal static int CombineHashCodes(int hash1, int hash2, int hash3, int hash4, int hash5, int hash6, int hash7, int hash8)
+        {
+            unchecked
+            {
+                int hash = HashInitialValue;
+                hash = (hash << 5) + hash + hash1;
+                hash = (hash << 5) + hash + hash2;
+                hash = (hash << 5) + hash + hash3;
+                hash = (hash << 5) + hash + hash4;
+                hash = (hash << 5) + hash + hash5;
+                hash = (hash << 5) + hash + hash6;
+                hash = (hash << 5) + hash + hash7;
+                hash = (hash << 5) + hash + hash8;
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Google.Api.Gax.Grpc.Gcp/GcpCallInvokerPool.cs
+++ b/src/Google.Api.Gax.Grpc.Gcp/GcpCallInvokerPool.cs
@@ -1,0 +1,177 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using Grpc.Gcp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc.Gcp
+{
+    /// <summary>
+    /// A pool of GCP call invokers for the same service, but with potentially different endpoints and/or channel options.
+    /// Each endpoint/options pair has a single <see cref="GcpCallInvoker"/>. All call invokers created by this pool use
+    /// default application credentials. This class is thread-safe.
+    /// </summary>
+    public sealed class GcpCallInvokerPool
+    {
+        private readonly DefaultChannelCredentialsCache _credentialsCache;
+
+        private readonly Dictionary<Key, GcpCallInvoker> _callInvokers = new Dictionary<Key, GcpCallInvoker>();
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Creates a call invoker pool which will apply the specified scopes to the default application credentials
+        /// if they require any.
+        /// </summary>
+        /// <param name="scopes">The scopes to apply. Must not be null, and must not contain null references. May be empty.</param>
+        public GcpCallInvokerPool(IEnumerable<string> scopes) =>
+            _credentialsCache = new DefaultChannelCredentialsCache(scopes);
+
+        /// <summary>
+        /// Shuts down all the open channels of all currently-allocated call invokers asynchronously. This does not prevent
+        /// the call invoker pool from being used later on, but the currently-allocated call invokers will not be reused.
+        /// </summary>
+        /// <returns>A task which will complete when all the (current) channels have been shut down.</returns>
+        public Task ShutdownChannelsAsync()
+        {
+            List<GcpCallInvoker> gcpCallInvokersToShutdown;
+            lock (_lock)
+            {
+                gcpCallInvokersToShutdown = _callInvokers.Values.ToList();
+                _callInvokers.Clear();
+            }
+            var shutdownTasks = gcpCallInvokersToShutdown.Select(c => c.ShutdownAsync());
+            return Task.WhenAll(shutdownTasks);
+        }
+
+        /// <summary>
+        /// Returns a call invoker from this pool, creating a new one if there is no call invoker
+        /// already associated with <paramref name="endpoint"/> and <paramref name="options"/>.
+        /// </summary>
+        /// <param name="endpoint">The endpoint to connect to. Must not be null.</param>
+        /// <param name="options">
+        /// The options to use for each channel created by the call invoker and/or the special
+        /// <see cref="GcpCallInvoker.ApiConfigChannelArg">GcpCallInvoker.ApiConfigChannelArg</see> option to
+        /// control the <see cref="GcpCallInvoker"/> behavior itself.
+        /// </param>
+        /// <returns>A call invoker for the specified endpoint.</returns>
+        public GcpCallInvoker GetCallInvoker(ServiceEndpoint endpoint, IEnumerable<ChannelOption> options = null)
+        {
+            GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
+            var credentials = _credentialsCache.GetCredentials();
+            return GetCallInvoker(endpoint, options, credentials);
+        }
+
+        /// <summary>
+        /// Asynchronously returns a call invoker from this pool, creating a new one if there is no call invoker
+        /// already associated with <paramref name="endpoint"/> and <paramref name="options"/>.
+        /// </summary>
+        /// <param name="endpoint">The endpoint to connect to. Must not be null.</param>
+        /// <param name="options">
+        /// The options to use for each channel created by the call invoker and/or the special
+        /// <see cref="GcpCallInvoker.ApiConfigChannelArg">GcpCallInvoker.ApiConfigChannelArg</see> option to
+        /// control the <see cref="GcpCallInvoker"/> behavior itself.
+        /// </param>
+        /// <returns>A task representing the asynchronous operation. The value of the completed
+        /// task will be a call invoker for the specified endpoint.</returns>
+        public async Task<GcpCallInvoker> GetCallInvokerAsync(ServiceEndpoint endpoint, IEnumerable<ChannelOption> options = null)
+        {
+            GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
+            var credentials = await _credentialsCache.GetCredentialsAsync().ConfigureAwait(false);
+            return GetCallInvoker(endpoint, options, credentials);
+        }
+
+        private GcpCallInvoker GetCallInvoker(ServiceEndpoint endpoint, IEnumerable<ChannelOption> options, ChannelCredentials credentials)
+        {
+            var optionsList = options?.ToList() ?? new List<ChannelOption>();
+            // "After a duration of this time the client/server pings its peer to see if the
+            // transport is still alive. Int valued, milliseconds."
+            // Required for any channel using a streaming RPC, to ensure an idle stream doesn't
+            // allow the TCP connection to be silently dropped by any intermediary network devices.
+            // 60 second keepalive time is reasonable. This will only add minimal network traffic,
+            // and only if the channel is idle for more than 60 seconds.
+            optionsList.Add(new ChannelOption("grpc.keepalive_time_ms", 60_000));
+
+            var key = new Key(endpoint, optionsList);
+
+            lock (_lock)
+            {
+                if (!_callInvokers.TryGetValue(key, out GcpCallInvoker callInvoker))
+                {
+                    callInvoker = new GcpCallInvoker(endpoint.ToString(), credentials, optionsList);
+                    _callInvokers[key] = callInvoker;
+                }
+                return callInvoker;
+            }
+        }
+
+        // Note: this class will disappear if/when https://github.com/grpc/grpc/issues/16533 is fixed.
+        private class ChannelOptionComparer : IEqualityComparer<ChannelOption>
+        {
+            public static readonly ChannelOptionComparer Instance = new ChannelOptionComparer();
+
+            private ChannelOptionComparer() { }
+
+            public bool Equals(ChannelOption x, ChannelOption y)
+            {
+                if (x == null && y == null)
+                {
+                    return true;
+                }
+
+                if (x == null ||
+                    y == null ||
+                    x.Type != y.Type ||
+                    x.Name != y.Name)
+                {
+                    return false;
+                }
+
+                return
+                    x.Type == ChannelOption.OptionType.Integer ? x.IntValue == y.IntValue :
+                    x.Type == ChannelOption.OptionType.String ? y.StringValue == y.StringValue :
+                    throw new ArgumentException("Unexpected channel option type: " + x.Type);
+            }
+
+            public int GetHashCode(ChannelOption obj)
+            {
+                return
+                    obj == null ? 0 :
+                    obj.Type == ChannelOption.OptionType.Integer ?
+                        EqualityHelpers.CombineHashCodes(obj.IntValue, obj.Name.GetHashCode(), (int)obj.Type) :
+                    obj.Type == ChannelOption.OptionType.String ?
+                        EqualityHelpers.CombineHashCodes(obj.StringValue.GetHashCode(), obj.Name.GetHashCode(), (int)obj.Type) :
+                    throw new ArgumentException("Unexpected channel option type: " + obj.Type);
+            }
+        }
+
+        private struct Key : IEquatable<Key>
+        {
+            public readonly ServiceEndpoint Endpoint;
+            public readonly List<ChannelOption> Options;
+
+            public Key(ServiceEndpoint endpoint, List<ChannelOption> options)
+            {
+                Endpoint = endpoint;
+                Options = options;
+            }
+
+            public override int GetHashCode() =>
+                EqualityHelpers.CombineHashCodes(
+                    Endpoint.GetHashCode(),
+                    EqualityHelpers.GetListHashCode(Options, ChannelOptionComparer.Instance));
+
+            public override bool Equals(object obj) => obj is Key other && Equals(other);
+
+            public bool Equals(Key other) =>
+                Endpoint.Equals(other.Endpoint) && Options.SequenceEqual(other.Options, ChannelOptionComparer.Instance);
+        }
+    }
+}

--- a/src/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
+++ b/src/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\CommonProjectProperties.xml" />
+
+  <!-- For the moment, this package is versioned independently. -->
+  <PropertyGroup>
+    <Version>2.5.0-beta01</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
+  </PropertyGroup>
+
+  <!-- Packaging information -->
+  <PropertyGroup>
+    <Title>Google Cloud Platform gRPC API Extensions</Title>
+    <Description>Additional gRPC API extensions for Google Cloud Platform APIs</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
+
+    <PackageReference Include="Grpc.Gcp" Version="1.0.0" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="1.0.1" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Import Project="..\..\StripDesktopOnNonWindows.xml" />
+
+</Project>

--- a/src/Google.Api.Gax.Grpc/ChannelPool.cs
+++ b/src/Google.Api.Gax.Grpc/ChannelPool.cs
@@ -67,7 +67,7 @@ namespace Google.Api.Gax.Grpc
         /// Shuts down all the currently-allocated channels asynchronously. This does not prevent the channel
         /// pool from being used later on, but the currently-allocated channels will not be reused.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A task which will complete when all the (current) channels have been shut down.</returns>
         public Task ShutdownChannelsAsync()
         {
             List<Channel> channelsToShutdown;

--- a/test/Google.Api.Gax.Grpc.Gcp.IntegrationTests/Google.Api.Gax.Grpc.Gcp.IntegrationTests.csproj
+++ b/test/Google.Api.Gax.Grpc.Gcp.IntegrationTests/Google.Api.Gax.Grpc.Gcp.IntegrationTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\CommonProjectProperties.xml" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Google.Api.Gax.Grpc.Gcp\Google.Api.Gax.Grpc.Gcp.csproj" />
+    
+    <!-- 
+      - TODO: Avoid this. Depending on a test project is nasty. Options:
+      - * Extract a common test project that both Grpc.IntegrationTests and Grpc.Gcp.IntegrationTests depend on
+      - * Put the Grpc.Gcp tests into Grpc.IntegrationTests
+      -->
+    <ProjectReference Include="..\Google.Api.Gax.Grpc.IntegrationTests\Google.Api.Gax.Grpc.IntegrationTests.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\..\StripDesktopOnNonWindows.xml" />
+
+</Project>

--- a/test/Google.Api.Gax.Grpc.Gcp.IntegrationTests/GrpcCallInvokerPoolTest.cs
+++ b/test/Google.Api.Gax.Grpc.Gcp.IntegrationTests/GrpcCallInvokerPoolTest.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+using Google.Api.Gax.Grpc.IntegrationTests;
+using Grpc.Core;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
+{
+    public class GcpCallInvokerPoolTest
+    {
+        private static readonly IEnumerable<string> EmptyScopes = Enumerable.Empty<string>();
+        [Fact]
+        public void SameEndpointAndOptions_SameCallInvoker()
+        {
+            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var options = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "abc") };
+            using (var fixture = new TestServiceFixture())
+            {
+                var callInvoker1 = pool.GetCallInvoker(fixture.Endpoint, options);
+                var callInvoker2 = pool.GetCallInvoker(fixture.Endpoint, options);
+                Assert.Same(callInvoker1, callInvoker2);
+            }
+        }
+        [Fact]
+        public void DifferentEndpoint_DifferentCallInvoker()
+        {
+            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var options = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "abc") };
+            using (TestServiceFixture fixture1 = new TestServiceFixture(), fixture2 = new TestServiceFixture())
+            {
+                var callInvoker1 = pool.GetCallInvoker(fixture1.Endpoint, options);
+                var callInvoker2 = pool.GetCallInvoker(fixture2.Endpoint, options);
+                Assert.NotSame(callInvoker1, callInvoker2);
+            }
+        }
+        [Fact]
+        public void DifferentOptions_DifferentCallInvoker()
+        {
+            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var options1 = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "abc") };
+            var options2 = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "def") };
+            using (var fixture = new TestServiceFixture())
+            {
+                var callInvoker1 = pool.GetCallInvoker(fixture.Endpoint, options1);
+                var callInvoker2 = pool.GetCallInvoker(fixture.Endpoint, options2);
+                Assert.NotSame(callInvoker1, callInvoker2);
+                var callInvoker3 = pool.GetCallInvoker(fixture.Endpoint);
+                Assert.NotSame(callInvoker1, callInvoker3);
+            }
+        }
+        [Fact]
+        public void ShutdownAsync_EmptiesPool()
+        {
+            var pool = new GcpCallInvokerPool(EmptyScopes);
+            using (var fixture = new TestServiceFixture())
+            {
+                var callInvoker1 = pool.GetCallInvoker(fixture.Endpoint);
+                // Note: *not* waiting for this to complete.
+                pool.ShutdownChannelsAsync();
+                var callInvoker2 = pool.GetCallInvoker(fixture.Endpoint);
+                Assert.NotSame(callInvoker1, callInvoker2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
(It's a good job that no-one is ever going to want to type that in
by hand; it's horrible name otherwise! It's likely to be a
dependency from more packages with friendlier names.)

Notes:

- This is the code from #273 just moved around a bit
- We may well want to move some code (EqualityHelpers and
  DefaultChannelCredentialsCache) up the dependency chain later,
  but we can do that later
- I've given it an initial version which reflects a desire for this
  to be "part of the GAX packages" with a common version number; it
  *could* be independent, but it's probably simpler to keep them
  together if we can
- There's a dodgy test-to-test dependency at the moment, but I'd
  rather address that in a subsequent PR

cc @evildour