### PR TITLE
Release GAX 3.0.0-beta02

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.0.0-beta01</Version>
+    <Version>3.0.0-beta02</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes since 3.0.0-beta01:

- Google.Apis.Auth dependency updated
- The "gccl" value in x-goog-api-client is now omitted
- ServiceSettingsBase exposes VersionHeaderBuilder publicly so that manual libraries can add "gccl" back into x-goog-api-client
- The gRPC ClientBuilderBase respects cancellation tokens more widely
- ChannelPool and ScopedCredentialProvider methods for retrieving
  channels/credentials have been made internal, as they're now not
  used within API libraries, only in ClientBuilderBase