### PR TITLE
Update GAX version (other than for common protos)

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.Production.xml" />
 
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>2.0.0-alpha00</Version>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>2.10.0</Version>
+    <Version>3.0.0-alpha00</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is the start of the "next major version" work described here:
https://googleapis.github.io/google-cloud-dotnet/docs/major-version.html