### PR TITLE
Use the version header builder in the REST core libraries within ClientBuilderBase

### DIFF
--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -20,7 +20,7 @@
 
     <PackageReference Include="Grpc.Auth" Version="[1.22.0, 2.0)" />
     <PackageReference Include="Grpc.Core" Version="[1.22.0, 2.0)" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.2" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.41.0" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/Google.Api.Gax.Rest.Tests/UserAgentHelperTest.cs
+++ b/Google.Api.Gax.Rest.Tests/UserAgentHelperTest.cs
@@ -19,6 +19,7 @@ namespace Google.Api.Gax.Rest.Tests
             Assert.StartsWith("gcloud-dotnet/1.0.0", UserAgentHelper.GetDefaultUserAgent(typeof(UserAgentHelperTest)));
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Fact]
         public void ModifyHeader_NewHeader()
         {
@@ -47,4 +48,5 @@ namespace Google.Api.Gax.Rest.Tests
             Assert.Contains("gccl/", values[0]);
         }
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/Google.Api.Gax.Rest/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Rest/ClientBuilderBase.cs
@@ -92,26 +92,30 @@ namespace Google.Api.Gax.Rest
         /// </summary>
         /// <returns>An initializer for the service.</returns>
         protected virtual BaseClientService.Initializer CreateServiceInitializer() =>
-            new BaseClientService.Initializer
-            {
-                HttpClientInitializer = GetHttpClientInitializer(),
-                ApiKey = ApiKey,
-                ApplicationName = ApplicationName ?? GetDefaultApplicationName(),
-                BaseUri = BaseUri
-            };
+            CreateServiceInitializerImpl(GetHttpClientInitializer());
 
         /// <summary>
         /// Creates an initializer for the service asynchronously. This method does not perform any validation.
         /// </summary>
         /// <returns>An initializer for the service.</returns>
         protected virtual async Task<BaseClientService.Initializer> CreateServiceInitializerAsync(CancellationToken cancellationToken) =>
-            new BaseClientService.Initializer
+            CreateServiceInitializerImpl(await GetHttpClientInitializerAsync(cancellationToken).ConfigureAwait(false));
+
+        private BaseClientService.Initializer CreateServiceInitializerImpl(IConfigurableHttpClientInitializer clientInitializer)
+        {
+            var initializer = new BaseClientService.Initializer
             {
-                HttpClientInitializer = await GetHttpClientInitializerAsync(cancellationToken).ConfigureAwait(false),
+                HttpClientInitializer = clientInitializer,
                 ApiKey = ApiKey,
                 ApplicationName = ApplicationName ?? GetDefaultApplicationName(),
                 BaseUri = BaseUri
             };
+            initializer.VersionHeaderBuilder
+                .AppendAssemblyVersion("gccl", GetType())
+                .AppendAssemblyVersion("gax", typeof(ClientBuilderBase<TClient>));
+
+            return initializer;
+        }
 
         /// <summary>
         /// Obtains credentials synchronously. Override this method in a concrete builder type if more

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.2" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.41.0" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/Google.Api.Gax.Rest/UserAgentHelper.cs
+++ b/Google.Api.Gax.Rest/UserAgentHelper.cs
@@ -27,6 +27,7 @@ namespace Google.Api.Gax.Rest
         /// </summary>
         /// <param name="type">The type to extract the version number from.</param>
         /// <returns>A request modifier.</returns>
+        [Obsolete("Use BaseClientService.Initializer.VersionHeaderBuilder instead")]
         public static Action<HttpRequestMessage> CreateRequestModifier(Type type)
         {
             var value = new VersionHeaderBuilder()

--- a/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -13,6 +13,10 @@ using System.Runtime.Versioning;
 
 namespace Google.Api.Gax
 {
+    // Note: this code is now duplicated in Google.Apis.
+    // The duplication is annoying, but hard to avoid due to dependencies.
+    // Any changes should be made in both places.
+
     /// <summary>
     /// Helps build version strings for the x-goog-api-client header.
     /// The value is a space-separated list of name/value pairs, where the value
@@ -39,8 +43,8 @@ namespace Google.Api.Gax
             GaxPreconditions.CheckNotNull(name, nameof(name));
             GaxPreconditions.CheckNotNull(version, nameof(version));
             // Names can't be empty, but versions can. (We use the empty string to indicate an unknown version.)
-            GaxPreconditions.CheckArgument(name.Length > 0 && !name.Contains(' ') && !name.Contains('/'), nameof(name), $"Invalid name: {name}");
-            GaxPreconditions.CheckArgument(!version.Contains(' ') && !version.Contains('/'), nameof(version), $"Invalid version: {version}");
+            GaxPreconditions.CheckArgument(name.Length > 0 && !name.Contains(" ") && !name.Contains("/"), nameof(name), $"Invalid name: {name}");
+            GaxPreconditions.CheckArgument(!version.Contains(" ") && !version.Contains("/"), nameof(version), $"Invalid version: {version}");
             GaxPreconditions.CheckArgument(!_names.Contains(name), nameof(name), "Names in version headers must be unique");
             _names.Add(name);
             _values.Add(version);


### PR DESCRIPTION
Now that the core libraries support x-goog-api-client, we don't want or need the UserAgentHelper code, so deprecate it.

Note: this commit won't build on its own; we need to wait for a new version of Google.Apis to be published, then depend on that.