### PR TITLE
Add format methods to common resource names

### DIFF
--- a/Google.Api.Gax/ResourceNames/BillingAccountName.cs
+++ b/Google.Api.Gax/ResourceNames/BillingAccountName.cs
@@ -5,48 +5,52 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using System;
+using gax = Google.Api.Gax;
+using sys = System;
 
 namespace Google.Api.Gax.ResourceNames
 {
+    // Note: the use of BillingAccountName as a parameter name (rather than billingAccountName) is unfortunate,
+    // but changing it now would require a new major version.
+
     /// <summary>
     /// Resource name for the 'billing account' resource which is widespread across Google Cloud Platform.
     /// While most resource names are generated on a per-API basis, many APIs use a billing account resource, and it's
     /// useful to be able to pass values from one API to another.
     /// </summary>
-    public sealed partial class BillingAccountName : IResourceName, IEquatable<BillingAccountName>
+    public sealed partial class BillingAccountName : gax::IResourceName, sys::IEquatable<BillingAccountName>
     {
-        private static readonly PathTemplate s_template = new PathTemplate("billingAccounts/{billing_account}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("billingAccounts/{billing_account}");
 
         /// <summary>
-        /// Parses the given billing account resource name in string form into a new
+        /// Parses the given billing resource name in string form into a new
         /// <see cref="BillingAccountName"/> instance.
         /// </summary>
-        /// <param name="BillingAccountName">The billing account resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="BillingAccountName">The billing resource name in string form. Must not be <c>null</c>.</param>
         /// <returns>The parsed <see cref="BillingAccountName"/> if successful.</returns>
         public static BillingAccountName Parse(string BillingAccountName)
         {
-            GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
-            TemplatedResourceName resourceName = s_template.ParseName(BillingAccountName);
+            gax::GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(BillingAccountName);
             return new BillingAccountName(resourceName[0]);
         }
 
         /// <summary>
-        /// Tries to parse the given billing account resource name in string form into a new
+        /// Tries to parse the given billing resource name in string form into a new
         /// <see cref="BillingAccountName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="BillingAccountName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="BillingAccountName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
-        /// <param name="BillingAccountName">The billing account resource name in string form. Must not be <c>null</c>.</param>
+        /// <param name="BillingAccountName">The billing resource name in string form. Must not be <c>null</c>.</param>
         /// <param name="result">When this method returns, the parsed <see cref="BillingAccountName"/>,
         /// or <c>null</c> if parsing fails.</param>
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string BillingAccountName, out BillingAccountName result)
         {
-            GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
-            TemplatedResourceName resourceName;
+            gax::GaxPreconditions.CheckNotNull(BillingAccountName, nameof(BillingAccountName));
+            gax::TemplatedResourceName resourceName;
             if (s_template.TryParseName(BillingAccountName, out resourceName))
             {
                 result = new BillingAccountName(resourceName[0]);
@@ -59,6 +63,12 @@ namespace Google.Api.Gax.ResourceNames
             }
         }
 
+        /// <summary>Formats the IDs into the string representation of the <see cref="BillingAccountName"/>.</summary>
+        /// <param name="billingAccountId">The <c>billingAccount</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="BillingAccountName"/>.</returns>
+        public static string Format(string billingAccountId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId)));
+
         /// <summary>
         /// Constructs a new instance of the <see cref="BillingAccountName"/> resource name class
         /// from its component parts.
@@ -66,7 +76,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <param name="billingAccountId">The billingAccount ID. Must not be <c>null</c>.</param>
         public BillingAccountName(string billingAccountId)
         {
-            BillingAccountId = GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
+            BillingAccountId = gax::GaxPreconditions.CheckNotNull(billingAccountId, nameof(billingAccountId));
         }
 
         /// <summary>
@@ -75,7 +85,7 @@ namespace Google.Api.Gax.ResourceNames
         public string BillingAccountId { get; }
 
         /// <inheritdoc />
-        public ResourceNameKind Kind => ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
         public override string ToString() => s_template.Expand(BillingAccountId);

