### PR TITLE
Make platform version detection more robust

### DIFF
--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -24,10 +24,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-  </ItemGroup>
-
   <Import Project="..\StripDesktopOnNonWindows.xml" />
 
 </Project>


### PR DESCRIPTION
It's unfortunate that we still need to use reflection in order to support .NET Standard 1.3, but we do so in a more robust way than the previous dependency did.

Additionally, we now fail gracefully: it's better to use an unknown version number for the environment than failing completely.

Fixes #231 

cc @amanda-tarafa 