### PR TITLE
Upgrade to gRPC 2.x and move Microsoft.Bcl.AsyncInterfaces

### DIFF
--- a/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
+++ b/Google.Api.Gax.Grpc.Gcp/Google.Api.Gax.Grpc.Gcp.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
     <PackageReference Include="Grpc.Gcp" Version="1.1.1" />
-    <PackageReference Include="Grpc.Core" Version="[1.22.0,2.0)" />
+    <PackageReference Include="Grpc.Core" Version="2.24.0" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>

--- a/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
+++ b/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
     <ProjectReference Include="..\Google.Api.Gax.Grpc.Testing\Google.Api.Gax.Grpc.Testing.csproj" />
   </ItemGroup>

--- a/Google.Api.Gax.Grpc.Tests/PageStreamingTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/PageStreamingTest.cs
@@ -166,7 +166,7 @@ namespace Google.Api.Gax.Grpc.Tests
             var server = new FakeServer(pagedResource);
             var request = new PageStreamingRequest { PageSize = 0 };
             var paged = server.PagedAsync(null, null, request);
-            Assert.Equal(pagedResource.Resource, await paged.AsRawResponses().Select(x => x.ToArray()).ToArray());
+            Assert.Equal(pagedResource.Resource, await paged.AsRawResponses().Select(x => x.ToArray()).ToArrayAsync());
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace Google.Api.Gax.Grpc.Tests
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest { PageSize = 0, PageToken = "1:0" };
             var paged = server.PagedAsync(null, null, request);
-            Assert.Equal(s_resourceA.Resource.Skip(1), await paged.AsRawResponses().Select(x => x.ToArray()).ToArray());
+            Assert.Equal(s_resourceA.Resource.Skip(1), await paged.AsRawResponses().Select(x => x.ToArray()).ToArrayAsync());
         }
 
         public static MatrixTheoryData<PagedResource, int> s_flatten = MatrixTheoryData.Create(
@@ -206,7 +206,7 @@ namespace Google.Api.Gax.Grpc.Tests
             var server = new FakeServer(pagedResource);
             var request = new PageStreamingRequest { PageSize = pageSize };
             var paged = server.PagedAsync(null, null, request);
-            Assert.Equal(pagedResource.All, await paged.ToArray());
+            Assert.Equal(pagedResource.All, await paged.ToArrayAsync());
         }
 
         public static MatrixTheoryData<PagedResource, int> s_fixedPageSize = MatrixTheoryData.Create(
@@ -274,12 +274,12 @@ namespace Google.Api.Gax.Grpc.Tests
             var request = new PageStreamingRequest { PageSize = 0 };
             var paged = server.PagedAsync(null, null, request);
             // Natural pages
-            Assert.Equal(1, await paged.AsRawResponses().Count());
-            var page1 = await paged.AsRawResponses().First();
+            Assert.Equal(1, await paged.AsRawResponses().CountAsync());
+            var page1 = await paged.AsRawResponses().FirstAsync();
             Assert.Empty(page1);
             Assert.Equal("", page1.NextPageToken);
             // Unnatural things
-            Assert.Empty(await paged.ToArray());
+            Assert.Empty(await paged.ToArrayAsync());
             Assert.Empty(await paged.ReadPageAsync(1));
         }
 

--- a/Google.Api.Gax.Grpc.Tests/RetryTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/RetryTest.cs
@@ -335,7 +335,7 @@ namespace Google.Api.Gax.Grpc.Tests
                 CallTimes.Add(_scheduler.Clock.GetCurrentDateTimeUtc());
                 CallSettingsReceived.Add(callSettings);
                 var responses = new[] { new SimpleResponse { Name = request.Name } };
