### PR TITLE
Add a ServiceEndpoint(string) constructor

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ServiceEndpointTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ServiceEndpointTest.cs
@@ -12,10 +12,25 @@ namespace Google.Api.Gax.Grpc.Tests
 {
     public class ServiceEndpointTest
     {
+        [Fact]
+        public void Construction_Invalid_HostOnly()
+        {
+            Assert.Throws<ArgumentException>(() => new ServiceEndpoint(""));
+            Assert.Throws<ArgumentNullException>(() => new ServiceEndpoint(null));
+        }
+
+        [Fact]
+        public void Construction_Valid_HostOnly()
+        {
+            var settings = new ServiceEndpoint("foo");
+            Assert.Equal("foo", settings.Host);
+            Assert.Equal(443, settings.Port);
+        }
+
         [Theory]
         [InlineData("foo", 1)]
         [InlineData("bar", 65535)]
-        public void Construction_Valid(string host, int port)
+        public void Construction_Valid_HostAndPort(string host, int port)
         {
             var settings = new ServiceEndpoint(host, port);
             Assert.Equal(host, settings.Host);
@@ -28,7 +43,7 @@ namespace Google.Api.Gax.Grpc.Tests
         [InlineData("host", 0, typeof(ArgumentOutOfRangeException))]
         [InlineData("host", -1, typeof(ArgumentOutOfRangeException))]
         [InlineData("host", 65536, typeof(ArgumentOutOfRangeException))]
-        public void Construction_Invalid(string host, int port, global::System.Type exceptionType)
+        public void Construction_Invalid_HostAndPort(string host, int port, global::System.Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new ServiceEndpoint(host, port));
         }

--- a/Google.Api.Gax.Grpc/ServiceEndpoint.cs
+++ b/Google.Api.Gax.Grpc/ServiceEndpoint.cs
@@ -17,6 +17,8 @@ namespace Google.Api.Gax.Grpc
     /// </summary>
     public sealed class ServiceEndpoint : IEquatable<ServiceEndpoint>
     {
+        private const int HttpsPort = 443;
+        
         /// <summary>
         /// The host name to connect to. Never null or empty.
         /// </summary>
@@ -26,6 +28,16 @@ namespace Google.Api.Gax.Grpc
         /// The port to connect to, in the range 1 to 65535 inclusive.
         /// </summary>
         public int Port { get; }
+
+        /// <summary>
+        /// Creates a new endpoint with the given host, using a port of 443.
+        /// </summary>
+        /// <param name="host">The host name to connect to. Must not be null or empty.</param>
+        public ServiceEndpoint(string host)
+        {
+            Host = GaxPreconditions.CheckNotNullOrEmpty(host, nameof(host));
+            Port = HttpsPort;
+        }
 
         /// <summary>
         /// Creates a new endpoint with the given host and port.
@@ -97,7 +109,7 @@ namespace Google.Api.Gax.Grpc
             if (colonIndex == -1)
             {
                 host = text;
-                port = 443;
+                port = HttpsPort;
             }
             else
             {


### PR DESCRIPTION
Most of the time users will only want to specify a host - let's make that easy.

Fixes #339.