### PR TITLE
Additional Task-related extension methods:

### DIFF
--- a/Google.Api.Gax.Tests/TaskCompletionSourceExtensionsTests.cs
+++ b/Google.Api.Gax.Tests/TaskCompletionSourceExtensionsTests.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Tests
+{
+    public class TaskCompletionSourceExtensionsTests
+    {
+        [Fact]
+        public async Task WithCancellationToken_None()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var task = tcs.WithCancellationToken(CancellationToken.None);
+
+            tcs.SetResult(5);
+            Assert.Equal(5, await task);
+        }
+
+        [Fact]
+        public async Task WithCancellationToken_Uncancelled()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var source = new CancellationTokenSource();
+            var task = tcs.WithCancellationToken(source.Token);
+
+            tcs.SetResult(5);
+            Assert.Equal(5, await task);
+        }
+
+        [Fact]
+        public async Task WithCancellationToken_CancelledBeforeCreation()
+        {
+            var source = new CancellationTokenSource();
+            source.Cancel();
+            var tcs = new TaskCompletionSource<int>();
+            var task = tcs.WithCancellationToken(source.Token);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+        }
+
+        [Fact]
+        public async Task WithCancellationToken_CancelledAfterCreation()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var source = new CancellationTokenSource();
+            var task = tcs.WithCancellationToken(source.Token);
+            source.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+        }
+    }
+}

--- a/Google.Api.Gax/TaskCompletionSourceExtensions.cs
+++ b/Google.Api.Gax/TaskCompletionSourceExtensions.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// Extension methods for <see cref="TaskCompletionSource{TResult}"/>.
+    /// </summary>
+    public static class TaskCompletionSourceExtensions
+    {
+        /// <summary>
+        /// Returns a task from a task completion source, but observing a given cancellation token.
+        /// </summary>
+        /// <typeparam name="TResult">The result type of the task completion source</typeparam>
+        /// <param name="source">The task completion source. Must not be null.</param>
+        /// <param name="cancellationToken">The cancellation token to observe.</param>
+        /// <returns>A task that will complete when <paramref name="source"/> completes, but
+        /// will observe <paramref name="cancellationToken"/> for cancellation.</returns>
+        public static Task<TResult> WithCancellationToken<TResult>(this TaskCompletionSource<TResult> source, CancellationToken cancellationToken)
+        {
+            GaxPreconditions.CheckNotNull(source, nameof(source));
+            if (!cancellationToken.CanBeCanceled)
+            {
+                return source.Task;
+            }
+            return Wait();
+
+            async Task<TResult> Wait()
+            {
+                using (cancellationToken.Register(() => source.TrySetCanceled()))
+                {
+                    return await source.Task.ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/Google.Api.Gax/TaskExtensions.cs
+++ b/Google.Api.Gax/TaskExtensions.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Api.Gax
@@ -44,12 +45,103 @@ namespace Google.Api.Gax
             catch (AggregateException e)
             {
                 // Unwrap the first exception, a bit like await would.
-                // It's very unlikely that we'd ever see an AggregateException without an inner exceptions,
+                // It's very unlikely that we'd ever see an AggregateException without an inner exception,
                 // but let's handle it relatively gracefully.
                 // Using ExceptionDispatchInfo to keep the original exception stack trace.
                 ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
             }
+        }
 
+        /// <summary>
+        /// Synchronously waits for the given task to complete.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <param name="task">The task to wait for.</param>
+        /// <param name="timeout">A TimeSpan that represents the number of milliseconds to wait, or
+        /// -1 milliseconds to wait indefinitely.</param>
+        public static void WaitWithUnwrappedExceptions(this Task task, TimeSpan timeout)
+        {
+            try
+            {
+                task.Wait(timeout);
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exception,
+                // but let's handle it relatively gracefully.
+                // Using ExceptionDispatchInfo to keep the original exception stack trace.
+                ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
+            }
+        }
+
+        /// <summary>
+        /// Synchronously waits for the given task to complete.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <param name="task">The task to wait for.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or
+        /// -1 to wait indefinitely.</param>
+        public static void WaitWithUnwrappedExceptions(this Task task, int millisecondsTimeout)
+        {
+            try
+            {
+                task.Wait(millisecondsTimeout);
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exception,
+                // but let's handle it relatively gracefully.
+                // Using ExceptionDispatchInfo to keep the original exception stack trace.
+                ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
+            }
+        }
+
+        /// <summary>
+        /// Synchronously waits for the given task to complete.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <param name="task">The task to wait for.</param>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or
+        /// -1 to wait indefinitely.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete</param>
+        public static void WaitWithUnwrappedExceptions(this Task task, int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            try
+            {
+                task.Wait(millisecondsTimeout, cancellationToken);
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exception,
+                // but let's handle it relatively gracefully.
+                // Using ExceptionDispatchInfo to keep the original exception stack trace.
+                ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
+            }
+        }
+
+        /// <summary>
+        /// Synchronously waits for the given task to complete.
+        /// Any <see cref="AggregateException"/> thrown is unwrapped to the first inner exception.
+        /// </summary>
+        /// <param name="task">The task to wait for.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete</param>
+        public static void WaitWithUnwrappedExceptions(this Task task, CancellationToken cancellationToken)
+        {
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException e)
+            {
+                // Unwrap the first exception, a bit like await would.
+                // It's very unlikely that we'd ever see an AggregateException without an inner exception,
+                // but let's handle it relatively gracefully.
+                // Using ExceptionDispatchInfo to keep the original exception stack trace.
+                ExceptionDispatchInfo.Capture(e.InnerExceptions.FirstOrDefault() ?? e).Throw();
+            }
         }
     }
 }


### PR DESCRIPTION
- WaitWithUnwrappedExceptions overloads to match Wait
- TaskCompletionSource.WithCancellationToken