### PR TITLE
Update auth dependencies to 1.44.1

### DIFF
--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
     <PackageReference Include="Grpc.Auth" Version="2.27.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.44.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.44.1" />
     
     <PackageReference Include="Grpc.Core.Api" Version="2.27.0" />
     

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="1.44.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.44.1" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />


### PR DESCRIPTION
This should fix our integration tests, which are failing due the
bug in 1.44.0 which makes loading credentials from a file
asynchronously fail due to a stream being closed while we're trying
to read from it.