### PR TITLE
Create GAX release 2.6.0-beta01

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.Production.xml" />
 
   <PropertyGroup>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <Version>1.4.0</Version>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
+++ b/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
@@ -2,11 +2,6 @@
 
   <Import Project="..\CommonProperties.Production.xml" />
 
-  <!-- For the moment, this package is versioned independently. -->
-  <PropertyGroup>
-    <Version>2.5.0-beta01</Version>
-  </PropertyGroup>
-
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0-beta01</Version>
   </PropertyGroup>
 </Project>

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <Version>2.5.0</Version>
   </PropertyGroup>
 </Project>

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,6 @@
 
 set -e
 
-# Myget has sometimes used caps and sometimes not for
-# its environment variables...
-if [ -n "$PrereleaseTag" -a -z "$PRERELEASETAG" ]
-then
-  PRERELEASETAG="$PrereleaseTag"
-fi
-
 # Clean up previous builds
 rm -rf {src,test,testing}/*/bin {src,test,testing}/*/obj
 
@@ -17,18 +10,6 @@ CONFIG=Release
 DOTNET_BUILD_ARGS="-c $CONFIG"
 # Arguments to use for test-related commands (test)
 DOTNET_TEST_ARGS="--no-build $DOTNET_BUILD_ARGS"
-
-# Three options:
-# - No environment variables: make sure it's not for release
-# - PRERELEASETAG set: use that
-# - NOVERSIONSUFFIX set: use no suffix; build as per project.json
-if [ -n "$PRERELEASETAG" ]
-then
-  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix $PRERELEASETAG"
-elif [ -z "$NOVERSIONSUFFIX" ]
-then
-  DOTNET_BUILD_ARGS="$DOTNET_BUILD_ARGS --version-suffix dont-release"  
-fi
 
 echo CLI args: $DOTNET_BUILD_ARGS
 

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -32,7 +32,6 @@ git clone https://github.com/googleapis/gax-dotnet.git releasebuild -c core.auto
 cd releasebuild
 git checkout $tag
 export CI=true # Forces SourceLink in the main build.
-export NOVERSIONSUFFIX=true
 ./build.sh
 dotnet pack Gax.sln --no-build -o $PWD/nuget -c Release
 


### PR DESCRIPTION
- First commit just changes a few details of how we build to be more consistent with our other repos
- Second commit is the actual version number change
