### PR TITLE
Proposal: Adds emulator support to Gax.Grpc

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
@@ -255,7 +255,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             Assert.Throws<InvalidOperationException>(builder.ValidateForTest);
         }
         
-        public class SampleClientBuilder : ClientBuilderBase<CallInvoker>
+        public class SampleClientBuilder : ClientBuilderBase<CallInvoker, EmulatorConfiguration, SampleClientBuilder>
         {
             public static string DefaultEndpoint { get; } = "default.nowhere.com";
             public static string[] DefaultScopes { get; } = new[] { "scope1", "scope2" };
@@ -276,19 +276,12 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             {
             }
 
-            public override CallInvoker Build()
-            {
-                base.Validate();
-                return CreateCallInvoker();
-            }
-
             public void ValidateForTest() => Validate();
 
-            public override async Task<CallInvoker> BuildAsync(CancellationToken cancellationToken = default(CancellationToken))
-            {
-                base.Validate();
-                return await CreateCallInvokerAsync(cancellationToken);
-            }
+            protected override CallInvoker BuildImpl() => CreateCallInvoker();
+
+            protected override Task<CallInvoker> BuildImplAsync(CancellationToken cancellationToken) => 
+                CreateCallInvokerAsync(cancellationToken);
 
             protected override ChannelPool GetChannelPool() => ChannelPool;
 

--- a/Google.Api.Gax.Grpc.IntegrationTests/EmulatorSupportTests.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/EmulatorSupportTests.cs
@@ -1,0 +1,193 @@
+﻿/*
+ * Copyright 2020 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.IntegrationTests
+{
+    public class EmulatorSupportTests
+    {
+        [Fact]
+        public void AppliesEmulator_Default()
+        {
+            Environment.SetEnvironmentVariable(DefaultEmulatorSupportClientBuilder.EmulatorEndpointEnvVar, "emulator.localhost");
+
+            var clientBuilder = new DefaultEmulatorSupportClientBuilder();
+            clientBuilder.EmulatorDetector.EmulatorDetection = EmulatorDetection.EmulatorOrProduction;
+            clientBuilder.Endpoint = "any.other.endpoint.com";
+            clientBuilder.CredentialsPath = "/wont/be/used.json";
+            clientBuilder.Build();
+
+            Assert.Equal("emulator.localhost", DefaultEmulatorSupportClientBuilder.EndpointUsedToCreateChannel);
+            Assert.Equal(ChannelCredentials.Insecure, DefaultEmulatorSupportClientBuilder.CredentialsUsedToCreateChannel);
+
+            Assert.Equal("any.other.endpoint.com", clientBuilder.Endpoint);
+            Assert.Equal("/wont/be/used.json", clientBuilder.CredentialsPath);
+
+            Environment.SetEnvironmentVariable(DefaultEmulatorSupportClientBuilder.EmulatorEndpointEnvVar, null);
+        }
+
+        public class DefaultEmulatorSupportClientBuilder : ClientBuilderBase<CallInvoker, EmulatorConfiguration, DefaultEmulatorSupportClientBuilder>
+        {
+            #region Test Code
+            public const string EmulatorEndpointEnvVar = "FAKE_EMULATOR_ENDPOINT_ENV_VAR";
+            public static string DefaultEndpoint { get; } = "default.nowhere.com";
+            public static string[] DefaultScopes { get; } = new[] { "scope1", "scope2" };
+            public ChannelPool ChannelPool { get; } = new ChannelPool(DefaultScopes);
+
+            public static string EndpointUsedToCreateChannel { get; private set; }
+            public static ChannelCredentials CredentialsUsedToCreateChannel { get; private set; }
+            public static ChannelBase ChannelCreated { get; private set; }
+            #endregion
+
+            #region Code needed for default Emulator support
+            public new EmulatorDetector<EmulatorConfiguration> EmulatorDetector => base.EmulatorDetector;
+
+            public DefaultEmulatorSupportClientBuilder()
+                : base(new EmulatorDetector<EmulatorConfiguration>(() => new EmulatorConfiguration(EmulatorEndpointEnvVar)))
+            { }
+            #endregion
+
+            #region Code that always needs to be overwritten
+            protected override CallInvoker BuildImpl() => CreateCallInvoker();
+
+            protected override Task<CallInvoker> BuildImplAsync(CancellationToken cancellationToken) =>
+                CreateCallInvokerAsync(cancellationToken);
+
+            protected override ChannelPool GetChannelPool() => ChannelPool;
+
+            protected override string GetDefaultEndpoint() => DefaultEndpoint;
+
+            protected override IReadOnlyList<string> GetDefaultScopes() => DefaultScopes;
+
+            private protected override ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials)
+            {
+                CredentialsUsedToCreateChannel = credentials;
+                EndpointUsedToCreateChannel = endpoint;
+                ChannelCreated = base.CreateChannel(endpoint, credentials);
+                return ChannelCreated;
+            }
+            #endregion
+        }
+
+        [Fact]
+        public void AppliesEmulator_Custom()
+        {
+            Environment.SetEnvironmentVariable(CustomEmulatorSupportClientBuilder.EmulatorEndpointEnvVar, "custom.emulator.localhost");
+
+            var clientBuilder = new CustomEmulatorSupportClientBuilder();
+            clientBuilder.EmulatorDetector.EmulatorDetection = EmulatorDetection.EmulatorOrProduction;
+            clientBuilder.Endpoint = "any.other.endpoint.com";
+            clientBuilder.CredentialsPath = "/wont/be/used.json";
+            clientBuilder.Build();
+
+            Assert.Equal("custom.emulator.localhost", CustomEmulatorSupportClientBuilder.EndpointUsedToCreateChannel);
+            // A better test than this one should be written, but this is good enought for demonstration purposes.
+            Assert.NotEqual(ChannelCredentials.Insecure, CustomEmulatorSupportClientBuilder.CredentialsUsedToCreateChannel);
+
+            Assert.Equal("any.other.endpoint.com", clientBuilder.Endpoint);
+            Assert.Equal("/wont/be/used.json", clientBuilder.CredentialsPath);
+
+            Environment.SetEnvironmentVariable(CustomEmulatorSupportClientBuilder.EmulatorEndpointEnvVar, null);
+        }
+
+        #region Inherit from EmulatorConfiguration if the API emulator needs other than Endpoint.
+        public class CustomEmulatorConfiguration : EmulatorConfiguration
+        {
+            private const string DummyServiceAccountCredentialFileContents = @"{
+""private_key_id"": ""PRIVATE_KEY_ID"",
+""private_key"": ""-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
+2x4zrzrwSUtmtR37XTTi0sPARTDF8uzmXy8UnE5RcVJzEH5T2Ssz/ylX4Sl/CI4L
+no1l8j9GiHJb49LSRjWe4Yx936q0Xj9H0R1HTxvjUPqwAsTwy2fKBTog+q1frqc9
+o8s2r6LYivUGDVbhuUzCaMJsf+x3AgMBAAECgYEAi0FTXsu/zRswAUGaViQiHjrL
+uU65BSHXNVjV/2fLNEKnGWGqpli68z1IXY+S2nwbUak7rnGsq9/0F6jtsW+hZbLk
+KXUOuuExpeC5Kd6ngWX/f2jqmhlUabiQijU9cVk7pMq8EHkRtvlosnMTUAEzempu
+QUPwn1PZHhmJkBvZ4lECQQDCErrxl+e3BwUDcS0yVEEmCNSG6xdXs2878b8rzbe7
+3Mmi6SuuOLi3PU92J+j+f/MOdtYrk13mEDdYmd5dhrt5AkEAwPvDEsDT/W4y4h5n
+gv1awGBA5aLFE1JNWM/Gwn4D1cGpEDHKFREaBtxMDCASpHJuw8r7zUywpKhmBZcf
+GS37bwJANdSAKfbafLfjuhqwUJ9yGpykZm/a36aTmerp/bpn1iHdg+RtCzwMcDb/
+TWSwibbvsflgWmHbz657y4WSWhq+8QJAWrpCNN/ZCk2zuGDo80lfUBAwkoVat8G6
+wWU1oZyS+vzIGef+hLb8kHsjeZPej9eIwZ39kcBbT54oELrCkRjwGwJAQ8V2A7lT
+ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
+4Z5p2prkjWTLcA==
+-----END PRIVATE KEY-----"",
+""client_email"": ""CLIENT_EMAIL"",
+""client_id"": ""CLIENT_ID"",
+""type"": ""service_account""}";
+
+            public string JsonCredential { get; } = DummyServiceAccountCredentialFileContents;
+
+            public override bool IsValid => base.IsValid && !string.IsNullOrEmpty(JsonCredential);
+
+            public CustomEmulatorConfiguration(string emulatorEndpointVariable)
+                : base(emulatorEndpointVariable)
+            { }
+        }
+        #endregion
+
+        public class CustomEmulatorSupportClientBuilder : ClientBuilderBase<CallInvoker, CustomEmulatorConfiguration, CustomEmulatorSupportClientBuilder>
+        {
+            #region Test code
+            public const string EmulatorEndpointEnvVar = "FAKE_EMULATOR_ENDPOINT_ENV_VAR";
+            public static string DefaultEndpoint { get; } = "custom.nowhere.com";
+            public static string[] DefaultScopes { get; } = new[] { "scope1", "scope2" };
+            public ChannelPool ChannelPool { get; } = new ChannelPool(DefaultScopes);
+
+            public static string EndpointUsedToCreateChannel { get; private set; }
+            public static ChannelCredentials CredentialsUsedToCreateChannel { get; private set; }
+            public static ChannelBase ChannelCreated { get; private set; }
+            #endregion
+
+            #region Code needed for custom Emulator support
+            public new EmulatorDetector<CustomEmulatorConfiguration> EmulatorDetector => base.EmulatorDetector;
+
+            public CustomEmulatorSupportClientBuilder()
+                : base(new EmulatorDetector<CustomEmulatorConfiguration>(() => new CustomEmulatorConfiguration(EmulatorEndpointEnvVar)))
+            { }
+
+            protected override CustomEmulatorSupportClientBuilder WithEmulatorConfiguration(CustomEmulatorConfiguration emulatorConfiguration)
+            {
+                CustomEmulatorSupportClientBuilder builder = base.WithEmulatorConfiguration(emulatorConfiguration);
+
+                // Let's clean up all conflicting settings on the clone.
+                builder.ChannelCredentials = null; // base set this to Insecure.
+
+                builder.JsonCredentials = emulatorConfiguration.JsonCredential;
+
+                return builder;
+            }
+            #endregion
+
+            #region Code that always needs to be overwritten
+            protected override CallInvoker BuildImpl() => CreateCallInvoker();
+
+            protected override Task<CallInvoker> BuildImplAsync(CancellationToken cancellationToken) =>
+                CreateCallInvokerAsync(cancellationToken);
+
+            protected override ChannelPool GetChannelPool() => ChannelPool;
+
+            protected override string GetDefaultEndpoint() => DefaultEndpoint;
+
+            protected override IReadOnlyList<string> GetDefaultScopes() => DefaultScopes;
+
+            private protected override ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials)
+            {
+                CredentialsUsedToCreateChannel = credentials;
+                EndpointUsedToCreateChannel = endpoint;
+                ChannelCreated = base.CreateChannel(endpoint, credentials);
+                return ChannelCreated;
+            }
+            #endregion
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc/EmulatorConfiguration.cs
+++ b/Google.Api.Gax.Grpc/EmulatorConfiguration.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Represents the basic emulator configuration which is
+    /// constructed from environment variables.
+    /// </summary>
+    /// <remarks>Inherit from this class if the current API emulator
+    /// needs extra configuration or if it can be configured from other than 
+    /// environment variables.</remarks>
+    public class EmulatorConfiguration
+    {
+        /// <summary>
+        /// The endpoint to connect to the emulator.
+        /// Can be null in which case this configuration will be considered invalid.
+        /// </summary>
+        public string Endpoint { get; }
+
+        /// <summary>
+        /// Whether this configuration is valid or not.
+        /// An invalid configuration will be trated as if no configuration exists.
+        /// </summary>
+        /// <remarks>This property can be overwridden to include more validity constraints.</remarks>
+        public virtual bool IsValid => Endpoint != null;
+
+        /// <summary>
+        /// Constructs a new emulator configuration obtaining the endpoint value
+        /// from the given environment variable.
+        /// </summary>
+        /// <param name="emulatorEndpointVariable">An environment variable name to obtaing the emulator endpoint from.</param>
+        public EmulatorConfiguration(string emulatorEndpointVariable)
+        {
+            // Note: we treat present-but-empty environment variables as if they were absent.
+            string endpoint = Environment.GetEnvironmentVariable(emulatorEndpointVariable)?.Trim();
+            Endpoint = string.IsNullOrEmpty(endpoint) ? null : endpoint;
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc/EmulatorDetector.cs
+++ b/Google.Api.Gax.Grpc/EmulatorDetector.cs
@@ -1,0 +1,103 @@
+﻿// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Determines whether an emulator configuration should be used or not.
+    /// </summary>
+    /// <typeparam name="TEmulatorConfiguration"></typeparam>
+    public sealed class EmulatorDetector<TEmulatorConfiguration>
+        where TEmulatorConfiguration : EmulatorConfiguration
+    {
+        private EmulatorDetection _emulatorDetection;
+        // TODO: Maybe support async in case the configuration is not obtained from env variables.
+        private readonly Func<TEmulatorConfiguration> _configurationBuilder;
+
+        /// <summary>
+        /// Specifies how the builder responds to the existence of an emulator configuration.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="EmulatorDetection.None"/>, meaning that the emulator
+        /// configuration is ignored.
+        /// </remarks>
+        public EmulatorDetection EmulatorDetection
+        {
+            get => _emulatorDetection;
+            set => _emulatorDetection = GaxPreconditions.CheckEnumValue(value, nameof(value));
+        }
+
+        /// <summary>
+        /// Constructs a new emulator detector that will use the given function
+        /// to obtain emulator configurations.
+        /// </summary>
+        /// <param name="configurationFactory">A function for obtaning emulator configurations.
+        /// May return null or configurations where <see cref="EmulatorConfiguration.IsValid"/> 
+        /// is false. Both cases will be treated as if no emulator configuration exists.</param>
+        public EmulatorDetector(Func<TEmulatorConfiguration> configurationFactory) =>
+            _configurationBuilder = GaxPreconditions.CheckNotNull(configurationFactory, nameof(configurationFactory));
+
+        /// <summary>
+        /// Attempts to detect an emulator configuration and if found assigns it to the given patameter.
+        /// Detecting an emulator configuration is both affected by whether an actual valid configuration
+        /// exists and the value of <see cref="EmulatorDetection"/>.
+        /// </summary>
+        /// <param name="emulatorConfiguration">The emulator configuration that should be use, if any.</param>
+        /// <returns>true if a configuration was detected, false otherwise.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// If the value of <see cref="EmulatorDetection"/> is <see cref="EmulatorDetection.ProductionOnly"/>
+        /// and a valid emulator configuration was detected.
+        /// If the value of <see cref="EmulatorDetection"/> is <see cref="EmulatorDetection.EmulatorOnly"/>
+        /// and there was no valid emulator configuration detected.
+        /// </exception>
+        public bool TryDetectEmulator(out TEmulatorConfiguration emulatorConfiguration)
+        {
+            emulatorConfiguration = null;
+            if (EmulatorDetection == EmulatorDetection.None)
+            {
+                return false;
+            }
+
+            var config = _configurationBuilder();
+            // Invalid configuration is treated the same as non-existent configuration.
+            config = config.IsValid ? config : null;
+            switch (EmulatorDetection)
+            {
+                case EmulatorDetection.ProductionOnly:
+                    GaxPreconditions.CheckState(
+                        config == null,
+                        $"Emulator configuration detected, contrary to use of {EmulatorDetection.ProductionOnly}");
+                    return false;
+                case EmulatorDetection.EmulatorOnly:
+                    GaxPreconditions.CheckState(
+                        config != null,
+                        "Emulator configuration couldn't be found.");
+                    emulatorConfiguration = config;
+                    return true;
+                case EmulatorDetection.EmulatorOrProduction:
+                    if (config != null)
+                    {
+                        emulatorConfiguration = config;
+                        return true;
+                    }
+                    return false;
+            }
+            // We should never get to this point.
+            // TODO: Consider throwing instead?
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Still in draft because more tests are needed. And it's a proposal anyway.

I've added one test that shows what an actual client builder should do to use the base's emulator suppor code.

Might be a little messy on the generics but clients won't see that anyway, so I think we can deal with it.