### PR TITLE
DO NOT MERGE: Prototype of "how to depend just on Grpc.Core.Api"

### DIFF
--- a/Google.Api.Gax.Grpc/ChannelFactory.cs
+++ b/Google.Api.Gax.Grpc/ChannelFactory.cs
@@ -1,0 +1,21 @@
+﻿/*
+ * Copyright 2019 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+using Grpc.Core;
+
+namespace Google.Api.Gax.Grpc
+{
+    // TODO: Make this an abstract class instead of a delegate?
+
+    /// <summary>
+    /// Creates a channel for the given endpoint, with the given credentials and options.
+    /// </summary>
+    /// <param name="endpoint">The endpoint to connect to. Must not be null.</param>
+    /// <param name="credentials">Credentials for the channel. Must not be null.</param>
+    /// <param name="options">Options for the channel. Must not be null.</param>
+    /// <returns>A channel for the given endpoint.</returns>
+    public delegate ChannelBase ChannelFactory(ServiceEndpoint endpoint, ChannelCredentials credentials, GrpcChannelOptions options);
+}

--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -22,11 +22,8 @@ namespace Google.Api.Gax.Grpc
     /// <typeparam name="TClient">The type of client created by this builder.</typeparam>
     public abstract class ClientBuilderBase<TClient>
     {
-        private static readonly IReadOnlyList<ChannelOption> s_defaultChannelPoolOptions = new List<ChannelOption>
-        {
-            GrpcChannelOptions.OneMinuteKeepalive,
-            GrpcChannelOptions.DisableServiceConfigResolution
-        };
+        private static readonly GrpcChannelOptions s_defaultOptions = GrpcChannelOptions.FromKeepAlive(TimeSpan.FromMinutes(1))
+            .MergedWith(GrpcChannelOptions.FromEnableServiceConfigResolution(false));
 
         /// <summary>
         /// The endpoint to connect to, or null to use the default endpoint.
@@ -73,6 +70,11 @@ namespace Google.Api.Gax.Grpc
         /// A custom user agent to specify in the channel metadata, or null if no custom user agent is required.
         /// </summary>
         public string UserAgent { get; set; }
+
+        /// <summary>
+        /// The channel factory to use, or null to use the default channel factory.
+        /// </summary>
+        public ChannelFactory ChannelFactory { get; set; }
 
         // Note: when adding any more properties, CopyCommonSettings must also be updated.
 
@@ -154,7 +156,7 @@ namespace Google.Api.Gax.Grpc
                 return CallInvoker;
             }
             var endpoint = Endpoint ?? GetDefaultEndpoint();
-            Channel channel;
+            ChannelBase channel;
             if (CanUseChannelPool)
             {
                 channel = GetChannelPool().GetChannel(endpoint, GetChannelOptions());
@@ -164,7 +166,7 @@ namespace Google.Api.Gax.Grpc
                 var credentials = GetChannelCredentials();
                 channel = CreateChannel(endpoint, credentials);
             }
-            return new DefaultCallInvoker(channel);
+            return channel.CreateCallInvoker();
         }
 
         /// <summary>
@@ -180,7 +182,7 @@ namespace Google.Api.Gax.Grpc
                 return CallInvoker;
             }
             var endpoint = Endpoint ?? GetDefaultEndpoint();
-            Channel channel;
+            ChannelBase channel;
             if (CanUseChannelPool)
             {
                 channel = await GetChannelPool().GetChannelAsync(endpoint, GetChannelOptions()).ConfigureAwait(false);
@@ -190,7 +192,7 @@ namespace Google.Api.Gax.Grpc
                 var credentials = await GetChannelCredentialsAsync(cancellationToken).ConfigureAwait(false);
                 channel = CreateChannel(endpoint, credentials);
             }
-            return new DefaultCallInvoker(channel);
+            return channel.CreateCallInvoker();
         }
 
         /// <summary>
@@ -256,10 +258,10 @@ namespace Google.Api.Gax.Grpc
         /// Returns the options to use when creating a channel.
         /// </summary>
         /// <returns>The options to use when creating a channel.</returns>
-        protected virtual IReadOnlyList<ChannelOption> GetChannelOptions() =>
+        protected virtual GrpcChannelOptions GetChannelOptions() =>
             UserAgent == null
-            ? s_defaultChannelPoolOptions
-            : new List<ChannelOption>(s_defaultChannelPoolOptions) { GrpcChannelOptions.PrimaryUserAgent(UserAgent) };
+            ? s_defaultOptions
+            : s_defaultOptions.MergedWith(GrpcChannelOptions.FromPrimaryUserAgent(UserAgent));
 
         /// <summary>
         /// Returns whether or not a channel pool can be used if a channel is required. The default behavior is to return
@@ -289,8 +291,9 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         public abstract Task<TClient> BuildAsync(CancellationToken cancellationToken = default);
 
-        private protected virtual Channel CreateChannel(ServiceEndpoint endpoint, ChannelCredentials credentials) =>
-            new Channel(endpoint.Host, endpoint.Port, credentials, GetChannelOptions());
+        // FIXME: Handle a default channel factory (null).
+        private protected virtual ChannelBase CreateChannel(ServiceEndpoint endpoint, ChannelCredentials credentials) =>
+            ChannelFactory.Invoke(endpoint, credentials, GetChannelOptions());
 
         private class DelegatedTokenAccess : ITokenAccess
         {

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
     <PackageReference Include="Grpc.Auth" Version="2.25.0" />
-    <PackageReference Include="Grpc.Core" Version="2.25.0" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.25.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />

--- a/Google.Api.Gax.Grpc/GrpcChannelOptions.cs
+++ b/Google.Api.Gax.Grpc/GrpcChannelOptions.cs
@@ -5,15 +5,16 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using Grpc.Core;
+using System;
 
 namespace Google.Api.Gax.Grpc
 {
     /// <summary>
     /// Convenience methods for obtaining channel options.
     /// </summary>
-    internal static class GrpcChannelOptions
+    public class GrpcChannelOptions : IEquatable<GrpcChannelOptions>
     {
+        /*
         /// <summary>
         /// "After a duration of this time the client/server pings its peer to see if the
         /// transport is still alive. Int valued, milliseconds."
@@ -33,7 +34,6 @@ namespace Google.Api.Gax.Grpc
         /// our retry policy.
         /// </remarks>
         internal static ChannelOption DisableServiceConfigResolution { get; } = new ChannelOption("grpc.service_config_disable_resolution", 1);
-
         /// <summary>
         /// Creates a channel option for the primary user agent, which appears first in the channel metadata.
         /// </summary>
@@ -41,5 +41,80 @@ namespace Google.Api.Gax.Grpc
         /// <returns>A channel option for the primary user agent</returns>
         internal static ChannelOption PrimaryUserAgent(string userAgent) =>
             new ChannelOption(ChannelOptions.PrimaryUserAgentString, GaxPreconditions.CheckNotNull(userAgent, nameof(userAgent)));
+            */
+        /// <summary>
+        /// An empty set of channel options.
+        /// </summary>
+        public static GrpcChannelOptions Empty { get; } = new GrpcChannelOptions();
+
+        private GrpcChannelOptions(
+            bool? enableServiceConfigResolution = null,
+            TimeSpan? keepAlive = null,
+            string primaryUserAgent = null)
+        {
+            EnableServiceConfigResolution = enableServiceConfigResolution;
+            KeepAlive = keepAlive;
+            PrimaryUserAgent = primaryUserAgent;
+        }
+
+        /// <summary>
+        /// If non-null, explicitly enables or disables service configuration resolution.
+        /// </summary>
+        public bool? EnableServiceConfigResolution { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the keep-alive period for the channel.
+        /// </summary>
+        public TimeSpan? KeepAlive { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the primary user agent for the channel.
+        /// </summary>
+        public string PrimaryUserAgent { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="userAgent"></param>
+        /// <returns></returns>
+        public static GrpcChannelOptions FromPrimaryUserAgent(string userAgent) =>
+            new GrpcChannelOptions(primaryUserAgent: userAgent);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="enableServiceConfigResolution"></param>
+        /// <returns></returns>
+        public static GrpcChannelOptions FromEnableServiceConfigResolution(bool enableServiceConfigResolution) =>
+            new GrpcChannelOptions(enableServiceConfigResolution: enableServiceConfigResolution);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="keepAlive"></param>
+        /// <returns></returns>
+        public static GrpcChannelOptions FromKeepAlive(TimeSpan keepAlive) =>
+            new GrpcChannelOptions(keepAlive: keepAlive);
+
+        /// <summary>
+        /// Returns a new object, with options from this object merged with <paramref name="overlaidOptions"/>.
+        /// If an option is non-null in both objects, the one from <paramref name="overlaidOptions"/> takes priority.
+        /// </summary>
+        /// <param name="overlaidOptions">The overlaid options.</param>
+        /// <returns></returns>
+        public GrpcChannelOptions MergedWith(GrpcChannelOptions overlaidOptions) =>
+            new GrpcChannelOptions(
+                overlaidOptions.EnableServiceConfigResolution ?? EnableServiceConfigResolution,
+                overlaidOptions.KeepAlive ?? KeepAlive,
+                overlaidOptions.PrimaryUserAgent ?? PrimaryUserAgent);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public bool Equals(GrpcChannelOptions other) => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as GrpcChannelOptions);
     }
 }


### PR DESCRIPTION
We'd need to work out how a "default" channel factory would be supplied, and what this would mean for client library packaging.