### PR TITLE
Use the region instead of zone in Cloud Run resources

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -65,13 +65,14 @@ namespace Google.Api.Gax.Grpc.Tests
         [Fact]
         public void CloudRunPlatform()
         {
-            var details = new CloudRunPlatformDetails("json", "projectId", "location", "service", "revision", "configuration");
+            var details = new CloudRunPlatformDetails("json", "projectId", "us-central1-1", "service", "revision", "configuration");
             var resource = MonitoredResourceBuilder.FromPlatform(new Platform(details));
             Assert.Equal("cloud_run_revision", resource.Type);
             Assert.Equal(new Dictionary<string, string>
             {
                 { "project_id", "projectId" },
-                { "location", "location" },
+                // Note this is the region, not the zone
+                { "location", "us-central1" },
                 { "service_name", "service" },
                 { "revision_name", "revision" },
                 { "configuration_name", "configuration" }

--- a/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
+++ b/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
@@ -108,7 +108,7 @@ namespace Google.Api.Gax.Grpc
                             { "project_id", cloudRun.ProjectId },
                             { "service_name", cloudRun.ServiceName },
                             { "revision_name", cloudRun.RevisionName },
-                            { "location", cloudRun.Location },
+                            { "location", cloudRun.Region },
                             { "configuration_name", cloudRun.ConfigurationName }
                         }
                     };

--- a/Google.Api.Gax.Tests/PlatformTest.cs
+++ b/Google.Api.Gax.Tests/PlatformTest.cs
@@ -64,10 +64,11 @@ namespace Google.Api.Gax.Tests
         [Fact]
         public void CloudRun_Valid()
         {
-            var details = new CloudRunPlatformDetails("json", "project", "location", "service", "revision", "configuration");
+            var details = new CloudRunPlatformDetails("json", "project", "us-central1-1", "service", "revision", "configuration");
             Assert.Equal("json", details.MetadataJson);
             Assert.Equal("project", details.ProjectId);
-            Assert.Equal("location", details.Location);
+            Assert.Equal("us-central1-1", details.Zone);
+            Assert.Equal("us-central1", details.Region);
             Assert.Equal("service", details.ServiceName);
             Assert.Equal("revision", details.RevisionName);
             Assert.Equal("configuration", details.ConfigurationName);
@@ -246,7 +247,7 @@ namespace Google.Api.Gax.Tests
         [Fact]
         public void Project_CloudRun()
         {
-            var details = new CloudRunPlatformDetails("json", "cr-project", "location", "service", "revision", "configuration");
+            var details = new CloudRunPlatformDetails("json", "cr-project", "us-central1-1", "service", "revision", "configuration");
             var platform = new Platform(details);
             Assert.Equal("cr-project", platform.ProjectId);
         }

--- a/Google.Api.Gax/CloudRunPlatformDetails.cs
+++ b/Google.Api.Gax/CloudRunPlatformDetails.cs
@@ -7,6 +7,7 @@
 
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq;
 
 namespace Google.Api.Gax
 {
@@ -52,8 +53,8 @@ namespace Google.Api.Gax
             {
                 return null;
             }
-            string location = zoneResourceName[1];
-            return new CloudRunPlatformDetails(metadataJson, projectId, location, serviceName, revisionName, configurationName);
+            string zone = zoneResourceName[1];
+            return new CloudRunPlatformDetails(metadataJson, projectId, zone, serviceName, revisionName, configurationName);
         }
 
         /// <summary>
@@ -62,17 +63,18 @@ namespace Google.Api.Gax
         /// <param name="metadataJson">JSON metadata, normally retrieved from the GCE metadata server.
         /// Must not be <c>null</c>.</param>
         /// <param name="projectId">The project ID. Must not be null.</param>
-        /// <param name="location">The location in which the service code is running. Must not be null.</param>
+        /// <param name="zone">The zone in which the service code is running. Must not be null.</param>
         /// <param name="serviceName">The name of the service. Must not be null.</param>
         /// <param name="revisionName">The name of the revision. Must not be null.</param>
         /// <param name="configurationName">The name of the configuration. Must not be null.</param>
         public CloudRunPlatformDetails(
-            string metadataJson, string projectId, string location,
+            string metadataJson, string projectId, string zone,
             string serviceName, string revisionName, string configurationName)
         {
             MetadataJson = GaxPreconditions.CheckNotNull(metadataJson, nameof(metadataJson));
             ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
-            Location = GaxPreconditions.CheckNotNull(location, nameof(location));
+            Zone = GaxPreconditions.CheckNotNull(zone, nameof(zone));
+            Region = string.Join("-", Zone.Split('-').Take(2));
             ServiceName = GaxPreconditions.CheckNotNull(serviceName, nameof(serviceName));
             RevisionName = GaxPreconditions.CheckNotNull(revisionName, nameof(revisionName));
             ConfigurationName = GaxPreconditions.CheckNotNull(configurationName, nameof(configurationName));
@@ -89,9 +91,15 @@ namespace Google.Api.Gax
         public string ProjectId { get; }
 
         /// <summary>
-        /// The location, e.g. "us-central1". This is never null.
+        /// The zone of the service, e.g. "us-central1-1". This is never null.
         /// </summary>
-        public string Location { get; }
+        public string Zone { get; }
+        
+        /// <summary>
+        /// The region part of the zone. For example, a zone of "us-central1-1" has a region 
+        /// of "us-central1".
+        /// </summary>
+        public string Region { get; }
 
         /// <summary>
         /// The name of the Cloud Run service being run. This is never null.
@@ -110,7 +118,7 @@ namespace Google.Api.Gax
 
         /// <inheritdoc/>
         public override string ToString() =>
-            $"[Cloud Run: ProjectId='{ProjectId}', Location='{Location}', " +
+            $"[Cloud Run: ProjectId='{ProjectId}', Zone='{Zone}', " +
             $"ServiceName='{ServiceName}', RevisionName='{RevisionName}', ConfigurationName='{ConfigurationName}']";
     }
 


### PR DESCRIPTION
This mimics what the Cloud Run console does.

Fixes #332.