### PR TITLE
Release version 3.0.0-beta01 of all GAX packages

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.0.0-alpha00</Version>
+    <Version>3.0.0-beta01</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is the first pre-release of GAX v3. It contains breaking changes compared with GAX v2, and should not be used in any code with a dependency on GAX v2.

(Note that we'll definitely want to merge #394 first, and probably #393 as well.)