### PR TITLE
Adds support for QuotaProject as a client builder option for both GAX and REST.

### DIFF
--- a/Google.Api.Gax.Grpc.GrpcCore/Google.Api.Gax.Grpc.GrpcCore.csproj
+++ b/Google.Api.Gax.Grpc.GrpcCore/Google.Api.Gax.Grpc.GrpcCore.csproj
@@ -15,6 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.27.0, 3.0.0)"/>
+    <PackageReference Include="Grpc.Core" Version="[2.31.0, 3.0.0)"/>
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Grpc.GrpcNetClient/Google.Api.Gax.Grpc.GrpcNetClient.csproj
+++ b/Google.Api.Gax.Grpc.GrpcNetClient/Google.Api.Gax.Grpc.GrpcNetClient.csproj
@@ -15,6 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
-    <PackageReference Include="Grpc.Net.Client" Version="[2.27.0, 3.0.0)"/>
+    <PackageReference Include="Grpc.Net.Client" Version="[2.31.0, 3.0.0)"/>
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -17,8 +17,8 @@
     <ProjectReference Include="..\Google.Api.CommonProtos\Google.Api.CommonProtos.csproj" />
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Grpc.Auth" Version="[2.27.0, 3.0.0)" />
-    <PackageReference Include="Google.Apis.Auth" Version="[1.44.1, 2.0.0)" />    
-    <PackageReference Include="Grpc.Core.Api" Version="[2.27.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Auth" Version="[2.31.0, 3.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.48.0, 2.0.0)" />
+    <PackageReference Include="Grpc.Core.Api" Version="[2.31.0, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -16,6 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="[1.44.1, 2.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.48.0, 2.0.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Marking as draft because:

- Google.Apis.Auth dependencies need to be reverted to packages instead of project.
- I still need to write the content for the file explaining why we are deprecataing per call credentials.

This won't build on Travis or AppVeyor until we have updated the dependencies.
As usual one commit at a time will make the most sense.