### PR TITLE
Improve environment detection

### DIFF
--- a/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
+++ b/Google.Api.Gax.Tests/VersionHeaderBuilderTest.cs
@@ -18,18 +18,22 @@ namespace Google.Api.Gax.Tests
             Assert.Equal("", new VersionHeaderBuilder().ToString());
         }
 
-        // We can't test the version header on the full framework or on .NET Core non-1.0, as
-        // the entry assembly's target framework isn't present or is "wrong". There's no simple,
-        // portable, reliable way to get the framework version at runtime. Benchmark.NET does a reasonable
-        // job, but it only targets netstandard2.0 which makes things a lot simpler.
-#if NETCOREAPP1_0
-        [Fact]
-        public void AppendDotNetEnvironment_AddsDotNetEntry()
+        // This theory will only have a single test case per framework, but it's the simplest way of expressing what we mean.
+        [Theory]
+#if NETCOREAPP1_0 || NETCOREAPP2_1
+        // In test frameworks, .NET Core is always reported as 1.0.0.
+        [InlineData("1.0.0")]
+#elif NET452
+        // This will be the runtime version, which will always be 4.0.x, but we don't know x.
+        [InlineData("4.0.")]
+#else
+#error Unsupported test frameowrk
+#endif
+        public void AppendDotNetEnvironment_AddsDotNetEntry(string expectedVersionPrefix)
         {
             string versionHeader = new VersionHeaderBuilder().AppendDotNetEnvironment().ToString();
-            Assert.StartsWith("gl-dotnet/1.0", versionHeader);
+            Assert.StartsWith($"gl-dotnet/{expectedVersionPrefix}", versionHeader);
         }
-#endif
 
         [Theory]
         [InlineData("foo", "1.2.3-bar", "foo/1.2.3-bar")]


### PR DESCRIPTION
Fixes #312 (as far as we need)

This uses System.Environment.Version when we can, if there's no entry assembly. That affects code running in tests, where previously we reported no version for .NET Framework tests; we now report 4.0.x (for a suitable value of x).

It's not 100% correct when running in test environments (in .NET Core we always get 1.0.0) , but it's probably the best balance between simplicity and correctness.

Results of a small test app:

Console application
netcoreapp1.1: 1.1.0
netcoreapp2.0: 2.0.0
netcoreapp2.1: 2.1.0
netcoreapp3.0: 3.0.0
net45: 4.5.0
net46: 4.6.0
net47: 4.7.0

Unit tests
netcoreapp2.1: 1.0.0
netcoreapp3.0: 1.0.0
net452: 4.0.30319
net46: 4.0.30319
net47: 4.0.30319