### PR TITLE
Creating and adapting release scripts for Kokoro.

### DIFF
--- a/.kokoro/release.bat
+++ b/.kokoro/release.bat
@@ -1,0 +1,4 @@
+:: See documentation in type-shell-output.bat
+
+cd /d %~dp0
+"C:\Program Files\Git\bin\bash.exe" release.sh

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT=$(readlink -f "$0")
+SCRIPT_DIR=$(dirname "$SCRIPT")
+
+cd $SCRIPT_DIR
+cd ..
+
+export NUGET_API_KEY="$(cat "$KOKORO_KEYSTORE_DIR"/73609_google-apis-nuget-api-key)"
+
+# Build the release and run the tests.
+./buildrelease.sh $(git rev-parse HEAD)
+
+# Push the changes to nuget.
+cd ./releasebuild/nuget
+for pkg in *.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k $NUGET_API_KEY $pkg; done

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
 # Script to perform a release build for GAX, based on
-# a tag which should already have been created.
-# This builds both GAX and the common protos; you should only push
-# the nuget packages you actually want to update.
-# Sample: buildrelease.sh Google.Api.Gax-2.1.0
+# a commit for which tags have been created.
+# This builds both GAX and the common protos; but will delete
+# all built packages that don't match one of the tags in the commit
+# hash. For instance, if there's only one tag in the commit hash 
+# that starts with Google.Api.Gax.Grpc then only the following nuget
+# packages will remain after the script is done:
+# Google.Api.Gax.Grpc.<version>.nupkg
+# Google.Api.Gax.Grpc.Gcp.<version>.nupkg
+# Google.Api.Gax.Grpc.Testing.<version>.nupkg
+# Sample: buildrelease.sh 847118821d8a8b4ac2ea3bbe692acea29c14c4da
 
 # The repo is cloned into a fresh "releasebuild" directory.
 
@@ -12,16 +18,11 @@ set -e
 
 if [ -z "$1" ]
 then
-  echo Please specify the release tag
+  echo "Please specify a commit hash."
   exit 1
 fi
 
-tag=$1
-
-# TODO: We don't really want a regex here... just a match.
-git fetch -v --dry-run --tags upstream 2>&1 \
-  | grep -e $tag > /dev/null \
-  || (echo "Tag $tag appears not to exist. Did you create it?"; exit 1)
+commit=$1
 
 # Do everything from the repository root for sanity.
 cd $(dirname $0)
@@ -30,9 +31,44 @@ rm -rf releasebuild
 git clone https://github.com/googleapis/gax-dotnet.git releasebuild -c core.autocrlf=input
 
 cd releasebuild
-git checkout $tag
+git checkout $commit
 export CI=true # Forces SourceLink in the main build.
 ./build.sh
 dotnet pack Gax.sln --no-build -o $PWD/nuget -c Release
+
+# Turn the multi-line output of git tag --points-at into space-separated list of projects
+projects=$(git tag --points-at $commit | sed 's/-.*//g' | awk -vORS=\  '{print $1}' | sed 's/ $//')
+
+if [ -z "$projects" ]
+then
+  echo "No tags found for commit $commit"
+  echo "Deleting all packages generated"
+  rm -rf nuget
+  exit 1
+fi
+
+oldIFS=$IFS
+IFS=' '
+read -a projectArray <<< "$projects"
+IFS=$oldIFS
+
+for package in nuget/*
+do
+  delete=true
+  for projectToKeep in ${projectArray[*]}
+  do
+    if [[ $package == nuget/$projectToKeep* ]];
+    then
+      delete=false
+	  echo "Keeping package $package"
+      break
+    fi
+  done
+  if [ "$delete" = true ];
+  then
+    echo "Deleting package $package"
+    rm -rf $package
+  fi
+done
 
 echo "Build complete. Push packages from releasebuild/nuget."


### PR DESCRIPTION
This ran from Kokoro almost to completion, and it wasn't successful because I was explicitly using a "fake_key" value for the nuget.org key, so as not to push any package to nuget. The failure was when pushing packages to nuget with the following expected error.

```
info : Pushing Google.Api.CommonProtos.1.5.0.nupkg to 'https://www.nuget.org/api/v2/package'...
info :   PUT https://www.nuget.org/api/v2/package/
info :   Forbidden https://www.nuget.org/api/v2/package/ 560ms
error: Response status code does not indicate success: 403 (The specified API key is invalid, has expired, or does not have permission to access the specified package.).
```

The two scripts in `.kokoro` are new. The `buildrelease.sh` script in the root directory is a modified version of the one that existed already. The main changes are as follows:

- The release is now based in a commit (which is what we get from Kokoro) and not a tag. The tags still need to be created beforehand, because they will be used to determined which packages to push to nuget.org. There can be several tags pointing at the same commit and all of those will be taken into account.
- The process still generates all nuget packages, but it deletes the ones that are not "included" in one of the tags pointing to the given commit. This happens so that the scripts in `.kokoro` can blindly push all packages to nuget.org.
  - For instance, if there's only one tag Google.Api.Gax-version then all the packages except the one generated for Google.Api.CommonProtos will be kept and pushed to nuget.
  - If there are two tags pointing to the given commit, say Google.Api.Gax.Grpc-version and Google.Api.CommonProtos-version then only the generated packages for Google.Api.Gax.Grpc.* and Google.Api.CommonProtos will be kept and pushed to nuget.

It's important then to generate the tags following the same format that has been used till now, so that Kokoro pushes the right packages to nuget.