### PR TITLE
Generated MonitoredResource for GKE now supports new Stackdriver Kubernetes Engine Monitoring instead of Legacy Stackdriver

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -90,6 +90,7 @@ namespace Google.Api.Gax.Grpc.Tests
   'instance': {
     'attributes': {
       'cluster-name': 'FakeClusterName',
+      'cluster-location': 'FakeClusterLocation'
     },
     'id': '123',
     'zone': 'projects/FakeProject/zones/FakeLocation'
@@ -122,20 +123,15 @@ namespace Google.Api.Gax.Grpc.Tests
             };
             var platform = new Platform(GkePlatformDetails.TryLoad(metadataJson, kubernetesData));
             var resource = MonitoredResourceBuilder.FromPlatform(platform);
-            Assert.Equal("gke_container", resource.Type);
+            Assert.Equal("k8s_container", resource.Type);
             Assert.Equal(new Dictionary<string, string>
             {
                 { "project_id", "FakeProjectId" },
                 { "cluster_name", "FakeClusterName" },
-                // Although the name of the label is namespace_id, the actual value returned and expected
-                // by Stackdriver is the namespace name.
-                { "namespace_id", "namespacename" },
-                { "instance_id", "123" },
-                // Although the name of the label is pod_id, the actual value returned and expected
-                // by Stackdriver is the pod name.
-                { "pod_id", "podname" },
+                { "namespace_name", "namespacename" },
+                { "pod_name", "podname" },
                 { "container_name", "containername" },
-                { "zone", "FakeLocation" }
+                { "location", "FakeClusterLocation" }
             }, resource.Labels);
         }
     }

--- a/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
+++ b/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
@@ -86,16 +86,15 @@ namespace Google.Api.Gax.Grpc
                     var gke = platform.GkeDetails;
                     return new MonitoredResource
                     {
-                        Type = "gke_container",
+                        Type = "k8s_container",
                         Labels =
                         {
                             { "project_id", gke.ProjectId },
                             { "cluster_name", gke.ClusterName },
-                            { "namespace_id", gke.NamespaceId },
-                            { "instance_id", gke.InstanceId },
-                            { "pod_id", gke.PodId },
+                            { "namespace_name", gke.NamespaceId}, // The field really only contains the name.
+                            { "pod_name", gke.PodId },
                             { "container_name", gke.ContainerName },
-                            { "zone", gke.Location }
+                            { "location", gke.ClusterLocation }
                         }
                     };
                 case PlatformType.CloudRun:

--- a/Google.Api.Gax.Tests/PlatformTest.cs
+++ b/Google.Api.Gax.Tests/PlatformTest.cs
@@ -91,16 +91,17 @@ namespace Google.Api.Gax.Tests
             Assert.Throws<ArgumentNullException>(() => GkePlatformDetails.TryLoad(null, new GkePlatformDetails.KubernetesData()));
             Assert.Throws<ArgumentNullException>(() => GkePlatformDetails.TryLoad("", null));
             Assert.Null(GkePlatformDetails.TryLoad("", new GkePlatformDetails.KubernetesData()));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails(null, "", "", "", "", "", "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", null, "", "", "", "", "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", null, "", "", "", "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", null, "", "", "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", null, "", "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", null, "", "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", null, "", "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", null, "", ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", "", null, ""));
-            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", "", "", null));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails(null, "", "", "", "", "", "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", null, "", "", "", "", "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", null, "", "", "", "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", null, "", "", "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", null, "", "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", null, "", "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", null, "", "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", null, "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", "", null, "", ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", "", "", null, ""));
+            Assert.Throws<ArgumentNullException>(() => new GkePlatformDetails("", "", "", "", "", "", "", "", "", "", null));
         }
 
         [Theory]
@@ -156,7 +157,7 @@ namespace Google.Api.Gax.Tests
             Assert.Equal("platformintegrationtest", gke.ContainerName);
         }
 
-        const string metadataValid = "{'project':{'projectId':'FakeProjectId'},'instance':{'attributes':{'cluster-name':'FakeClusterName'},'id':'123','zone':'projects/FakeProject/zones/FakeLocation'}}";
+        const string metadataValid = "{'project':{'projectId':'FakeProjectId'},'instance':{'attributes':{'cluster-name':'FakeClusterName', 'cluster-location':'FakeClusterLocation'},'id':'123','zone':'projects/FakeProject/zones/FakeLocation'}}";
         const string metadataIncomplete = "{'project':{'projectId':'FakeProjectId'},'instance':{'attr";
         const string namespaceValid = "{'kind':'Namespace','metadata':{'name':'namespacename'}}";
         const string namespaceMissingKind = "{'notkind':'Namespace','metadata':{'name':'namespacename'}}";
@@ -223,7 +224,7 @@ namespace Google.Api.Gax.Tests
         {
             var details = new GkePlatformDetails(
                 "json", "gke-project", "cluster", "location", "host", "instance",
-                "projects/123/zone", "namespace", "pod", "container");
+                "projects/123/zone", "namespace", "pod", "container", "clusterLocation");
             var platform = new Platform(details);
             Assert.Equal("gke-project", platform.ProjectId);
         }

--- a/Google.Api.Gax.Tests/Resources/Metadata.json
+++ b/Google.Api.Gax.Tests/Resources/Metadata.json
@@ -2,6 +2,7 @@
   "instance": {
     "attributes": {
       "cluster-name": "platformintegrationtest",
+      "cluster-location": "europe-west2-c",
       "created-by": "projects/233772281425/zones/europe-west2-c/instanceGroupManagers/gke-platformintegrationt-default-pool-bf36c574-grp",
       "gci-ensure-gke-docker": "true",
       "gci-update-strategy": "update_disabled",


### PR DESCRIPTION
This is a breaking change:

  * The `Type` of the monitored resource is now `k8s_container` instead of `gke_container`.
  * The `instance_id` label is not included.
  * The `zone` label is not included.
  * A new `location` label is included whose value is the location of the cluster (may be different from node/pod location).
  * The `namespace_id` label is now called `namespace_name`. The value is the same.
  * The `pod_id` label is now called `pod_name`. The value is the same.

There's more information about Legacy to Stackdriver Kubernetes Engine Monitoring migration in https://cloud.google.com/monitoring/kubernetes-engine/migration.

All the information needed to build a Legacy GKE `Google.Api.MonitoredResource` can be found in `Google.Api.Gax.GkePlatformDetails`. An instance of `Google.Api.Gax.GkePlatformDetails` representing the platform the code is running in can be obtained by calling `Google.Api.Gax.Platfomr.Instance()`.

Closes #347 .