### PR TITLE
Update Google.Api.Gax.Grpc.Gcp

### DIFF
--- a/Google.Api.Gax.Grpc.Gcp.IntegrationTests/GrpcCallInvokerPoolTest.cs
+++ b/Google.Api.Gax.Grpc.Gcp.IntegrationTests/GrpcCallInvokerPoolTest.cs
@@ -15,6 +15,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
     public class GcpCallInvokerPoolTest
     {
         private static readonly IEnumerable<string> EmptyScopes = Enumerable.Empty<string>();
+
         [Fact]
         public void SameEndpointAndOptions_SameCallInvoker()
         {
@@ -27,6 +28,21 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
                 Assert.Same(callInvoker1, callInvoker2);
             }
         }
+
+        [Fact]
+        public void SameEndpointAndEqualOptions_SameCallInvoker()
+        {
+            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var options1 = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "abc") };
+            var options2 = new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "abc") };
+            using (var fixture = new TestServiceFixture())
+            {
+                var callInvoker1 = pool.GetCallInvoker(fixture.Endpoint, options1);
+                var callInvoker2 = pool.GetCallInvoker(fixture.Endpoint, options2);
+                Assert.Same(callInvoker1, callInvoker2);
+            }
+        }
+
         [Fact]
         public void DifferentEndpoint_DifferentCallInvoker()
         {
@@ -39,6 +55,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
                 Assert.NotSame(callInvoker1, callInvoker2);
             }
         }
+
         [Fact]
         public void DifferentOptions_DifferentCallInvoker()
         {
@@ -54,6 +71,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
                 Assert.NotSame(callInvoker1, callInvoker3);
             }
         }
+
         [Fact]
         public void ShutdownAsync_EmptiesPool()
         {

--- a/Google.Api.Gax.Grpc.Gcp/GcpCallInvokerPool.cs
+++ b/Google.Api.Gax.Grpc.Gcp/GcpCallInvokerPool.cs
@@ -112,46 +112,6 @@ namespace Google.Api.Gax.Grpc.Gcp
             }
         }
 
-        // Note: this class will disappear if/when https://github.com/grpc/grpc/issues/16533 is fixed.
-        private class ChannelOptionComparer : IEqualityComparer<ChannelOption>
-        {
-            public static readonly ChannelOptionComparer Instance = new ChannelOptionComparer();
-
-            private ChannelOptionComparer() { }
-
-            public bool Equals(ChannelOption x, ChannelOption y)
-            {
-                if (x == null && y == null)
-                {
-                    return true;
-                }
-
-                if (x == null ||
-                    y == null ||
-                    x.Type != y.Type ||
-                    x.Name != y.Name)
-                {
-                    return false;
-                }
-
-                return
-                    x.Type == ChannelOption.OptionType.Integer ? x.IntValue == y.IntValue :
-                    x.Type == ChannelOption.OptionType.String ? y.StringValue == y.StringValue :
-                    throw new ArgumentException("Unexpected channel option type: " + x.Type);
-            }
-
-            public int GetHashCode(ChannelOption obj)
-            {
-                return
-                    obj == null ? 0 :
-                    obj.Type == ChannelOption.OptionType.Integer ?
-                        EqualityHelpers.CombineHashCodes(obj.IntValue, obj.Name.GetHashCode(), (int)obj.Type) :
-                    obj.Type == ChannelOption.OptionType.String ?
-                        EqualityHelpers.CombineHashCodes(obj.StringValue.GetHashCode(), obj.Name.GetHashCode(), (int)obj.Type) :
-                    throw new ArgumentException("Unexpected channel option type: " + obj.Type);
-            }
-        }
-
         private struct Key : IEquatable<Key>
         {
             public readonly ServiceEndpoint Endpoint;
@@ -166,12 +126,12 @@ namespace Google.Api.Gax.Grpc.Gcp
             public override int GetHashCode() =>
                 EqualityHelpers.CombineHashCodes(
                     Endpoint.GetHashCode(),
-                    EqualityHelpers.GetListHashCode(Options, ChannelOptionComparer.Instance));
+                    EqualityHelpers.GetListHashCode(Options, EqualityComparer<ChannelOption>.Default));
 
             public override bool Equals(object obj) => obj is Key other && Equals(other);
 
             public bool Equals(Key other) =>
-                Endpoint.Equals(other.Endpoint) && Options.SequenceEqual(other.Options, ChannelOptionComparer.Instance);
+                Endpoint.Equals(other.Endpoint) && Options.SequenceEqual(other.Options);
         }
     }
 }

--- a/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
+++ b/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
-
-    <PackageReference Include="Grpc.Gcp" Version="1.0.0" />
+    <PackageReference Include="Grpc.Gcp" Version="1.1.0" />
+    <PackageReference Include="Grpc.Core" Version="1.16.0" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
- Use the latest Grpc.Gcp package
- Use the latest Grpc.Core package
- Remove our own ChannelOptions equality comparer as Grpc.Core now does this for us