### PR TITLE
Introduce new methods for x-goog-request-params header

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ApiCallTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ApiCallTest.cs
@@ -163,5 +163,23 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Same(replacement, thrown);
             Assert.Same(original, callbackException);
         }
+
+        [Fact]
+        public void WithGoogleRequestParam()
+        {
+            CallSettings syncCallSettings = null;
+            CallSettings asyncCallSettings = null;
+            var call0 = new ApiCall<SimpleRequest, SimpleResponse>(
+                (req, cs) => { asyncCallSettings = cs; return null; },
+                (req, cs) => { syncCallSettings = cs; return null; },
+                null);
+
+            var call1 = call0.WithGoogleRequestParam("parent", request => request.Name);
+            call1.Sync(new SimpleRequest { Name = "test" }, null);
+            call1.Async(new SimpleRequest { Name = "test" }, null);
+
+            CallSettingsTest.AssertSingleHeader(syncCallSettings, CallSettings.RequestParamsHeader, "parent=test");
+            CallSettingsTest.AssertSingleHeader(asyncCallSettings, CallSettings.RequestParamsHeader, "parent=test");
+        }
     }
 }

--- a/Google.Api.Gax.Grpc.Tests/ApiServerStreamingCallTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ApiServerStreamingCallTest.cs
@@ -75,5 +75,23 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.NotEqual(ctBase, asyncCallSettings.CancellationToken.Value);
             Assert.NotEqual(ctPerCall, asyncCallSettings.CancellationToken.Value);
         }
+
+        [Fact]
+        public void WithGoogleRequestParam()
+        {
+            CallSettings syncCallSettings = null;
+            CallSettings asyncCallSettings = null;
+            var call0 = new ApiServerStreamingCall<SimpleRequest, SimpleResponse>(
+                (req, cs) => { asyncCallSettings = cs; return null; },
+                (req, cs) => { syncCallSettings = cs; return null; },
+                null);
+
+            var call1 = call0.WithGoogleRequestParam("parent", request => request.Name);
+            call1.Call(new SimpleRequest { Name = "test" }, null);
+            call1.CallAsync(new SimpleRequest { Name = "test" }, null);
+
+            CallSettingsTest.AssertSingleHeader(syncCallSettings, CallSettings.RequestParamsHeader, "parent=test");
+            CallSettingsTest.AssertSingleHeader(asyncCallSettings, CallSettings.RequestParamsHeader, "parent=test");
+        }
     }
 }

--- a/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
@@ -197,5 +197,25 @@ namespace Google.Api.Gax.Grpc.Tests
                 CallSettings.FromTrailingMetadataHandler(handler2));
             Assert.Equal(handler1 + handler2, settings.TrailingMetadataHandler);
         }
+
+        [Theory]
+        [InlineData("parent", "foo", "parent=foo")]
+        [InlineData("parent", "a,b", "parent=a%2Cb")]
+        [InlineData("transaction", "xy==", "transaction=xy%3D%3D")]
+        [InlineData("parent", null, "parent=")]
+        public void FromGoogleRequestParamsHeader(string parameterName, string parameterValue, string expectedHeaderValue)
+        {
+            var callSettings = CallSettings.FromGoogleRequestParamsHeader(parameterName, parameterValue);
+            AssertSingleHeader(callSettings, CallSettings.RequestParamsHeader, expectedHeaderValue);
+        }
+
+        internal static void AssertSingleHeader(CallSettings callSettings, string expectedHeaderName, string expectedHeaderValue)
+        {
+            var metadata = new Metadata();
+            callSettings.HeaderMutation(metadata);
+            Assert.Equal(1, metadata.Count);
+            Assert.Equal(expectedHeaderName, metadata[0].Key);
+            Assert.Equal(expectedHeaderValue, metadata[0].Value);
+        }
     }
 }

--- a/Google.Api.Gax.Grpc/ApiCall.cs
+++ b/Google.Api.Gax.Grpc/ApiCall.cs
@@ -161,7 +161,7 @@ namespace Google.Api.Gax.Grpc
                 BaseCallSettings);
 
         /// <summary>
-        /// Construct a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an overlay to
+        /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an overlay to
         /// the underlying <see cref="CallSettings"/>. If a value exists in both the original and
         /// the overlay, the overlay takes priority.
         /// </summary>
@@ -174,7 +174,7 @@ namespace Google.Api.Gax.Grpc
                 BaseCallSettings);
 
         /// <summary>
-        /// Construct a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an exception customizer
+        /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an exception customizer
         /// to both the synchronous and asynchronous calls.
         /// </summary>
         /// <remarks>
