### PR TITLE
Replace the very specific WithVersionHeader method with WithMergedBaseCallSettings

### DIFF
--- a/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
@@ -70,10 +70,11 @@ namespace Google.Api.Gax.Grpc
             return _call(effectiveCallSettings);
         }
 
-        internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithVersionHeader(string versionHeader) =>
-            new ApiBidirectionalStreamingCall<TRequest, TResponse>(
-                _call,
-                CallSettings.FromHeader(VersionHeaderBuilder.HeaderName, versionHeader).MergedWith(BaseCallSettings),
-                StreamingSettings);
+        /// <summary>
+        /// Returns a new API call using the original base call settings merged with <paramref name="callSettings"/>.
+        /// Where there's a conflict, the original base call settings have priority.
+        /// </summary>
+        internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
+            new ApiBidirectionalStreamingCall<TRequest, TResponse>(_call, callSettings.MergedWith(BaseCallSettings), StreamingSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ApiCall.cs
+++ b/Google.Api.Gax.Grpc/ApiCall.cs
@@ -144,15 +144,12 @@ namespace Google.Api.Gax.Grpc
         public TResponse Sync(TRequest request, CallSettings perCallCallSettings) =>
             _syncCall(request, BaseCallSettings.MergedWith(perCallCallSettings));
 
-        internal ApiCall<TRequest, TResponse> WithVersionHeader(string versionHeader) =>
-            // TODO: Check that this is what we want. It allows call settings to remove our
-            // version header. The caller can always do this manually anyway, of course, so
-            // I'm tempted to leave it...
-            new ApiCall<TRequest, TResponse>(
-                _asyncCall,
-                _syncCall,
-                CallSettings.FromHeader(VersionHeaderBuilder.HeaderName, versionHeader)
-                    .MergedWith(BaseCallSettings));
+        /// <summary>
+        /// Returns a new API call using the original base call settings merged with <paramref name="callSettings"/>.
+        /// Where there's a conflict, the original base call settings have priority.
+        /// </summary>
+        internal ApiCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
+            new ApiCall<TRequest, TResponse>(_asyncCall, _syncCall, callSettings.MergedWith(BaseCallSettings));
 
         internal ApiCall<TRequest, TResponse> WithRetry(IClock clock, IScheduler scheduler) =>
             new ApiCall<TRequest, TResponse>(

--- a/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
@@ -72,11 +72,12 @@ namespace Google.Api.Gax.Grpc
         public AsyncServerStreamingCall<TResponse> Call(TRequest request, CallSettings perCallCallSettings) =>
             _syncCall(request, BaseCallSettings.MergedWith(perCallCallSettings));
 
-        internal ApiServerStreamingCall<TRequest, TResponse> WithVersionHeader(string versionHeader) =>
-            new ApiServerStreamingCall<TRequest, TResponse>(
-                _asyncCall,
-                _syncCall,
-                CallSettings.FromHeader(VersionHeaderBuilder.HeaderName, versionHeader).MergedWith(BaseCallSettings));
+        /// <summary>
+        /// Returns a new API call using the original base call settings merged with <paramref name="callSettings"/>.
+        /// Where there's a conflict, the original base call settings have priority.
+        /// </summary>
+        internal ApiServerStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
+            new ApiServerStreamingCall<TRequest, TResponse>(_asyncCall, _syncCall, callSettings.MergedWith(BaseCallSettings));
 
         internal ApiServerStreamingCall<TRequest, TResponse> WithRetry(IClock clock, IScheduler scheduler) =>
             new ApiServerStreamingCall<TRequest, TResponse>(

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -17,7 +17,7 @@ namespace Google.Api.Gax.Grpc
     public class ClientHelper
     {
         private readonly CallSettings _clientCallSettings;
-        private readonly string _versionHeader;
+        private readonly CallSettings _versionCallSettings;
 
         /// <summary>
         /// Constructs a helper from the given settings.
@@ -30,7 +30,7 @@ namespace Google.Api.Gax.Grpc
             Clock = settings.Clock ?? SystemClock.Instance;
             Scheduler = settings.Scheduler ?? SystemScheduler.Instance;
             _clientCallSettings = settings.CallSettings;
-            _versionHeader = settings.VersionHeader;
+            _versionCallSettings = CallSettings.FromHeader(VersionHeaderBuilder.HeaderName, settings.VersionHeader);
         }
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Google.Api.Gax.Grpc
             // I.e. Version header is added first, then retry is performed.
             return ApiCall.Create(asyncGrpcCall, syncGrpcCall, baseCallSettings, Clock)
                 .WithRetry(Clock, Scheduler)
-                .WithVersionHeader(_versionHeader);
+                .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Google.Api.Gax.Grpc
             // I.e. Version header is added first, then retry is performed.
             return ApiServerStreamingCall.Create(grpcCall, baseCallSettings, Clock)
                 .WithRetry(Clock, Scheduler)
-                .WithVersionHeader(_versionHeader);
+                .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Google.Api.Gax.Grpc
         {
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiBidirectionalStreamingCall.Create(grpcCall, baseCallSettings, streamingSettings, Clock)
-                .WithVersionHeader(_versionHeader);
+                .WithMergedBaseCallSettings(_versionCallSettings);
         }
     }
 }


### PR DESCRIPTION
WithVersionHeader was only used in ClientHelper, which can easily migrate to the new call.