### PR TITLE
Remove server-side retry

### DIFF
--- a/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
@@ -79,12 +79,6 @@ namespace Google.Api.Gax.Grpc
         internal ApiServerStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
             new ApiServerStreamingCall<TRequest, TResponse>(_asyncCall, _syncCall, callSettings.MergedWith(BaseCallSettings));
 
-        internal ApiServerStreamingCall<TRequest, TResponse> WithRetry(IClock clock, IScheduler scheduler) =>
-            new ApiServerStreamingCall<TRequest, TResponse>(
-                _asyncCall.WithRetry(clock, scheduler, response => response.ResponseHeadersAsync),
-                _syncCall.WithRetry(clock, scheduler, response => response.ResponseHeadersAsync.WaitWithUnwrappedExceptions()),
-                BaseCallSettings);
-
         /// <summary>
         /// Constructs a new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> that applies an overlay to
         /// the underlying <see cref="CallSettings"/>. If a value exists in both the original and


### PR DESCRIPTION
It doesn't work anyway, so let's not pretend it does.

Part of #367, but we'll need a corresponding generator change. (We could potentially change the generator to ignore a retry config for now, then error later after we've tidied up existing configs.)

(Mind you, the fact that I've only removed an internal method suggests it probably wasn't being used even now...)