### PR TITLE
Make some methods on ChannelPool and ScopedCredentialProvider internal

### DIFF
--- a/Google.Api.Gax.Grpc/ChannelPool.cs
+++ b/Google.Api.Gax.Grpc/ChannelPool.cs
@@ -90,7 +90,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="endpoint">The endpoint to connect to. Must not be null.</param>
         /// <param name="channelOptions">The channel options to include. May be null.</param>
         /// <returns>A channel for the specified endpoint.</returns>
-        public ChannelBase GetChannel(GrpcAdapter grpcAdapter, string endpoint, GrpcChannelOptions channelOptions)
+        internal ChannelBase GetChannel(GrpcAdapter grpcAdapter, string endpoint, GrpcChannelOptions channelOptions)
         {
             GaxPreconditions.CheckNotNull(grpcAdapter, nameof(grpcAdapter));
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
@@ -109,7 +109,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>A task representing the asynchronous operation. The value of the completed
         /// task will be channel for the specified endpoint.</returns>
-        public async Task<ChannelBase> GetChannelAsync(GrpcAdapter grpcAdapter, string endpoint, GrpcChannelOptions channelOptions, CancellationToken cancellationToken)
+        internal async Task<ChannelBase> GetChannelAsync(GrpcAdapter grpcAdapter, string endpoint, GrpcChannelOptions channelOptions, CancellationToken cancellationToken)
         {
             GaxPreconditions.CheckNotNull(grpcAdapter, nameof(grpcAdapter));
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));

--- a/Google.Api.Gax.Rest/AssemblyInfo.cs
+++ b/Google.Api.Gax.Rest/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Google.Api.Gax.Rest.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100bfa2d20e82583e5f3a47efa518d8a7cda58d6e1b61f51ed3de3900f238fb01e0ca95b3ed1c68147e4865a336b252f070d5207e653c9014d271fc829c18981d1c80d418d300545c3ad0e1ff4d77c596177dbfe0a588fff57306f1d6ba655de3cfa520ad777ea73bb7a92fd6027071c94bb12d5871fcd076299de0502bca12e3aa")]

--- a/Google.Api.Gax.Rest/ScopedCredentialProvider.cs
+++ b/Google.Api.Gax.Rest/ScopedCredentialProvider.cs
@@ -48,7 +48,7 @@ namespace Google.Api.Gax.Rest
         /// in which case the default application credentials will be used.</param>
         /// <returns>A task representing the asynchronous operation. The result of the task
         /// is the scoped credentials.</returns>
-        public GoogleCredential GetCredentials(GoogleCredential credentials) =>
+        internal GoogleCredential GetCredentials(GoogleCredential credentials) =>
             credentials == null
                 // No need to apply scopes here - they're already applied.
                 ? _lazyScopedDefaultCredentials.Value.ResultWithUnwrappedExceptions()
@@ -62,7 +62,7 @@ namespace Google.Api.Gax.Rest
         /// <param name="cancellationToken">A cancellation token for the operation.</param>
         /// <returns>A task representing the asynchronous operation. The result of the task
         /// is the scoped credentials.</returns>
-        public Task<GoogleCredential> GetCredentialsAsync(GoogleCredential credentials, CancellationToken cancellationToken) =>
+        internal Task<GoogleCredential> GetCredentialsAsync(GoogleCredential credentials, CancellationToken cancellationToken) =>
             credentials == null
                 ? WithCancellationToken(_lazyScopedDefaultCredentials.Value, cancellationToken)
                 : Task.FromResult(ApplyScopes(credentials));


### PR DESCRIPTION
These can be made public later, but while they're internal we can
change the signatures easily if necessary.

The client libraries don't currently call these methods themselves,
and it seems unlikely that customer code would need to.