### PR TITLE
Provide support for Cloud Run as a platform

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -5,10 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Api.Gax.Grpc.Tests
@@ -62,6 +59,22 @@ namespace Google.Api.Gax.Grpc.Tests
                 { "project_id", "FakeProjectId" },
                 { "module_id", "FakeService" },
                 { "version_id", "FakeVersion" }
+            }, resource.Labels);
+        }
+
+        [Fact]
+        public void CloudRunPlatform()
+        {
+            var details = new CloudRunPlatformDetails("json", "projectId", "location", "service", "revision", "configuration");
+            var resource = MonitoredResourceBuilder.FromPlatform(new Platform(details));
+            Assert.Equal("cloud_run_revision", resource.Type);
+            Assert.Equal(new Dictionary<string, string>
+            {
+                { "project_id", "projectId" },
+                { "location", "location" },
+                { "service_name", "service" },
+                { "revision_name", "revision" },
+                { "configuration_name", "configuration" }
             }, resource.Labels);
         }
 

--- a/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
+++ b/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
@@ -98,6 +98,21 @@ namespace Google.Api.Gax.Grpc
                             { "zone", gke.Location }
                         }
                     };
+                case PlatformType.CloudRun:
+                    var cloudRun = platform.CloudRunDetails;
+                    return new MonitoredResource
+                    {
+                        Type = "cloud_run_revision",
+                        Labels =
+                        {
+                            { "project_id", cloudRun.ProjectId },
+                            { "service_name", cloudRun.ServiceName },
+                            { "revision_name", cloudRun.RevisionName },
+                            { "location", cloudRun.Location },
+                            { "configuration_name", cloudRun.ConfigurationName }
+                        }
+                    };
+
                 default:
                     // This isn't great, but is better than throwing an exception.
                     return GlobalResource;

--- a/Google.Api.Gax.Tests/PlatformTest.cs
+++ b/Google.Api.Gax.Tests/PlatformTest.cs
@@ -1,6 +1,11 @@
-﻿using Newtonsoft.Json.Linq;
+﻿/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -54,6 +59,29 @@ namespace Google.Api.Gax.Tests
             var metadataJson = "{'project':{'projectId':'FakeProjectId'},'instance':{'id':'123','zone':'FakeLocation'}}";
             var gce = new GcePlatformDetails(metadataJson, "FakeProjectId", "123", "FakeLocation");
             Assert.Throws<InvalidOperationException>(() => gce.Location);
+        }
+
+        [Fact]
+        public void CloudRun_Valid()
+        {
+            var details = new CloudRunPlatformDetails("json", "project", "location", "service", "revision", "configuration");
+            Assert.Equal("json", details.MetadataJson);
+            Assert.Equal("project", details.ProjectId);
+            Assert.Equal("location", details.Location);
+            Assert.Equal("service", details.ServiceName);
+            Assert.Equal("revision", details.RevisionName);
+            Assert.Equal("configuration", details.ConfigurationName);
+        }
+
+        [Fact]
+        public void CloudRun_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails(null, "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails("", null, "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails("", "", null, "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails("", "", "", null, "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails("", "", "", "", null, ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunPlatformDetails("", "", "", "", "", null));
         }
 
         [Fact]


### PR DESCRIPTION
This is sufficiently different from GCE that it makes sense to break it out. It's possible that KNative apps running in different environments will have *similar* details, but they may not have a project ID for example... so for now, let's be specific. We canalways add a generic KNative type later.