### PR TITLE
Provide a simpler retry API.

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/RetryAttemptTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/RetryAttemptTest.cs
@@ -1,0 +1,122 @@
+﻿/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Api.Gax.Testing;
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class RetryAttemptTest
+    {
+        private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan FiveSeconds = TimeSpan.FromSeconds(5);
+
+        [Fact]
+        public Task DeadlineRespected()
+        {
+            var settings = RetrySettings.FromExponentialBackoff(
+                maxAttempts: 10, initialBackoff: OneSecond, maxBackoff: FiveSeconds,
+                backoffMultiplier: 2, retryFilter: ex => true, backoffJitter: RetrySettings.NoJitter);
+            var scheduler = new FakeScheduler();
+            var deadline = scheduler.Clock.GetCurrentDateTimeUtc() + FiveSeconds;
+
+            var sequence = RetryAttempt.CreateRetrySequence(settings, scheduler, deadline, scheduler.Clock);
+            // Should attempt at T=0, T=1, T=3, then stop because the next attempt would be after the deadline.
+            return AssertAttemptsAsync(sequence, scheduler, () => new Exception(), 0, 1, 3);
+        }
+
+        [Fact]
+        public Task MaxAttemptsRespected()
+        {
+            var settings = RetrySettings.FromConstantBackoff(
+                maxAttempts: 4, backoff: OneSecond, retryFilter: ex => true, backoffJitter: RetrySettings.NoJitter);
+            var scheduler = new FakeScheduler();
+
+            var sequence = RetryAttempt.CreateRetrySequence(settings, scheduler);
+            // Should attempt at T=0, T=1, T=2, T=3, then stop because we're only allowed four attempts.
+            return AssertAttemptsAsync(sequence, scheduler, () => new Exception(), 0, 1, 2, 3);
+        }
+
+        [Fact]
+        public Task JitterRespected()
+        {
+            var settings = RetrySettings.FromExponentialBackoff(
+                maxAttempts: 6, initialBackoff: TimeSpan.FromSeconds(2), maxBackoff: TimeSpan.FromSeconds(10),
+                backoffMultiplier: 2, retryFilter: ex => true, backoffJitter: new HalvingJitter());
+            var scheduler = new FakeScheduler();
+
+
+            var sequence = RetryAttempt.CreateRetrySequence(settings, scheduler);
+            // Sequence of theoretical backoffs is 2, 4, 8, 10, 10, 10
+            // Sequence of jittered backoffs is 1, 2, 4, 5, 5.
+            return AssertAttemptsAsync(sequence, scheduler, () => new Exception(), 0, 1, 3, 7, 12, 17);
+        }
+
+        [Fact]
+        public Task PredicateRespected()
+        {
+            int count = 0;
+            Func<Exception> exceptionProvider = () => ++count == 3 ? new Exception() : new RpcException(Status.DefaultCancelled);
+
+            var settings = RetrySettings.FromExponentialBackoff(
+                maxAttempts: 4, initialBackoff: OneSecond, maxBackoff: FiveSeconds,
+                backoffMultiplier: 1, retryFilter: ex => ex is RpcException, backoffJitter: RetrySettings.NoJitter);
+            var scheduler = new FakeScheduler();
+            var sequence = RetryAttempt.CreateRetrySequence(settings, scheduler);
+            return AssertAttemptsAsync(sequence, scheduler, exceptionProvider, 0, 1, 2);
+        }
+
+        [Fact]
+        public Task InitialBackoffOverrideRespected()
+        {
+            var settings = RetrySettings.FromConstantBackoff(
+                maxAttempts: 4, backoff: FiveSeconds, retryFilter: ex => true, backoffJitter: RetrySettings.NoJitter);
+            var scheduler = new FakeScheduler();
+
+            var sequence = RetryAttempt.CreateRetrySequence(settings, scheduler, initialBackoffOverride: OneSecond);
+            // Should attempt at T=0, T=1, T=6, T=11.
+            return AssertAttemptsAsync(sequence, scheduler, () => new Exception(), 0, 1, 6, 11);
+        }
+
+        private Task AssertAttemptsAsync(
+            IEnumerable<RetryAttempt> attempts, FakeScheduler scheduler, Func<Exception> exceptionProvider,
+            params int[] expectedAttemptTimes)
+        {
+            var start = scheduler.Clock.GetCurrentDateTimeUtc();
+            var iterator = attempts.GetEnumerator();
+            Assert.True(iterator.MoveNext());
+            return scheduler.RunAsync(async () =>
+            {
+                for (int i = 0; i < expectedAttemptTimes.Length; i++)
+                {
+                    var attempt = iterator.Current;
+                    bool expectedLastAttempt = (i == expectedAttemptTimes.Length - 1);
+                    Assert.Equal(start.AddSeconds(expectedAttemptTimes[i]), scheduler.Clock.GetCurrentDateTimeUtc());
+                    if (expectedLastAttempt)
+                    {
+                        Assert.False(attempt.ShouldRetry(exceptionProvider()));
+                    }
+                    else
+                    {
+                        Assert.True(attempt.ShouldRetry(exceptionProvider()));
+                        await attempt.BackoffAsync(default);
+                        Assert.True(iterator.MoveNext());
+                    }
+                }
+            });
+        }
+
+        private class HalvingJitter : RetrySettings.IJitter
+        {
+            public TimeSpan GetDelay(TimeSpan maxDelay) => TimeSpan.FromTicks(maxDelay.Ticks / 2);
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/RetryTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/RetryTest.cs
@@ -21,7 +21,7 @@ namespace Google.Api.Gax.Grpc.Tests
 {
     public class RetryTest
     {
-        private static readonly Predicate<RpcException> NotFoundFilter = RetrySettings.FilterForStatusCodes(StatusCode.NotFound);
+        private static readonly Predicate<Exception> NotFoundFilter = RetrySettings.FilterForStatusCodes(StatusCode.NotFound);
 
         private static async Task<TResponse> Call<TRequest, TResponse>(
             bool async, ApiCall<TRequest, TResponse> call, TRequest request, CallSettings callSettings)
@@ -250,7 +250,7 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Equal(time0 + delay, scheduler.Clock.GetCurrentDateTimeUtc());
         }
 
-        private static RetrySettings ConstantBackoff(int maxAttempts, TimeSpan backoff, Predicate<RpcException> retryFilter)
+        private static RetrySettings ConstantBackoff(int maxAttempts, TimeSpan backoff, Predicate<Exception> retryFilter)
         {
             GaxPreconditions.CheckNonNegativeDelay(backoff, nameof(backoff));
             return new RetrySettings(maxAttempts, backoff, backoff, 1.0, retryFilter, RetrySettings.NoJitter);

--- a/Google.Api.Gax.Grpc/RetryAttempt.cs
+++ b/Google.Api.Gax.Grpc/RetryAttempt.cs
@@ -1,0 +1,121 @@
+﻿/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// An attempt at a retriable operation. Use <see cref="CreateRetrySequence(RetrySettings, IScheduler, DateTime?, IClock, TimeSpan?)"/>
+    /// or <see cref="CreateRetrySequence(RetrySettings, IScheduler, TimeSpan?)"/> to create a sequence of attempts that follow the specified settings.
+    /// </summary>
+    public sealed class RetryAttempt
+    {
+        private readonly RetrySettings _settings;
+        private readonly IScheduler _scheduler;
+        private readonly IClock _clock;
+        private readonly DateTime? _deadline;
+
+        /// <summary>
+        /// The 1-based number of this attempt. If this is equal to <see cref="RetrySettings.MaxAttempts"/> for the settings
+        /// used to create this attempt, <see cref="ShouldRetry(Exception)"/> will always return false.
+        /// </summary>
+        public int AttemptNumber { get; }
+
+        /// <summary>
+        /// The time that will be used to sleep or delay in <see cref="Backoff"/> and <see cref="BackoffAsync(CancellationToken)"/>.
+        /// This has already had jitter applied to it.
+        /// </summary>
+        public TimeSpan JitteredBackoff { get; }
+
+        /// <summary>
+        /// Returns a sequence of retry attempts. The sequence has <see cref="RetrySettings.MaxAttempts"/> elements, and calling
+        /// <see cref="ShouldRetry(Exception)"/> on the last attempt will always return false. This overload assumes no deadline,
+        /// and so does not require a clock.
+        /// </summary>
+        /// <param name="settings">The retry settings to create a sequence for. Must not be null.</param>
+        /// <param name="scheduler">The scheduler to use for delays.</param>
+        /// <param name="initialBackoffOverride">An override value to allow an initial backoff which is not the same
+        /// as <see cref="RetrySettings.InitialBackoff"/>. This is typically to allow an "immediate first retry".</param>
+        /// <returns></returns>
+        public static IEnumerable<RetryAttempt> CreateRetrySequence(RetrySettings settings, IScheduler scheduler, TimeSpan? initialBackoffOverride = null)
+        {
+            GaxPreconditions.CheckNotNull(settings, nameof(settings));
+            GaxPreconditions.CheckNotNull(scheduler, nameof(scheduler));
+
+            TimeSpan backoff = initialBackoffOverride ?? settings.InitialBackoff;
+            for (int i = 1; i <= settings.MaxAttempts; i++)
+            {
+                yield return new RetryAttempt(settings, null, null, scheduler, i, settings.BackoffJitter.GetDelay(backoff));
+                backoff = settings.NextBackoff(backoff);
+            }
+        }
+
+        /// <summary>
+        /// Returns a sequence of retry attempts. The sequence has <see cref="RetrySettings.MaxAttempts"/> elements, and calling
+        /// <see cref="ShouldRetry(Exception)"/> on the last attempt will always return false.
+        /// </summary>
+        /// <param name="settings">The retry settings to create a sequence for. Must not be null.</param>
+        /// <param name="scheduler">The scheduler to use for delays.</param>
+        /// <param name="deadline">The overall deadline for the operation.</param>
+        /// <param name="clock">The clock to use to compare the current time with the deadline.</param>
+        /// <param name="initialBackoffOverride">An override value to allow an initial backoff which is not the same
+        /// as <see cref="RetrySettings.InitialBackoff"/>. This is typically to allow an "immediate first retry".</param>
+        /// <returns></returns>
+        public static IEnumerable<RetryAttempt> CreateRetrySequence(RetrySettings settings, IScheduler scheduler, DateTime? deadline, IClock clock, TimeSpan? initialBackoffOverride = null)
+        {
+            GaxPreconditions.CheckNotNull(settings, nameof(settings));
+            GaxPreconditions.CheckNotNull(clock, nameof(clock));
+            GaxPreconditions.CheckNotNull(scheduler, nameof(scheduler));
+
+            // It's simpler not to need nullable logic when computing deadlines.
+            var effectiveDeadline = deadline ?? DateTime.MaxValue;
+            TimeSpan backoff = initialBackoffOverride ?? settings.InitialBackoff;
+            for (int i = 1; i <= settings.MaxAttempts; i++)
+            {
+                yield return new RetryAttempt(settings, effectiveDeadline, clock, scheduler, i, settings.BackoffJitter.GetDelay(backoff));
+                backoff = settings.NextBackoff(backoff);
+            }
+        }
+
+        private RetryAttempt(RetrySettings settings, DateTime? deadline, IClock clock, IScheduler scheduler, int attemptNumber, TimeSpan jitteredBackoff) =>
+            (_settings, _deadline, _clock, _scheduler, AttemptNumber, JitteredBackoff) =
+            (settings, deadline, clock, scheduler, attemptNumber, jitteredBackoff);
+
+        /// <summary>
+        /// Indicates whether the operation should be retried when the given exception has been thrown.
+        /// This will return false if the exception indicates that the operation shouldn't be retried,
+        /// or the maximum number of attempts has been reached, or the next backoff would exceed the overall
+        /// deadline. (It is assumed that <see cref="Backoff"/> or <see cref="BackoffAsync"/>
+        /// will be called immediately afterwards.)
+        /// </summary>
+        /// <param name="exception">The exception thrown by the retriable operation.</param>
+        /// <returns><c>true</c> if the operation should be retried; <c>false</c> otherwise.</returns>
+        public bool ShouldRetry(Exception exception) =>
+            AttemptNumber < _settings.MaxAttempts &&
+            (_deadline is null || _clock.GetCurrentDateTimeUtc() + JitteredBackoff < _deadline) &&
+            _settings.RetryFilter(exception);
+
+        /// <summary>
+        /// Synchronously sleeps for a period of <see cref="JitteredBackoff"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to apply to the sleep operation.</param>
+        public void Backoff(CancellationToken cancellationToken) =>
+            _scheduler.Sleep(JitteredBackoff, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously delays for a period of <see cref="JitteredBackoff"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to apply to the delay operation.</param>
+        public Task BackoffAsync(CancellationToken cancellationToken) =>
+            _scheduler.Delay(JitteredBackoff, cancellationToken);
+    }
+}


### PR DESCRIPTION
This is currently just a proposal. Next steps would be:

- Adding tests
- Checking that we can use this easily in places that use RetrySettings in APIs (on next-major-version)

This is an alternative approach to #369. It avoids putting extra logic in RetrySettings, but hopefully gives a simpler API for other code that needs details of the retry sequence.