--- a/Google.Api.Gax/ResourceNames/FolderName.cs
+++ b/Google.Api.Gax/ResourceNames/FolderName.cs
@@ -5,7 +5,8 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using System;
+using gax = Google.Api.Gax;
+using sys = System;
 
 namespace Google.Api.Gax.ResourceNames
 {
@@ -14,9 +15,9 @@ namespace Google.Api.Gax.ResourceNames
     /// While most resource names are generated on a per-API basis, many APIs use a folder resource, and it's
     /// useful to be able to pass values from one API to another.
     /// </summary>
-    public sealed partial class FolderName : IResourceName, IEquatable<FolderName>
+    public sealed partial class FolderName : gax::IResourceName, sys::IEquatable<FolderName>
     {
-        private static readonly PathTemplate s_template = new PathTemplate("folders/{folder}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("folders/{folder}");
 
         /// <summary>
         /// Parses the given folder resource name in string form into a new
@@ -26,8 +27,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns>The parsed <see cref="FolderName"/> if successful.</returns>
         public static FolderName Parse(string folderName)
         {
-            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
-            TemplatedResourceName resourceName = s_template.ParseName(folderName);
+            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(folderName);
             return new FolderName(resourceName[0]);
         }
 
@@ -36,7 +37,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <see cref="FolderName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="folderName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="folderName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="folderName">The folder resource name in string form. Must not be <c>null</c>.</param>
@@ -45,8 +46,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string folderName, out FolderName result)
         {
-            GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
-            TemplatedResourceName resourceName;
+            gax::GaxPreconditions.CheckNotNull(folderName, nameof(folderName));
+            gax::TemplatedResourceName resourceName;
             if (s_template.TryParseName(folderName, out resourceName))
             {
                 result = new FolderName(resourceName[0]);
@@ -59,6 +60,12 @@ namespace Google.Api.Gax.ResourceNames
             }
         }
 
+        /// <summary>Formats the IDs into the string representation of the <see cref="FolderName"/>.</summary>
+        /// <param name="folderId">The <c>folder</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="FolderName"/>.</returns>
+        public static string Format(string folderId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId)));
+
         /// <summary>
         /// Constructs a new instance of the <see cref="FolderName"/> resource name class
         /// from its component parts.
@@ -66,7 +73,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <param name="folderId">The folder ID. Must not be <c>null</c>.</param>
         public FolderName(string folderId)
         {
-            FolderId = GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
+            FolderId = gax::GaxPreconditions.CheckNotNull(folderId, nameof(folderId));
         }
 
         /// <summary>
@@ -75,7 +82,7 @@ namespace Google.Api.Gax.ResourceNames
         public string FolderId { get; }
 
         /// <inheritdoc />
-        public ResourceNameKind Kind => ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
         public override string ToString() => s_template.Expand(FolderId);

--- a/Google.Api.Gax/ResourceNames/OrganizationName.cs
+++ b/Google.Api.Gax/ResourceNames/OrganizationName.cs
@@ -5,7 +5,8 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using System;
+using gax = Google.Api.Gax;
+using sys = System;
 
 namespace Google.Api.Gax.ResourceNames
 {
@@ -14,9 +15,9 @@ namespace Google.Api.Gax.ResourceNames
     /// While most resource names are generated on a per-API basis, many APIs use an organization resource, and it's
     /// useful to be able to pass values from one API to another.
     /// </summary>
-    public sealed partial class OrganizationName : IResourceName, IEquatable<OrganizationName>
+    public sealed partial class OrganizationName : gax::IResourceName, sys::IEquatable<OrganizationName>
     {
-        private static readonly PathTemplate s_template = new PathTemplate("organizations/{organization}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("organizations/{organization}");
 
         /// <summary>
         /// Parses the given organization resource name in string form into a new
@@ -26,8 +27,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns>The parsed <see cref="OrganizationName"/> if successful.</returns>
         public static OrganizationName Parse(string organizationName)
         {
-            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
-            TemplatedResourceName resourceName = s_template.ParseName(organizationName);
+            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(organizationName);
             return new OrganizationName(resourceName[0]);
         }
 
@@ -36,7 +37,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <see cref="OrganizationName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="organizationName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="organizationName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="organizationName">The organization resource name in string form. Must not be <c>null</c>.</param>
@@ -45,8 +46,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string organizationName, out OrganizationName result)
         {
-            GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
-            TemplatedResourceName resourceName;
+            gax::GaxPreconditions.CheckNotNull(organizationName, nameof(organizationName));
+            gax::TemplatedResourceName resourceName;
             if (s_template.TryParseName(organizationName, out resourceName))
             {
                 result = new OrganizationName(resourceName[0]);
@@ -59,6 +60,12 @@ namespace Google.Api.Gax.ResourceNames
             }
         }
 
+        /// <summary>Formats the IDs into the string representation of the <see cref="OrganizationName"/>.</summary>
+        /// <param name="organizationId">The <c>organization</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="OrganizationName"/>.</returns>
+        public static string Format(string organizationId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId)));
+
         /// <summary>
         /// Constructs a new instance of the <see cref="OrganizationName"/> resource name class
         /// from its component parts.
