### PR TITLE
[Kokoro] Changing working dir before executing the build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+cd $(dirname $0)
+
 # Clean up previous builds
 rm -rf {src,test,testing}/*/bin {src,test,testing}/*/obj
 


### PR DESCRIPTION
It was as simple as that. For windows this is done on the .kokoro/build.sh file before hand.