### PR TITLE
Use gke_container instead of container for GKE monitored resources

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -122,7 +122,7 @@ namespace Google.Api.Gax.Grpc.Tests
             };
             var platform = new Platform(GkePlatformDetails.TryLoad(metadataJson, kubernetesData));
             var resource = MonitoredResourceBuilder.FromPlatform(platform);
-            Assert.Equal("container", resource.Type);
+            Assert.Equal("gke_container", resource.Type);
             Assert.Equal(new Dictionary<string, string>
             {
                 { "project_id", "FakeProjectId" },

--- a/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
+++ b/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
@@ -86,7 +86,7 @@ namespace Google.Api.Gax.Grpc
                     var gke = platform.GkeDetails;
                     return new MonitoredResource
                     {
-                        Type = "container",
+                        Type = "gke_container",
                         Labels =
                         {
                             { "project_id", gke.ProjectId },


### PR DESCRIPTION
Fixes #233.

Note that this requires additional changes in Google.Cloud.Diagnostics.AspNetCore and Google.Cloud.Diagnostics.Common; new packages should be pushed out at the same time.