### PR TITLE
Release all GAX libraries as v3.0.0.

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.Production.xml" />
 
   <PropertyGroup>
-    <Version>2.0.0-beta02</Version>
+    <Version>2.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 

--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.0.0-beta03</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
There are no changes since 3.0.0-beta03.