@@ -66,7 +73,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <param name="organizationId">The organization ID. Must not be <c>null</c>.</param>
         public OrganizationName(string organizationId)
         {
-            OrganizationId = GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
+            OrganizationId = gax::GaxPreconditions.CheckNotNull(organizationId, nameof(organizationId));
         }
 
         /// <summary>
@@ -75,7 +82,7 @@ namespace Google.Api.Gax.ResourceNames
         public string OrganizationId { get; }
 
         /// <inheritdoc />
-        public ResourceNameKind Kind => ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
         public override string ToString() => s_template.Expand(OrganizationId);

--- a/Google.Api.Gax/ResourceNames/ProjectName.cs
+++ b/Google.Api.Gax/ResourceNames/ProjectName.cs
@@ -5,7 +5,8 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using System;
+using gax = Google.Api.Gax;
+using sys = System;
 
 namespace Google.Api.Gax.ResourceNames
 {
@@ -14,9 +15,9 @@ namespace Google.Api.Gax.ResourceNames
     /// While most resource names are generated on a per-API basis, many APIs use a project resource, and it's
     /// useful to be able to pass values from one API to another.
     /// </summary>
-    public sealed partial class ProjectName : IResourceName, IEquatable<ProjectName>
+    public sealed partial class ProjectName : gax::IResourceName, sys::IEquatable<ProjectName>
     {
-        private static readonly PathTemplate s_template = new PathTemplate("projects/{project}");
+        private static readonly gax::PathTemplate s_template = new gax::PathTemplate("projects/{project}");
 
         /// <summary>
         /// Parses the given project resource name in string form into a new
@@ -26,8 +27,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns>The parsed <see cref="ProjectName"/> if successful.</returns>
         public static ProjectName Parse(string projectName)
         {
-            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            TemplatedResourceName resourceName = s_template.ParseName(projectName);
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName = s_template.ParseName(projectName);
             return new ProjectName(resourceName[0]);
         }
 
@@ -36,7 +37,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <see cref="ProjectName"/> instance.
         /// </summary>
         /// <remarks>
-        /// This method still throws <see cref="ArgumentNullException"/> if <paramref name="projectName"/> is null,
+        /// This method still throws <see cref="sys::ArgumentNullException"/> if <paramref name="projectName"/> is null,
         /// as this would usually indicate a programming error rather than a data error.
         /// </remarks>
         /// <param name="projectName">The project resource name in string form. Must not be <c>null</c>.</param>
@@ -45,8 +46,8 @@ namespace Google.Api.Gax.ResourceNames
         /// <returns><c>true</c> if the name was parsed successfully; <c>false</c> otherwise.</returns>
         public static bool TryParse(string projectName, out ProjectName result)
         {
-            GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
-            TemplatedResourceName resourceName;
+            gax::GaxPreconditions.CheckNotNull(projectName, nameof(projectName));
+            gax::TemplatedResourceName resourceName;
             if (s_template.TryParseName(projectName, out resourceName))
             {
                 result = new ProjectName(resourceName[0]);
@@ -59,6 +60,12 @@ namespace Google.Api.Gax.ResourceNames
             }
         }
 
+        /// <summary>Formats the IDs into the string representation of the <see cref="ProjectName"/>.</summary>
+        /// <param name="projectId">The <c>project</c> ID. Must not be <c>null</c>.</param>
+        /// <returns>The string representation of the <see cref="ProjectName"/>.</returns>
+        public static string Format(string projectId) =>
+            s_template.Expand(gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId)));
+
         /// <summary>
         /// Constructs a new instance of the <see cref="ProjectName"/> resource name class
         /// from its component parts.
@@ -66,7 +73,7 @@ namespace Google.Api.Gax.ResourceNames
         /// <param name="projectId">The project ID. Must not be <c>null</c>.</param>
         public ProjectName(string projectId)
         {
-            ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+            ProjectId = gax::GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
         }
 
         /// <summary>
@@ -75,7 +82,7 @@ namespace Google.Api.Gax.ResourceNames
         public string ProjectId { get; }
 
         /// <inheritdoc />
-        public ResourceNameKind Kind => ResourceNameKind.Simple;
+        public gax::ResourceNameKind Kind => gax::ResourceNameKind.Simple;
 
         /// <inheritdoc />
         public override string ToString() => s_template.Expand(ProjectId);


### PR DESCRIPTION
The class bodies are now copy/pasted from the generator, complete with namespace alias usage, for simplicity.
BillingAccountName needs special effort, however, as the generator (in logging, anyway) creates BillingName rather than BillingAccountName, and we have an historical mistake in terms of parameter names (BillingAccountName instead of billingAccountName)