-                var responseStream = new AsyncStreamAdapter<SimpleResponse>(responses.ToAsyncEnumerable().GetEnumerator());
+                var responseStream = new AsyncStreamAdapter<SimpleResponse>(responses.ToAsyncEnumerable().GetAsyncEnumerator());
                 var responseHeaders = Task.Run(async () =>
                 {
                     await _scheduler.Delay(_callDuration, callSettings.CancellationToken.GetValueOrDefault());

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -18,8 +18,8 @@
     <ProjectReference Include="..\Google.Api.CommonProtos\Google.Api.CommonProtos.csproj" />
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Grpc.Auth" Version="[1.22.0, 2.0)" />
-    <PackageReference Include="Grpc.Core" Version="[1.22.0, 2.0)" />
+    <PackageReference Include="Grpc.Auth" Version="2.24.0" />
+    <PackageReference Include="Grpc.Core" Version="2.24.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.41.1" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />

--- a/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
+++ b/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Rest\Google.Api.Gax.Rest.csproj" />
     <ProjectReference Include="..\Google.Api.Gax.Testing\Google.Api.Gax.Testing.csproj" />
   </ItemGroup>

--- a/Google.Api.Gax.Rest.Tests/PageStreamingTest.cs
+++ b/Google.Api.Gax.Rest.Tests/PageStreamingTest.cs
@@ -170,7 +170,7 @@ namespace Google.Api.Gax.Rest
             var server = new FakeServer(pagedResource);
             var request = new PageStreamingRequest(server) { PageSize = 0 };
             var paged = server.PagedAsync(request);
-            Assert.Equal(pagedResource.Resource, await paged.AsRawResponses().Select(x => x.Items.ToArray()).ToArray());
+            Assert.Equal(pagedResource.Resource, await paged.AsRawResponses().Select(x => x.Items.ToArray()).ToArrayAsync());
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace Google.Api.Gax.Rest
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest(server) { PageSize = 0, PageToken = "1:0" };
             var paged = server.PagedAsync(request);
-            Assert.Equal(s_resourceA.Resource.Skip(1), await paged.AsRawResponses().Select(x => x.Items.ToArray()).ToArray());
+            Assert.Equal(s_resourceA.Resource.Skip(1), await paged.AsRawResponses().Select(x => x.Items.ToArray()).ToArrayAsync());
         }
 
         public static MatrixTheoryData<PagedResource, int> s_flatten = MatrixTheoryData.Create(
@@ -210,7 +210,7 @@ namespace Google.Api.Gax.Rest
             var server = new FakeServer(pagedResource);
             var request = new PageStreamingRequest(server) { PageSize = pageSize };
             var paged = server.PagedAsync(request);
-            Assert.Equal(pagedResource.All, await paged.ToArray());
+            Assert.Equal(pagedResource.All, await paged.ToArrayAsync());
         }
 
         public static MatrixTheoryData<PagedResource, int> s_fixedPageSize = MatrixTheoryData.Create(
@@ -278,12 +278,12 @@ namespace Google.Api.Gax.Rest
             var request = new PageStreamingRequest(server) { PageSize = 0 };
             var paged = server.PagedAsync(request);
             // Natural pages
-            Assert.Equal(1, await paged.AsRawResponses().Count());
-            var page1 = await paged.AsRawResponses().First();
+            Assert.Equal(1, await paged.AsRawResponses().CountAsync());
+            var page1 = await paged.AsRawResponses().FirstAsync();
             Assert.Null(page1.Items);
             Assert.Null(page1.NextPageToken);
             // Unnatural things
-            Assert.Empty(await paged.ToArray());
+            Assert.Empty(await paged.ToArrayAsync());
             Assert.Empty(await paged.ReadPageAsync(1));
         }
 

--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <!-- Packaging information -->
@@ -14,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Interactive.Async" Version="[3.2.0,4.0)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />

--- a/Google.Api.Gax/PagedAsyncEnumerable.cs
+++ b/Google.Api.Gax/PagedAsyncEnumerable.cs
@@ -54,7 +54,7 @@ namespace Google.Api.Gax
         }
 
         /// <inheritdoc />
-        public virtual IAsyncEnumerator<TResource> GetEnumerator()
+        public virtual IAsyncEnumerator<TResource> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This is mostly straightforward, but there are a few points to note:

- Without updating to .NET Core 3.0 SDK, we can't use async yield return, so we still have significant implementation code
- The AsyncStreamAdapter doesn't handle cancellation in an ideal way right now; that's probably okay for testing code, but we might need to look at it again.

cc @amanda-tarafa (feel free to review as well, but I suspect only one person needs to look through the async enumerator implementation; there's no *policy* decision here)