@@ -191,6 +191,21 @@ namespace Google.Api.Gax.Grpc
                 _asyncCall.WithExceptionCustomizer(customizer),
                 _syncCall.WithExceptionCustomizer(customizer),
                 BaseCallSettings);
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an x-goog-request-params header to each request,
+        /// using the specified parameter name and a value derived from the request.
+        /// </summary>
+        /// <param name="parameterName">The parameter name in the header. Must not be null.</param>
+        /// <param name="valueSelector">A function to call on each request, to determine the value to specify in the header.
+        /// The parameter must not be null, but may return null.</param>
+        /// <returns>A new <see cref="ApiCall{TRequest, TResponse}"/> which applies the header on each request.</returns>
+        public ApiCall<TRequest, TResponse> WithGoogleRequestParam(string parameterName, Func<TRequest, string> valueSelector)
+        {
+            GaxPreconditions.CheckNotNull(parameterName, nameof(parameterName));
+            GaxPreconditions.CheckNotNull(valueSelector, nameof(valueSelector));
+            return WithCallSettingsOverlay(request => CallSettings.FromGoogleRequestParamsHeader(parameterName, valueSelector(request)));
         }
     }
 }

--- a/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
@@ -85,16 +85,31 @@ namespace Google.Api.Gax.Grpc
                 BaseCallSettings);
 
         /// <summary>
-        /// Construct a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an overlay to
+        /// Constructs a new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> that applies an overlay to
         /// the underlying <see cref="CallSettings"/>. If a value exists in both the original and
         /// the overlay, the overlay takes priority.
         /// </summary>
         /// <param name="callSettingsOverlayFn">Function that builds the overlay <see cref="CallSettings"/>.</param>
-        /// <returns>A new <see cref="ApiCall{TRequest, TResponse}"/> with the overlay applied.</returns>
+        /// <returns>A new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> with the overlay applied.</returns>
         public ApiServerStreamingCall<TRequest, TResponse> WithCallSettingsOverlay(Func<TRequest, CallSettings> callSettingsOverlayFn) =>
             new ApiServerStreamingCall<TRequest, TResponse>(
                 (req, cs) => _asyncCall(req, cs.MergedWith(callSettingsOverlayFn(req))),
                 (req, cs) => _syncCall(req, cs.MergedWith(callSettingsOverlayFn(req))),
                 BaseCallSettings);
+
+        /// <summary>
+        /// Constructs a new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> that applies an x-goog-request-params header to each request,
+        /// using the specified parameter name and a value derived from the request.
+        /// </summary>
+        /// <param name="parameterName">The parameter name in the header. Must not be null.</param>
+        /// <param name="valueSelector">A function to call on each request, to determine the value to specify in the header.
+        /// The parameter must not be null, but may return null.</param>
+        /// <returns>A new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> which applies the header on each request.</returns>
+        public ApiServerStreamingCall<TRequest, TResponse> WithGoogleRequestParam(string parameterName, Func<TRequest, string> valueSelector)
+        {
+            GaxPreconditions.CheckNotNull(parameterName, nameof(parameterName));
+            GaxPreconditions.CheckNotNull(valueSelector, nameof(valueSelector));
+            return WithCallSettingsOverlay(request => CallSettings.FromGoogleRequestParamsHeader(parameterName, valueSelector(request)));
+        }
     }
 }

--- a/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/Google.Api.Gax.Grpc/CallSettings.cs
@@ -17,6 +17,7 @@ namespace Google.Api.Gax.Grpc
     public sealed class CallSettings
     {
         internal const string FieldMaskHeader = "x-goog-fieldmask";
+        internal const string RequestParamsHeader = "x-goog-request-params";
 
         internal static CallSettings CancellationTokenNone { get; } = new CallSettings(default(CancellationToken), null, null, null, null, null);
 
@@ -232,5 +233,15 @@ namespace Google.Api.Gax.Grpc
 
         // TODO: Accept a Google.Protobuf.FieldMask when we're convinced it's useful and we know
         // exactly what to do with it.
+
+        /// <summary>
+        /// Creates a CallSettings which applies an x-goog-request-params header with the specified
+        /// parameter name and value.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter. Must not be null.</param>
+        /// <param name="value">The value of the parameter, which may be null. This is equivalent to an empty string.</param>
+        /// <returns>A CallSettings which applies the appropriate parameter.</returns>
+        internal static CallSettings FromGoogleRequestParamsHeader(string parameterName, string value) =>
+            CallSettings.FromHeader(RequestParamsHeader, parameterName + "=" + Uri.EscapeDataString(value ?? ""));
     }
 }


### PR DESCRIPTION
The parameter value needs to be escaped, which is worth doing centrally, but it's header-specific.

Note: we shouldn't release a beta just yet, as the *exact* escaping is still being discussed.