### PR TITLE
Make gRPC library implementation-neutral in API surface

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/ChannelPoolTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ChannelPoolTest.cs
@@ -43,8 +43,8 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void SameOptions_SameChannel()
         {
-            var options1 = new[] { new ChannelOption("x", 5) };
-            var options2 = new[] { new ChannelOption("x", 5) };
+            var options1 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
+            var options2 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
             var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
@@ -57,8 +57,8 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void DifferentOptions_DifferentChannel()
         {
-            var options1 = new[] { new ChannelOption("x", 5) };
-            var options2 = new[] { new ChannelOption("x", 6) };
+            var options1 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
+            var options2 = GrpcChannelOptions.Empty.WithCustomOption("x", 6);
             var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
@@ -74,7 +74,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
             var pool = new ChannelPool(EmptyScopes);
             using (var fixture = new TestServiceFixture())
             {
-                var channel = pool.GetChannel(fixture.Endpoint);
+                var channel = (Channel) pool.GetChannel(fixture.Endpoint);
                 Assert.NotEqual(ChannelState.Shutdown, channel.State);
                 await pool.ShutdownChannelsAsync();
                 Assert.Equal(ChannelState.Shutdown, channel.State);

--- a/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
@@ -56,7 +56,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         {
             var builder = new SampleClientBuilder();
 
-            Channel channelFromPool = builder.ChannelPool.GetChannel(SampleClientBuilder.DefaultEndpoint);
+            ChannelBase channelFromPool = builder.ChannelPool.GetChannel(SampleClientBuilder.DefaultEndpoint);
 
             Action<CallInvoker> validator = invoker =>
             {
@@ -73,8 +73,8 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             var endpoint = "custom.nowhere.com";
             var builder = new SampleClientBuilder { Endpoint = endpoint };
 
-            Channel channelFromPoolWithDefaultEndpoint = builder.ChannelPool.GetChannel(SampleClientBuilder.DefaultEndpoint);
-            Channel channelFromPoolWithCustomEndpoint = builder.ChannelPool.GetChannel("custom.nowhere.com");
+            ChannelBase channelFromPoolWithDefaultEndpoint = builder.ChannelPool.GetChannel(SampleClientBuilder.DefaultEndpoint);
+            ChannelBase channelFromPoolWithCustomEndpoint = builder.ChannelPool.GetChannel("custom.nowhere.com");
 
             Action<CallInvoker> validator = invoker =>
             {
@@ -263,7 +263,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
 
             public string EndpointUsedToCreateChannel { get; private set; }
             public ChannelCredentials CredentialsUsedToCreateChannel { get; private set; }
-            public Channel ChannelCreated { get; private set; }
+            public ChannelBase ChannelCreated { get; private set; }
 
             private readonly string _name;
 
@@ -303,7 +303,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
                 ChannelCreated = null;
             }
 
-            private protected override Channel CreateChannel(string endpoint, ChannelCredentials credentials)
+            private protected override ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials)
             {
                 CredentialsUsedToCreateChannel = credentials;
                 EndpointUsedToCreateChannel = endpoint;

--- a/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
     <ProjectReference Include="..\Google.Api.Gax.Grpc.Testing\Google.Api.Gax.Grpc.Testing.csproj" />
+    <PackageReference Include="Grpc.Core" Version="2.25.0" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Grpc.Tests/GrpcChannelOptionsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/GrpcChannelOptionsTest.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class GrpcChannelOptionsTest
+    {
+        [Fact]
+        public void WithPrimaryUserAgent()
+        {
+            var original = GrpcChannelOptions.Empty;
+            var withChange = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+
+            Assert.Null(original.PrimaryUserAgent);
+            Assert.Equal("agent", withChange.PrimaryUserAgent);
+        }
+
+        [Fact]
+        public void WithEnableServiceConfigResolution()
+        {
+            var original = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var withChange = original.WithEnableServiceConfigResolution(false);
+
+            Assert.Null(original.EnableServiceConfigResolution);
+            Assert.Equal(false, withChange.EnableServiceConfigResolution);
+            Assert.Equal("agent", withChange.PrimaryUserAgent);
+        }
+
+        [Fact]
+        public void WithKeepAliveTime()
+        {
+            var original = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var keepAlive = TimeSpan.FromHours(1);
+            var withChange = original.WithKeepAliveTime(keepAlive);
+
+            Assert.Null(original.KeepAliveTime);
+            Assert.Equal(keepAlive, withChange.KeepAliveTime);
+            Assert.Equal("agent", withChange.PrimaryUserAgent);
+        }
+
+        [Fact]
+        public void WithMaxReceiveMessageSize()
+        {
+            var original = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var withChange = original.WithMaxReceiveMessageSize(100);
+
+            Assert.Null(original.MaxReceiveMessageSize);
+            Assert.Equal(100, withChange.MaxReceiveMessageSize);
+            Assert.Equal("agent", withChange.PrimaryUserAgent);
+        }
+
+        [Fact]
+        public void WithMaxSendMessageSize()
+        {
+            var original = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var withChange = original.WithMaxSendMessageSize(100);
+
+            Assert.Null(original.MaxSendMessageSize);
+            Assert.Equal(100, withChange.MaxSendMessageSize);
+            Assert.Equal("agent", withChange.PrimaryUserAgent);
+        }
+
+        [Fact]
+        public void WithCustomOption()
+        {
+            var original = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var withChange = original
+                .WithCustomOption("option1", "first")
+                .WithCustomOption("option2", 2)
+                .WithCustomOption(new GrpcChannelOptions.CustomOption("option3", 3));
+
+            Assert.Empty(original.CustomOptions);
+            var expectedOptions = new[]
+            {
+                new GrpcChannelOptions.CustomOption("option1", "first"),
+                new GrpcChannelOptions.CustomOption("option2", 2),
+                new GrpcChannelOptions.CustomOption("option3", 3)
+            };
+            Assert.Equal(expectedOptions, withChange.CustomOptions);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var mutations = new Func<GrpcChannelOptions, GrpcChannelOptions>[]
+            {
+                options => options.WithPrimaryUserAgent("agent"),
+                options => options.WithEnableServiceConfigResolution(true),
+                options => options.WithKeepAliveTime(TimeSpan.FromSeconds(1)),
+                options => options.WithMaxReceiveMessageSize(100),
+                options => options.WithMaxSendMessageSize(200),
+                options => options.WithCustomOption("custom", 1)
+            };
+
+            foreach (var mutation in mutations)
+            {
+                var option1 = mutation(GrpcChannelOptions.Empty);
+                var option2 = mutation(GrpcChannelOptions.Empty);
+                Assert.Equal(option1, option2);
+                Assert.Equal(option1.GetHashCode(), option2.GetHashCode());
+                Assert.NotEqual(option1, GrpcChannelOptions.Empty);
+                Assert.NotEqual(option1.GetHashCode(), GrpcChannelOptions.Empty.GetHashCode());
+            }
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/GrpcCoreChannelFactoryTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/GrpcCoreChannelFactoryTest.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class GrpcCoreChannelFactoryTest
+    {
+        // We just test option conversion so far.
+        [Fact]
+        public void ConvertOptions_PrimaryUserAgent()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithPrimaryUserAgent("agent");
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+
+            Assert.Equal(new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "agent") }, grpcCoreOptions);
+        }
+
+        [Fact]
+        public void ConvertOptions_EnableServiceConfigResolution()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithEnableServiceConfigResolution(false);
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+
+            Assert.Equal(new[] { new ChannelOption(GrpcCoreChannelFactory.ServiceConfigDisableResolution, 1) }, grpcCoreOptions);
+        }
+
+        [Fact]
+        public void ConvertOptions_KeepAliveTime()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithKeepAliveTime(TimeSpan.FromSeconds(2));
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+
+            Assert.Equal(new[] { new ChannelOption(GrpcCoreChannelFactory.KeepAliveTimeMs, 2000) }, grpcCoreOptions);
+        }
+
+        [Fact]
+        public void ConvertOptions_MaxReceiveSize()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithMaxReceiveMessageSize(150);
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+
+            Assert.Equal(new[] { new ChannelOption(ChannelOptions.MaxReceiveMessageLength, 150) }, grpcCoreOptions);
+        }
+
+        [Fact]
+        public void ConvertOptions_MaxSendSize()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithMaxSendMessageSize(150);
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+
+            Assert.Equal(new[] { new ChannelOption(ChannelOptions.MaxSendMessageLength, 150) }, grpcCoreOptions);
+        }
+
+        [Fact]
+        public void ConvertOptions_CustomOptions()
+        {
+            var gaxOptions = GrpcChannelOptions.Empty.WithCustomOption("c1", 1).WithCustomOption("c2", "two");
+            var grpcCoreOptions = GrpcCoreChannelFactory.ConvertOptions(gaxOptions);
+            var expectedOptions = new[]
+            {
+                new ChannelOption("c1", 1),
+                new ChannelOption("c2", "two")
+            };
+            Assert.Equal(expectedOptions, grpcCoreOptions);
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    <DefineConstants Condition="'$(CORE_API_ONLY)' == 'True'">CORE_API_ONLY</DefineConstants>
   </PropertyGroup>
 
   <!-- Packaging information -->
@@ -18,8 +19,11 @@
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
     <PackageReference Include="Grpc.Auth" Version="2.25.0" />
-    <PackageReference Include="Grpc.Core" Version="2.25.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.42.0" />
+    
+    <PackageReference Include="Grpc.Core" Version="2.25.0" Condition="'$(CORE_API_ONLY)' != 'True'" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.25.0" Condition="'$(CORE_API_ONLY)' == 'True'" />
+    
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/Google.Api.Gax.Grpc/GrpcChannelOptions.cs
+++ b/Google.Api.Gax.Grpc/GrpcChannelOptions.cs
@@ -1,45 +1,292 @@
 ﻿/*
- * Copyright 2019 Google LLC
+ * Copyright 2020 Google LLC
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file or at
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Google.Api.Gax.Grpc
 {
+    // TODO: How do you clear one of these properties?
+
     /// <summary>
-    /// Convenience methods for obtaining channel options.
+    /// Portable abstraction of channel options
     /// </summary>
-    internal static class GrpcChannelOptions
+    public sealed class GrpcChannelOptions : IEquatable<GrpcChannelOptions>
     {
-        /// <summary>
-        /// "After a duration of this time the client/server pings its peer to see if the
-        /// transport is still alive. Int valued, milliseconds."
-        /// Required for any channel using a streaming RPC, to ensure an idle stream doesn't
-        /// allow the TCP connection to be silently dropped by any intermediary network devices.
-        /// 60 second keepalive time is reasonable. This will only add minimal network traffic,
-        /// and only if the channel is idle for more than 60 seconds.
-        /// </summary>
-        internal static ChannelOption OneMinuteKeepalive { get; } = new ChannelOption("grpc.keepalive_time_ms", 60_000);
+        private static readonly IReadOnlyList<CustomOption> s_emptyOptions = new List<CustomOption>().AsReadOnly();
 
         /// <summary>
-        /// "Disable looking up the service config via the name resolver."
+        /// An empty set of channel options.
         /// </summary>
-        /// <remarks>
-        /// Currently this defaults to "on" (so disabled) anyway, but that may change later.
-        /// Explicitly disable service config resolution for now; we'll allow it to be enabled when we have code to change
-        /// our retry policy.
-        /// </remarks>
-        internal static ChannelOption DisableServiceConfigResolution { get; } = new ChannelOption("grpc.service_config_disable_resolution", 1);
+        public static GrpcChannelOptions Empty { get; } = new GrpcChannelOptions();
+
+        private GrpcChannelOptions(
+            bool? enableServiceConfigResolution = null,
+            TimeSpan? keepAliveTime = null,
+            string primaryUserAgent = null,
+            int? maxSendMessageSize = null,
+            int? maxReceiveMessageSize = null,
+            IReadOnlyList<CustomOption> customOptions = null)
+        {
+            EnableServiceConfigResolution = enableServiceConfigResolution;
+            KeepAliveTime = keepAliveTime;
+            PrimaryUserAgent = primaryUserAgent;
+            MaxSendMessageSize = maxSendMessageSize;
+            MaxReceiveMessageSize = maxReceiveMessageSize;
+            CustomOptions = customOptions ?? s_emptyOptions;
+        }
 
         /// <summary>
-        /// Creates a channel option for the primary user agent, which appears first in the channel metadata.
+        /// If non-null, explicitly enables or disables service configuration resolution.
         /// </summary>
-        /// <param name="userAgent">Custom primary user agent for the channel. Must not be null.</param>
-        /// <returns>A channel option for the primary user agent</returns>
-        internal static ChannelOption PrimaryUserAgent(string userAgent) =>
-            new ChannelOption(ChannelOptions.PrimaryUserAgentString, GaxPreconditions.CheckNotNull(userAgent, nameof(userAgent)));
+        public bool? EnableServiceConfigResolution { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the keep-alive period for the channel.
+        /// </summary>
+        public TimeSpan? KeepAliveTime { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the primary user agent for the channel.
+        /// </summary>
+        public string PrimaryUserAgent { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the maximum size in bytes that can be sent from the client, per request.
+        /// </summary>
+        public int? MaxSendMessageSize { get; }
+
+        /// <summary>
+        /// If non-null, explicitly specifies the maximum size in bytes that can be received from the client, per response.
+        /// </summary>
+        public int? MaxReceiveMessageSize { get; }
+
+        /// <summary>
+        /// Immutable list of custom options. This is never null, but may be empty.
+        /// </summary>
+        public IReadOnlyList<CustomOption> CustomOptions { get; }
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with <see cref="PrimaryUserAgent"/> set to
+        /// <paramref name="primaryUserAgent"/>.
+        /// </summary>
+        /// <param name="primaryUserAgent">The new primary user agent. Must not be null.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithPrimaryUserAgent(string primaryUserAgent) =>
+            MergedWith(new GrpcChannelOptions(primaryUserAgent: GaxPreconditions.CheckNotNull(primaryUserAgent, nameof(primaryUserAgent))));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with <see cref="EnableServiceConfigResolution"/> set to
+        /// <paramref name="enableServiceConfigResolution"/>.
+        /// </summary>
+        /// <param name="enableServiceConfigResolution">The new option for enabling service config resolution.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithEnableServiceConfigResolution(bool enableServiceConfigResolution) =>
+            MergedWith(new GrpcChannelOptions(enableServiceConfigResolution: enableServiceConfigResolution));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with <see cref="KeepAliveTime"/> set to
+        /// <paramref name="keepAliveTime"/>.
+        /// </summary>
+        /// <param name="keepAliveTime">The new keep-alive time.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithKeepAliveTime(TimeSpan keepAliveTime) =>
+            MergedWith(new GrpcChannelOptions(keepAliveTime: keepAliveTime));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with <see cref="MaxSendMessageSize"/> set to
+        /// <paramref name="maxSendMessageSize"/>.
+        /// </summary>
+        /// <param name="maxSendMessageSize">The new maximum send message size, in bytes.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithMaxSendMessageSize(int maxSendMessageSize) =>
+            MergedWith(new GrpcChannelOptions(maxSendMessageSize: maxSendMessageSize));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with <see cref="MaxReceiveMessageSize"/> set to
+        /// <paramref name="maxReceiveMessageSize"/>.
+        /// </summary>
+        /// <param name="maxReceiveMessageSize">The new maximum receive message size, in bytes.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithMaxReceiveMessageSize(int maxReceiveMessageSize) =>
+            MergedWith(new GrpcChannelOptions(maxReceiveMessageSize: maxReceiveMessageSize));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with a new integer-valued <see cref="CustomOption"/>
+        /// at the end of <see cref="CustomOptions"/>.
+        /// </summary>
+        /// <param name="name">The name of the new custom option. Must not be null.</param>
+        /// <param name="value">The value of the new custom option.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithCustomOption(string name, int value) =>
+            WithCustomOption(new CustomOption(name, value));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with a new string-valued <see cref="CustomOption"/>
+        /// at the end of <see cref="CustomOptions"/>.
+        /// </summary>
+        /// <param name="name">The name of the new custom option. Must not be null.</param>
+        /// <param name="value">The value of the new custom option. Must not be null.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithCustomOption(string name, string value) =>
+            WithCustomOption(new CustomOption(name, value));
+
+        /// <summary>
+        /// Returns a new instance with the same options as this one, but with a new integer-valued <see cref="CustomOption"/>
+        /// at the end of <see cref="CustomOptions"/>.
+        /// </summary>
+        /// <param name="option">The additional custom option to include. Must not be null.</param>
+        /// <returns>The new options.</returns>
+        public GrpcChannelOptions WithCustomOption(CustomOption option) =>
+            MergedWith(new GrpcChannelOptions(
+                customOptions: new ReadOnlyCollection<CustomOption>(new[] { GaxPreconditions.CheckNotNull(option, nameof(option)) })));
+
+        /// <summary>
+        /// Returns a new object, with options from this object merged with <paramref name="overlaidOptions"/>.
+        /// If an option is non-null in both objects, the one from <paramref name="overlaidOptions"/> takes priority.
+        /// </summary>
+        /// <param name="overlaidOptions">The overlaid options. Must not be null.</param>
+        /// <returns>The new merged options.</returns>
+        public GrpcChannelOptions MergedWith(GrpcChannelOptions overlaidOptions)
+        {
+            GaxPreconditions.CheckNotNull(overlaidOptions, nameof(overlaidOptions));
+            return new GrpcChannelOptions(
+                overlaidOptions.EnableServiceConfigResolution ?? EnableServiceConfigResolution,
+                overlaidOptions.KeepAliveTime ?? KeepAliveTime,
+                overlaidOptions.PrimaryUserAgent ?? PrimaryUserAgent,
+                overlaidOptions.MaxSendMessageSize ?? MaxSendMessageSize,
+                overlaidOptions.MaxReceiveMessageSize ?? MaxReceiveMessageSize,
+                MergeCustomOptions(CustomOptions, overlaidOptions.CustomOptions));
+
+            IReadOnlyList<CustomOption> MergeCustomOptions(IReadOnlyList<CustomOption> originalOptions, IReadOnlyList<CustomOption> overlaidOptions)
+            {
+                if (originalOptions.Count == 0)
+                {
+                    return overlaidOptions;
+                }
+                if (overlaidOptions.Count == 0)
+                {
+                    return originalOptions;
+                }
+
+                // TODO: Implement the following functionality (TODO: check this is desirable!)
+                // - For all distinctly-named options, include the original options followed by the overlaid options
+                // - For any option in both collections, include the new value in the original position (and not later)
+                // - What happens if any option is in both places?
+                return originalOptions.Concat(overlaidOptions).ToList().AsReadOnly();
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as GrpcChannelOptions);
+
+        /// <inheritdoc />
+        public override int GetHashCode() =>
+            GaxEqualityHelpers.CombineHashCodes(
+                EnableServiceConfigResolution.GetHashCode(),
+                KeepAliveTime.GetHashCode(),
+                PrimaryUserAgent?.GetHashCode() ?? 0,
+                MaxSendMessageSize.GetHashCode(),
+                MaxReceiveMessageSize.GetHashCode(),
+                GaxEqualityHelpers.GetListHashCode(CustomOptions));
+
+        /// <inheritdoc />
+        public bool Equals(GrpcChannelOptions other) =>
+            other is object &&
+            EnableServiceConfigResolution == other.EnableServiceConfigResolution &&
+            KeepAliveTime == other.KeepAliveTime &&
+            PrimaryUserAgent == other.PrimaryUserAgent &&
+            MaxSendMessageSize == other.MaxSendMessageSize &&
+            MaxReceiveMessageSize == other.MaxReceiveMessageSize &&
+            GaxEqualityHelpers.ListsEqual(CustomOptions, other.CustomOptions);
+
+        /// <summary>
+        /// A custom option, with a name and a value of either a 32-bit integer or a string.
+        /// </summary>
+        public class CustomOption : IEquatable<CustomOption>
+        {
+            /// <summary>
+            /// Possible types of value within a custom option.
+            /// </summary>
+            public enum OptionType
+            {
+                /// <summary>
+                /// Channel option with an integer value.
+                /// </summary>
+                Integer,
+
+                /// <summary>
+                /// Channel option with a string value.
+                /// </summary>
+                String
+            }
+
+            /// <summary>
+            /// Name of the option. This is never null.
+            /// </summary>
+            public string Name { get; }
+
+            /// <summary>
+            /// Value of the option, for string options. This is never null for string options, and always
+            /// null for other options.
+            /// </summary>
+            public string StringValue { get; }
+
+            /// <summary>
+            /// Value of the option, for integer options, or 0 for other options.
+            /// </summary>
+            public int IntegerValue { get; }
+
+            /// <summary>
+            /// The type of value represented within this option.
+            /// </summary>
+            public OptionType Type { get; }
+
+            /// <summary>
+            /// Creates a custom integer option.
+            /// </summary>
+            /// <param name="name">The name of the option. Must not be null.</param>
+            /// <param name="value">Value of the option.</param>
+            public CustomOption(string name, int value)
+            {
+                Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+                StringValue = null;
+                IntegerValue = value;
+                Type = OptionType.Integer;
+            }
+
+            /// <summary>
+            /// Creates a custom string option.
+            /// </summary>
+            /// <param name="name">The name of the option. Must not be null.</param>
+            /// <param name="value">Value of the option. Must not be null.</param>
+            public CustomOption(string name, string value)
+            {
+                Name = GaxPreconditions.CheckNotNull(name, nameof(name));
+                StringValue = GaxPreconditions.CheckNotNull(value, nameof(value));
+                IntegerValue = 0;
+                Type = OptionType.String;
+            }
+
+            /// <inheritdoc />
+            public override bool Equals(object obj) => Equals(obj as CustomOption);
+
+            /// <inheritdoc />
+            public override int GetHashCode() => GaxEqualityHelpers.CombineHashCodes((int) Type, IntegerValue, Name.GetHashCode(), StringValue?.GetHashCode() ?? 0);
+
+            /// <inheritdoc />
+            public bool Equals(CustomOption other) =>
+                other is object &&
+                Type == other.Type &&
+                Name == other.Name &&
+                StringValue == other.StringValue &&
+                IntegerValue == other.IntegerValue;
+        }
     }
 }

--- a/Google.Api.Gax.Grpc/GrpcCoreChannelFactory.cs
+++ b/Google.Api.Gax.Grpc/GrpcCoreChannelFactory.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Copyright 2020 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+
+namespace Google.Api.Gax.Grpc
+{
+    internal sealed class GrpcCoreChannelFactory
+    {
+        internal const string ServiceConfigDisableResolution = "grpc.service_config_disable_resolution";
+        internal const string KeepAliveTimeMs = "grpc.keepalive_time_ms";
+
+#if CORE_API_ONLY
+        internal ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
+            throw new NotImplementedException("GrpcCoreChannelFactory is not implemented in CORE_API_ONLY builds");
+#else
+        internal ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
+            // TODO: Cache the result of ConvertOptions? It's probably not called terribly frequently.
+            new Channel(endpoint, credentials, ConvertOptions(options));
+
+        // Internal for the sake of testing.
+        internal static List<ChannelOption> ConvertOptions(GrpcChannelOptions options)
+        {
+            List<ChannelOption> ret = new List<ChannelOption>();
+            if (options.EnableServiceConfigResolution is bool enableServiceConfigResolution)
+            {
+                ret.Add(new ChannelOption("grpc.service_config_disable_resolution", enableServiceConfigResolution ? 0 : 1));
+            }
+            if (options.KeepAliveTime is TimeSpan keepAlive)
+            {
+                ret.Add(new ChannelOption("grpc.keepalive_time_ms", (int) keepAlive.TotalMilliseconds));
+            }
+            if (options.MaxReceiveMessageSize is int maxReceiveMessageSize)
+            {
+                ret.Add(new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxReceiveMessageSize));
+            }
+            if (options.MaxSendMessageSize is int maxSendMessageSize)
+            {
+                ret.Add(new ChannelOption(ChannelOptions.MaxSendMessageLength, maxSendMessageSize));
+            }
+            if (options.PrimaryUserAgent is string primaryUserAgent)
+            {
+                ret.Add(new ChannelOption(ChannelOptions.PrimaryUserAgentString, primaryUserAgent));
+            }
+            foreach (var customOption in options.CustomOptions)
+            {
+                var channelOption = customOption.Type switch
+                {
+                    GrpcChannelOptions.CustomOption.OptionType.Integer => new ChannelOption(customOption.Name, customOption.IntegerValue),
+                    GrpcChannelOptions.CustomOption.OptionType.String => new ChannelOption(customOption.Name, customOption.StringValue),
+                    _ => throw new InvalidOperationException($"Unknown custom option type: {customOption.Type}")
+                };
+                ret.Add(channelOption);
+            }
+            return ret;
+        }
+#endif
+    }
+}

--- a/Google.Api.Gax.Grpc/GrpcImplementation.cs
+++ b/Google.Api.Gax.Grpc/GrpcImplementation.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Copyright 2020 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using System.Threading;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Interoperability layer for the aspects of gRPC that aren't covered by Grpc.Core.Api.
+    /// Currently internal, and only a Grpc.Core implementation exists - but it should be possible to 
+    /// create an implementation for Grpc.Net.Client too.
+    /// Unclear as yet whether this should be:
+    /// - A sealed class constructed from delegates
+    /// - An abstract class
+    /// - An interface
+    /// - Just a delegate
+    /// </summary>
+    internal sealed class GrpcImplementation
+    {
+        /// <summary>
+        /// Returns the default implementation, based on which assemblies are available at execution time.
+        /// Grpc.Core is preferred over Grpc.Net.Client.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="GrpcCore"/> and <see cref="GrpcNetClient"/>, this property never returns null.
+        /// </remarks>
+        public static GrpcImplementation Default => GrpcCore ?? GrpcNetClient ??
+            throw new InvalidOperationException("No gRPC implementation could be detected.");
+
+        /// <summary>
+        /// Returns a Grpc.Core-based implementation if the assembly is available, or null otherwise.
+        /// (Currently always returns a non-null value.)
+        /// </summary>
+        public static GrpcImplementation GrpcCore => s_grpcCore.Value;
+
+        /// <summary>
+        /// Returns a Grpc.Net.Client-based implementation if the assembly is available, or null otherwise.
+        /// (Currently always returns null.)
+        /// </summary>
+        public static GrpcImplementation GrpcNetClient => s_grpcNetClient.Value;
+
+        private static readonly Lazy<GrpcImplementation> s_grpcCore =
+            new Lazy<GrpcImplementation>(CreateGrpcCoreImplementation, LazyThreadSafetyMode.ExecutionAndPublication);
+        private static readonly Lazy<GrpcImplementation> s_grpcNetClient =
+            new Lazy<GrpcImplementation>(CreateGrpcNetClientImplementation, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private readonly Func<string, ChannelCredentials, GrpcChannelOptions, ChannelBase> _channelCreator;
+
+        private GrpcImplementation(Func<string, ChannelCredentials, GrpcChannelOptions, ChannelBase> channelCreator) =>
+            _channelCreator = channelCreator;
+
+        internal ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
+            _channelCreator(endpoint, credentials, options);
+
+        private static GrpcImplementation CreateGrpcCoreImplementation() => new GrpcImplementation(new GrpcCoreChannelFactory().CreateChannel);
+
+        private static GrpcImplementation CreateGrpcNetClientImplementation() => null;
+    }
+}

--- a/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
+++ b/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
@@ -7,7 +7,6 @@
 
 using Grpc.Core;
 using Grpc.Core.Interceptors;
-using System;
 
 namespace Google.Api.Gax.Grpc
 {
@@ -27,7 +26,9 @@ namespace Google.Api.Gax.Grpc
                 .AppendAssemblyVersion("gccl", GetType())
                 .AppendAssemblyVersion("gapic", GetType())
                 .AppendAssemblyVersion("gax", typeof(CallSettings))
-                .AppendAssemblyVersion("grpc", typeof(Channel));
+                // Note: this will be the version of gRPC Core API that we're using, not necessarily the implementation.
+                // But the implementation will depend on the API, so it's likely that it's all in sync.
+                .AppendAssemblyVersion("grpc", typeof(ChannelBase));
         }
 
         /// <summary>

--- a/Google.Api.Gax/GaxEqualityHelpers.cs
+++ b/Google.Api.Gax/GaxEqualityHelpers.cs
@@ -51,7 +51,7 @@ namespace Google.Api.Gax
         }
 
         /// <summary>
-        /// Computes an ordering-sensitive hash code for a list, using the given equality comparer.
+        /// Computes an ordering-sensitive hash code for a list, using the default equality comparer for the type.
         /// </summary>
         /// <param name="list">The list to compute a hash code for. May be null.</param>
         /// <returns>The computed hash code.</returns>

--- a/build.sh
+++ b/build.sh
@@ -15,11 +15,16 @@ DOTNET_TEST_ARGS="--no-build $DOTNET_BUILD_ARGS"
 
 echo CLI args: $DOTNET_BUILD_ARGS
 
-echo Restoring
-dotnet restore -v minimal Gax.sln
+echo Building with CORE_API_ONLY
+# Check that Google.Api.Gax.Grpc doesn't expose any non-Grpc.Core.Api in the public surface
+# (This relies on being careful where we use CORE_API_ONLY; an alternative would
+# be to check the actual public API surface with a separate tool.)
+dotnet build -nologo -clp:NoSummary -p:CORE_API_ONLY=True Google.Api.Gax.Grpc
+# Make sure we don't end up using that build elsewhere.
+dotnet clean -nologo -clp:NoSummary -v quiet Google.Api.Gax.Grpc
 
 echo Building
-dotnet build $DOTNET_BUILD_ARGS Gax.sln
+dotnet build -nologo -clp:NoSummary -v quiet $DOTNET_BUILD_ARGS Gax.sln
 
 echo Testing
 
@@ -27,5 +32,5 @@ for testproject in *.Tests
 do
   # This will run the tests on every platform  
   # defined for the project.
-  dotnet test $DOTNET_TEST_ARGS $testproject
+  dotnet test -nologo --no-build $DOTNET_TEST_ARGS $testproject
 done


### PR DESCRIPTION
This still depends on Grpc.Core and has a default implementation (embedded in it) that uses Grpc.Core, but the public API surface only depends on Grpc.Core.Api.

Still to come in later commits:

- Doc comments on GrpcChannelOptions
- Tests for GrpcChannelOptions
- Tests for GrpcCoreChannelFactory
- Decisions around how to handle duplication of custom options (either with each other or with standard options)
- A proof-of-concept for a Grpc.Net.Client implementation.