### PR TITLE
Makes it impossible to send the x-goog-user-project header more than once.

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
@@ -26,7 +26,7 @@ namespace Google.Api.Gax.Grpc.Tests
         [Fact]
         public void MergedWith_OneNull()
         {
-            CallSettings settings1 = new CallSettings(null, null, null, null, null, null, null);
+            CallSettings settings1 = new CallSettings(null, null, null, null, null, null);
             CallSettings settings2 = null;
             Assert.Same(settings1, settings1.MergedWith(settings2));
             Assert.Same(settings1, settings2.MergedWith(settings1));
@@ -40,8 +40,8 @@ namespace Google.Api.Gax.Grpc.Tests
 
             CancellationToken token = new CancellationTokenSource().Token;
 
-            var settings1 = new CallSettings(token, null, expiration1, null, null, null, null);
-            var settings2 = new CallSettings(null, null, expiration2, null, null, null, null);
+            var settings1 = new CallSettings(token, expiration1, null, null, null, null);
+            var settings2 = new CallSettings(null, expiration2, null, null, null, null);
             var merged = settings1.MergedWith(settings2);
             Assert.Equal(token, merged.CancellationToken);
             Assert.Same(expiration2, merged.Expiration);
@@ -51,7 +51,7 @@ namespace Google.Api.Gax.Grpc.Tests
         public void WithCancellationToken()
         {
             CancellationToken token1 = new CancellationTokenSource().Token;
-            var original = new CallSettings(token1, null, Expiration.None, null, null, null, null);
+            var original = new CallSettings(token1, Expiration.None, null, null, null, null);
 
             CancellationToken token2 = new CancellationTokenSource().Token;
             var result = original.WithCancellationToken(token2);
@@ -69,9 +69,11 @@ namespace Google.Api.Gax.Grpc.Tests
 
             CancellationToken token = new CancellationTokenSource().Token;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var original = new CallSettings(token, credentials1, null, null, null, null, null);
             var result = original.WithCallCredentials(credentials2);
             Assert.Same(credentials2, result.Credentials);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(token, result.CancellationToken);
         }
 
@@ -79,11 +81,13 @@ namespace Google.Api.Gax.Grpc.Tests
         public void WithCallCredentials_NullSettings()
         {
             CallSettings noSettings = null;
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Null(noSettings.WithCallCredentials(null));
             AsyncAuthInterceptor interceptor = (context, metadata) => Task.Delay(0);
             var credentials = CallCredentials.FromInterceptor(interceptor);
             var result = noSettings.WithCallCredentials(credentials);
             Assert.Same(credentials, result.Credentials);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -93,9 +97,11 @@ namespace Google.Api.Gax.Grpc.Tests
             var credentials = CallCredentials.FromInterceptor(interceptor);
             CancellationToken token = new CancellationTokenSource().Token;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var original = new CallSettings(token, credentials, null, null, null, null, null);
             var result = original.WithCallCredentials(null);
             Assert.Null(result.Credentials);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(token, result.CancellationToken);
         }
 

--- a/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
@@ -117,6 +117,14 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Same(callSettings.WriteOptions, options.WriteOptions);
         }
 
+        [Theory]
+        [InlineData("x-goog-user-project", "my-project")]
+        public void ToCallOptions_InvalidHeaderMutations(string header, string value) =>
+            Assert.Throws<InvalidOperationException>(
+                () => CallSettings
+                .FromHeaderMutation(metadata => metadata.Add(new Metadata.Entry(header, value)))
+                .ToCallOptions(new Mock<IClock>().Object));
+
         [Fact]
         public void CancellationTokenNone()
         {
@@ -182,6 +190,11 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Equal("name", metadata[0].Key);
             Assert.Equal("value", metadata[0].Value);
         }
+
+        [Theory]
+        [InlineData("x-goog-user-project", "my-project")]
+        public void FromHeader_Invalid(string header, string value) =>
+            Assert.Throws<InvalidOperationException>(() => CallSettings.FromHeader(header, value));
 
         // Note: this test may well need to change, e.g. if we start to use a side channel.
         [Fact]

--- a/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/CallSettingsTest.cs
@@ -23,8 +23,8 @@ namespace Google.Api.Gax.Grpc.Tests
             Action<Metadata> clearAndAddFoo = m => { m.Clear(); m.Add("foo", "bar"); };
             Action<Metadata> addSample = m => m.Add("sample", "value");
 
-            CallSettings clearAndAddFooSettings = new CallSettings(null, null, null, null, clearAndAddFoo, null, null);
-            CallSettings addSampleSettings = new CallSettings(null, null, null, null, addSample, null, null);
+            CallSettings clearAndAddFooSettings = new CallSettings(null, null, null, clearAndAddFoo, null, null);
+            CallSettings addSampleSettings = new CallSettings(null, null, null, addSample, null, null);
 
             var merged1 = CallSettings.Merge(clearAndAddFooSettings, addSampleSettings);
             var merged2 = CallSettings.Merge(addSampleSettings, clearAndAddFooSettings);
@@ -107,8 +107,7 @@ namespace Google.Api.Gax.Grpc.Tests
                 retry: new RetrySettings(5, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), 2.0, RetrySettings.FilterForStatusCodes(), RetrySettings.RandomJitter),
                 cancellationToken: new CancellationTokenSource().Token,
                 writeOptions: new WriteOptions(WriteFlags.NoCompress),
-                propagationToken: null, // Not possible to create/mock
-                credentials: null // Not possible to create/mock
+                propagationToken: null // Not possible to create/mock
             );
             var options = callSettings.ToCallOptions(mockClock.Object);
             Assert.Equal(1, options.Headers.Count);
@@ -156,11 +155,13 @@ namespace Google.Api.Gax.Grpc.Tests
         [Fact]
         public void FromCredential()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Null(CallSettings.FromCallCredentials(null));
             AsyncAuthInterceptor interceptor = (context, metadata) => Task.Delay(0);
             var credential = CallCredentials.FromInterceptor(interceptor);
             var settings = CallSettings.FromCallCredentials(credential);
             Assert.Same(credential, settings.Credentials);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/Google.Api.Gax.Grpc.Tests/ServiceSettingsBaseTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ServiceSettingsBaseTest.cs
@@ -34,7 +34,7 @@ namespace Google.Api.Gax.Grpc.Tests
         public void Clone()
         {
             var clock = new Mock<IClock>();
-            var callSettings = new CallSettings(new CancellationTokenSource().Token, null, null, null, null, null, null);
+            var callSettings = new CallSettings(new CancellationTokenSource().Token, null, null, null, null, null);
             var settings = new TestSettings
             {
                 CallSettings = callSettings,

--- a/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/Google.Api.Gax.Grpc/CallSettings.cs
@@ -42,7 +42,10 @@ namespace Google.Api.Gax.Grpc
         }
 
         /// <summary>
-        /// Obsolete. Plese use <see cref="CallSettings(System.Threading.CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken)"/> instead.
+        /// Obsolete.
+        /// This is obsolete as it allows per-call credentials to be specified.
+        /// Please use <see cref="CallSettings(System.Threading.CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken)"/>,
+        /// and see https://github.com/googleapis/gax-dotnet/blob/master/docs/PER_CALL_CREDENTIAL.md for more information.
         /// Constructs an instance with the specified settings.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
@@ -52,7 +55,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="headerMutation">Action to modify the headers to send at the beginning of the call.</param>
         /// <param name="writeOptions"><see cref="global::Grpc.Core.WriteOptions"/> that will be used for the call.</param>
         /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
-        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
+        [Obsolete("This is obsolete as it allows per-call credentials to be specified. Please use an alternative overload and see https://github.com/googleapis/gax-dotnet/blob/master/docs/PER_CALL_CREDENTIAL.md for more information.")]
         public CallSettings(
             CancellationToken? cancellationToken,
             CallCredentials credentials,
@@ -84,19 +87,17 @@ namespace Google.Api.Gax.Grpc
             ContextPropagationToken propagationToken,
             Action<Metadata> responseMetadataHandler,
             Action<Metadata> trailingMetadataHandler)
+#pragma warning disable CS0618 // Type or member is obsolete
+            : this(cancellationToken, null, expiration, retry, headerMutation, writeOptions, propagationToken, responseMetadataHandler, trailingMetadataHandler)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
-            CancellationToken = cancellationToken;
-            Expiration = expiration;
-            Retry = retry;
-            HeaderMutation = headerMutation;
-            WriteOptions = writeOptions;
-            PropagationToken = propagationToken;
-            ResponseMetadataHandler = responseMetadataHandler;
-            TrailingMetadataHandler = trailingMetadataHandler;
         }
 
         /// <summary>
-        /// Obsolete. Please use <see cref="CallSettings(CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken, Action{Metadata}, Action{Metadata})"/> instead.
+        /// Obsolete.
+        /// This is obsolete as it allows per-call credentials to be specified.
+        /// Please use <see cref="CallSettings(CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken, Action{Metadata}, Action{Metadata})"/>,
+        /// and see https://github.com/googleapis/gax-dotnet/blob/master/docs/PER_CALL_CREDENTIAL.md for more information.
         /// Constructs an instance with the specified settings.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
@@ -108,7 +109,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
         /// <param name="responseMetadataHandler">Action to invoke when response metadata is received.</param>
         /// <param name="trailingMetadataHandler">Action to invoke when trailing metadata is received.</param>
-        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
+        [Obsolete("This is obsolete as it allows per-call credentials to be specified. Please use an alternative overload and see https://github.com/googleapis/gax-dotnet/blob/master/docs/PER_CALL_CREDENTIAL.md for more information.")]
         public CallSettings(
             CancellationToken? cancellationToken,
             CallCredentials credentials,

--- a/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/Google.Api.Gax.Grpc/CallSettings.cs
@@ -20,9 +20,29 @@ namespace Google.Api.Gax.Grpc
         internal const string RequestParamsHeader = "x-goog-request-params";
         internal const string RequestReasonHeader = "x-goog-request-reason";
 
-        internal static CallSettings CancellationTokenNone { get; } = new CallSettings(default(CancellationToken), null, null, null, null, null, null);
+        internal static CallSettings CancellationTokenNone { get; } = new CallSettings(default(CancellationToken), null, null, null, null, null);
 
         /// <summary>
+        /// Constructs an instance with the specified settings.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
+        /// <param name="expiration"><see cref="Expiration"/> to use, or null for default expiration behavior.</param>
+        /// <param name="retry"><see cref="Retry"/> to use, or null for default retry behavior.</param>
+        /// <param name="headerMutation">Action to modify the headers to send at the beginning of the call.</param>
+        /// <param name="writeOptions"><see cref="global::Grpc.Core.WriteOptions"/> that will be used for the call.</param>
+        /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
+        public CallSettings(
+            CancellationToken? cancellationToken,
+            Expiration expiration,
+            RetrySettings retry,
+            Action<Metadata> headerMutation,
+            WriteOptions writeOptions,
+            ContextPropagationToken propagationToken) : this(cancellationToken, expiration, retry, headerMutation, writeOptions, propagationToken, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Obsolete. Plese use <see cref="CallSettings(System.Threading.CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken)"/> instead.
         /// Constructs an instance with the specified settings.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
@@ -32,6 +52,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="headerMutation">Action to modify the headers to send at the beginning of the call.</param>
         /// <param name="writeOptions"><see cref="global::Grpc.Core.WriteOptions"/> that will be used for the call.</param>
         /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
+        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
         public CallSettings(
             CancellationToken? cancellationToken,
             CallCredentials credentials,
@@ -47,6 +68,38 @@ namespace Google.Api.Gax.Grpc
         /// Constructs an instance with the specified settings.
         /// </summary>
         /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
+        /// <param name="expiration"><see cref="Expiration"/> to use, or null for default expiration behavior.</param>
+        /// <param name="retry"><see cref="Retry"/> to use, or null for default retry behavior.</param>
+        /// <param name="headerMutation">Action to modify the headers to send at the beginning of the call.</param>
+        /// <param name="writeOptions"><see cref="global::Grpc.Core.WriteOptions"/> that will be used for the call.</param>
+        /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
+        /// <param name="responseMetadataHandler">Action to invoke when response metadata is received.</param>
+        /// <param name="trailingMetadataHandler">Action to invoke when trailing metadata is received.</param>
+        public CallSettings(
+            CancellationToken? cancellationToken,
+            Expiration expiration,
+            RetrySettings retry,
+            Action<Metadata> headerMutation,
+            WriteOptions writeOptions,
+            ContextPropagationToken propagationToken,
+            Action<Metadata> responseMetadataHandler,
+            Action<Metadata> trailingMetadataHandler)
+        {
+            CancellationToken = cancellationToken;
+            Expiration = expiration;
+            Retry = retry;
+            HeaderMutation = headerMutation;
+            WriteOptions = writeOptions;
+            PropagationToken = propagationToken;
+            ResponseMetadataHandler = responseMetadataHandler;
+            TrailingMetadataHandler = trailingMetadataHandler;
+        }
+
+        /// <summary>
+        /// Obsolete. Please use <see cref="CallSettings(CancellationToken?, Expiration, RetrySettings, Action{Metadata}, WriteOptions, ContextPropagationToken, Action{Metadata}, Action{Metadata})"/> instead.
+        /// Constructs an instance with the specified settings.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token that can be used for cancelling the call.</param>
         /// <param name="credentials">Credentials to use for the call.</param>
         /// <param name="expiration"><see cref="Expiration"/> to use, or null for default expiration behavior.</param>
         /// <param name="retry"><see cref="Retry"/> to use, or null for default retry behavior.</param>
@@ -55,6 +108,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="propagationToken"><see cref="ContextPropagationToken"/> for propagating settings from a parent call.</param>
         /// <param name="responseMetadataHandler">Action to invoke when response metadata is received.</param>
         /// <param name="trailingMetadataHandler">Action to invoke when trailing metadata is received.</param>
+        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
         public CallSettings(
             CancellationToken? cancellationToken,
             CallCredentials credentials,
@@ -101,6 +155,7 @@ namespace Google.Api.Gax.Grpc
         /// <summary>
         /// Credentials to use for the call.
         /// </summary>
+        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
         public CallCredentials Credentials { get; }
 
         /// <summary>
@@ -144,6 +199,8 @@ namespace Google.Api.Gax.Grpc
             {
                 return original;
             }
+#pragma warning disable CS0618 // Type or member is obsolete.
+            // But as long as user code can specify credentials we should continue to respect that.
             return new CallSettings(
                 overlaid.CancellationToken ?? original.CancellationToken,
                 overlaid.Credentials ?? original.Credentials,
@@ -156,6 +213,7 @@ namespace Google.Api.Gax.Grpc
                 overlaid.PropagationToken ?? original.PropagationToken,
                 original.ResponseMetadataHandler + overlaid.ResponseMetadataHandler,
                 original.TrailingMetadataHandler + overlaid.TrailingMetadataHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -164,14 +222,16 @@ namespace Google.Api.Gax.Grpc
         /// <param name="cancellationToken">The cancellation token for the new settings.</param>
         /// <returns>A new instance.</returns>
         public static CallSettings FromCancellationToken(CancellationToken cancellationToken) =>
-            cancellationToken.CanBeCanceled ? new CallSettings(cancellationToken, null, null, null, null, null, null) : CancellationTokenNone;
+            cancellationToken.CanBeCanceled ? new CallSettings(cancellationToken, null, null, null, null, null) : CancellationTokenNone;
 
         /// <summary>
+        /// Obsolete. See: https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md
         /// Creates a <see cref="CallSettings"/> for the specified call credentials, or returns null
         /// if <paramref name="credentials"/> is null.
         /// </summary>
         /// <param name="credentials">The call credentials for the new settings.</param>
         /// <returns>A new instance, or null if <paramref name="credentials"/> is null.</returns>
+        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
         public static CallSettings FromCallCredentials(CallCredentials credentials) =>
             credentials == null ? null : new CallSettings(null, credentials, null, null, null, null, null);
 
@@ -182,7 +242,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="expiration">The call timing for the new settings.</param>
         /// <returns>A new instance or null if <paramref name="expiration"/> is null..</returns>
         public static CallSettings FromExpiration(Expiration expiration) =>
-            expiration == null ? null : new CallSettings(null, null, expiration,  null, null, null, null);
+            expiration == null ? null : new CallSettings(null, expiration,  null, null, null, null);
 
         /// <summary>
         /// Creates a <see cref="CallSettings"/> for the specified retry settings, or returns null
@@ -191,7 +251,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="retry">The call timing for the new settings.</param>
         /// <returns>A new instance or null if <paramref name="retry"/> is null..</returns>
         public static CallSettings FromRetry(RetrySettings retry) =>
-            retry == null ? null : new CallSettings(null, null, null, retry, null, null, null);
+            retry == null ? null : new CallSettings(null, null, retry, null, null, null);
 
         /// <summary>
         /// Creates a <see cref="CallSettings"/> for the specified header mutation, or returns null
@@ -200,7 +260,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="headerMutation">Action to modify the headers to send at the beginning of the call.</param>
         /// <returns>A new instance, or null if <paramref name="headerMutation"/> is null..</returns>
         public static CallSettings FromHeaderMutation(Action<Metadata> headerMutation) =>
-            headerMutation == null ? null : new CallSettings(null, null, null, null, headerMutation, null, null);
+            headerMutation == null ? null : new CallSettings(null, null, null, headerMutation, null, null);
 
         /// <summary>
         /// Creates a <see cref="CallSettings"/> for the specified response metadata handler, or returns null
@@ -209,7 +269,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="responseMetadataHandler">Action to receive response metadata when the call completes.</param>
         /// <returns>A new instance, or null if <paramref name="responseMetadataHandler"/> is null..</returns>
         public static CallSettings FromResponseMetadataHandler(Action<Metadata> responseMetadataHandler) =>
-            responseMetadataHandler == null ? null : new CallSettings(null, null, null, null, null, null, null, responseMetadataHandler, null);
+            responseMetadataHandler == null ? null : new CallSettings(null, null, null, null, null, null, responseMetadataHandler, null);
 
         /// <summary>
         /// Creates a <see cref="CallSettings"/> for the specified trailing metadata handler, or returns null
@@ -218,7 +278,7 @@ namespace Google.Api.Gax.Grpc
         /// <param name="trailingMetadataHandler">Action to receive trailing metadata when the call completes.</param>
         /// <returns>A new instance, or null if <paramref name="trailingMetadataHandler"/> is null..</returns>
         public static CallSettings FromTrailingMetadataHandler(Action<Metadata> trailingMetadataHandler) =>
-            trailingMetadataHandler == null ? null : new CallSettings(null, null, null, null, null, null, null, null, trailingMetadataHandler);
+            trailingMetadataHandler == null ? null : new CallSettings(null, null, null, null, null, null, null, trailingMetadataHandler);
         
         /// <summary>
         /// Creates a <see cref="CallSettings"/> for the specified header name and value.

--- a/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/Google.Api.Gax.Grpc/CallSettings.cs
@@ -289,6 +289,7 @@ namespace Google.Api.Gax.Grpc
         public static CallSettings FromHeader(string name, string value)
         {
             GaxPreconditions.CheckNotNull(name, nameof(name));
+            CallSettingsExtensions.CheckHeader(name);
             GaxPreconditions.CheckNotNull(value, nameof(value));
             return FromHeaderMutation(metadata => metadata.Add(name, value));
         }

--- a/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
+++ b/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
@@ -45,6 +45,7 @@ namespace Google.Api.Gax.Grpc
             settings.MergedWith(CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
+        /// Obsolete. https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md
         /// Returns a new <see cref="CallSettings"/> with the specified call credentials,
         /// merged with the (optional) original settings specified by <paramref name="settings"/>.
         /// </summary>
@@ -55,6 +56,7 @@ namespace Google.Api.Gax.Grpc
         /// not present in the new call settings. If both this and <paramref name="settings"/> are null,
         /// the return value is null.</param>
         /// <returns>A new set of call settings, or null if both parameters are null.</returns>
+        [Obsolete("https://github.com/googleapis/gax-dotnet/blob/master/PER_CALL_CREDENTIAL.md")]
         public static CallSettings WithCallCredentials(
             this CallSettings settings,
             CallCredentials credentials) =>
@@ -80,10 +82,13 @@ namespace Google.Api.Gax.Grpc
             Expiration expiration) =>
             settings == null
                 ? CallSettings.FromExpiration(expiration)
+#pragma warning disable CS0618 // Type or member is obsolete
+                // But as long as user code can specify credentials we should continue to respect that.
                 : new CallSettings(settings.CancellationToken, settings.Credentials,
                     expiration, settings.Retry, settings.HeaderMutation,
                     settings.WriteOptions, settings.PropagationToken,
                     settings.ResponseMetadataHandler, settings.TrailingMetadataHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Returns a new <see cref="CallSettings"/> with the specified retry settings,
@@ -101,10 +106,13 @@ namespace Google.Api.Gax.Grpc
             RetrySettings retry) =>
             settings == null
                 ? CallSettings.FromRetry(retry)
+#pragma warning disable CS0618 // Type or member is obsolete
+                // But as long as user code can specify credentials we should continue to respect that.
                 : new CallSettings(settings.CancellationToken, settings.Credentials,
                     settings.Expiration, retry, settings.HeaderMutation,
                     settings.WriteOptions, settings.PropagationToken,
                     settings.ResponseMetadataHandler, settings.TrailingMetadataHandler);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Returns a new <see cref="CallSettings"/> with the specified header,
@@ -221,7 +229,10 @@ namespace Google.Api.Gax.Grpc
                 cancellationToken: callSettings.CancellationToken ?? default(CancellationToken),
                 writeOptions: callSettings.WriteOptions,
                 propagationToken: callSettings.PropagationToken,
+#pragma warning disable CS0618 // Type or member is obsolete
+                // But as long as user code can specify credentials we should continue to respect that.
                 credentials: callSettings.Credentials);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/docs/PER_CALL_CREDENTIAL.md
+++ b/docs/PER_CALL_CREDENTIAL.md
@@ -1,0 +1,49 @@
+### Per call credentials depreaction.
+As of Google.Api.Gax 3.1.0, `Google.Api.Gax.Grpc.CallSettings.CallCredetianls` has been marked obsolete,
+as well as the `Google.Api.Gax.Grpc.CallSettings` constructors that receive `Grpc.Core.CallCredentials`
+as a parameter. The behaviour due to using any of these members is the same as before and it's described below.
+
+### Specifying call credentials for a gRPC call.
+There are two ways in which you can specify call credentials for gRPC calls.
+
+  * You can set any of the credential sources in client builders inheriting from
+  `Google.Api.Gax.Grcp.ClientBuilderBase` (or none, and defaults will be used).
+  All calls made with clients built from these builders will include the specified credential.
+  * You can set credentials on `Google.Api.Gax.Grpc.CallSettings`. All calls made with these
+  settings will include the specified credential in addition to the credential specified
+  for the client.
+
+This means that both call credentials specified for the client and for the specific call
+will be sent to the service. The credential specified at the call site (via `CallSettings`)
+does not override the credential specified at the client.
+
+Given that Google APIs only accept one credential (ignoring all others), we have decided to
+deprecate `Google.Api.Gax.Grpc.CallSettings.CallCredetianls` to avoid sending two credentials
+per call, which could lead to unexpected behaviour now or in the future.
+
+It's not recommended that you use the obsolete members when communicating with Google APIs.
+If you need to make calls with different credentials, the recommendation is to create a client
+per credential.
+
+If for some reason you still need to make calls to Google APIs with different credentials and
+cannot create different clients then use the following approach to guarantee that just one credential
+is being sent.
+
+  * Set an `Grpc.Core.SslCredentials` on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`.
+  `SslCredentials` do not contain a credential that can be used to authenticate and authorize calls, it's
+  only used to establish the TSL channel used for communication with the service.
+  * And use `Google.Api.Gax.Grpc.CallSettings` for each call by setting `CallCredentials` to the specific
+  credential. Take into account that you'd still be using an obsolete member that will eventually dissapear from
+  `Google.Api.Gax.Grpc`.
+
+### Making calls with multiple credentials.
+Gax libraries can be used to communicate with services other than Google APIs, and some of those
+may accept or even require multiple credentials to be sent per call. This is still achievable.
+
+  * By setting a composed gRPC credential on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`.
+  See [gRPC's .NET library documentation](https://grpc.io/docs/languages/csharp/) for more details on how
+  to compose credentials.
+  * Or by setting both a credential on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`
+  and on `Google.Api.Gax.Grpc.CallSettings.CallCredetianls`.
+  Take into account that you'd still be using an obsolete member that will eventually dissapear from
+  `Google.Api.Gax.Grpc`.

--- a/docs/PER_CALL_CREDENTIAL.md
+++ b/docs/PER_CALL_CREDENTIAL.md
@@ -1,5 +1,5 @@
-### Per call credentials depreaction.
-As of Google.Api.Gax 3.1.0, `Google.Api.Gax.Grpc.CallSettings.CallCredetianls` has been marked obsolete,
+# Per-call credentials deprecation
+As of Google.Api.Gax 3.1.0, `Google.Api.Gax.Grpc.CallSettings.CallCredentials` has been marked obsolete,
 as well as the `Google.Api.Gax.Grpc.CallSettings` constructors that receive `Grpc.Core.CallCredentials`
 as a parameter. The behaviour due to using any of these members is the same as before and it's described below.
 
@@ -7,7 +7,7 @@ as a parameter. The behaviour due to using any of these members is the same as b
 There are two ways in which you can specify call credentials for gRPC calls.
 
   * You can set any of the credential sources in client builders inheriting from
-  `Google.Api.Gax.Grcp.ClientBuilderBase` (or none, and defaults will be used).
+  `Google.Api.Gax.Grpc.ClientBuilderBase` (or none, and defaults will be used).
   All calls made with clients built from these builders will include the specified credential.
   * You can set credentials on `Google.Api.Gax.Grpc.CallSettings`. All calls made with these
   settings will include the specified credential in addition to the credential specified
@@ -18,10 +18,10 @@ will be sent to the service. The credential specified at the call site (via `Cal
 does not override the credential specified at the client.
 
 Given that Google APIs only accept one credential (ignoring all others), we have decided to
-deprecate `Google.Api.Gax.Grpc.CallSettings.CallCredetianls` to avoid sending two credentials
+deprecate `Google.Api.Gax.Grpc.CallSettings.CallCredentials` to avoid sending two credentials
 per call, which could lead to unexpected behaviour now or in the future.
 
-It's not recommended that you use the obsolete members when communicating with Google APIs.
+We recommend that you do not use the obsolete members when communicating with Google APIs.
 If you need to make calls with different credentials, the recommendation is to create a client
 per credential.
 
@@ -30,20 +30,20 @@ cannot create different clients then use the following approach to guarantee tha
 is being sent.
 
   * Set an `Grpc.Core.SslCredentials` on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`.
-  `SslCredentials` do not contain a credential that can be used to authenticate and authorize calls, it's
-  only used to establish the TSL channel used for communication with the service.
-  * And use `Google.Api.Gax.Grpc.CallSettings` for each call by setting `CallCredentials` to the specific
+  `SslCredentials` do not contain a credential that can be used to authenticate and authorize calls; they are
+  only used to establish the TLS channel used for communication with the service.
+  *  Use `Google.Api.Gax.Grpc.CallSettings` for each call by setting `CallCredentials` to the specific
   credential. Take into account that you'd still be using an obsolete member that will eventually dissapear from
   `Google.Api.Gax.Grpc`.
 
 ### Making calls with multiple credentials.
-Gax libraries can be used to communicate with services other than Google APIs, and some of those
+GAX libraries can be used to communicate with services other than Google APIs, and some of those
 may accept or even require multiple credentials to be sent per call. This is still achievable.
 
   * By setting a composed gRPC credential on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`.
   See [gRPC's .NET library documentation](https://grpc.io/docs/languages/csharp/) for more details on how
   to compose credentials.
   * Or by setting both a credential on `Google.Api.Gax.Grcp.ClientBuilderBase.ChannelCredentials`
-  and on `Google.Api.Gax.Grpc.CallSettings.CallCredetianls`.
+  and on `Google.Api.Gax.Grpc.CallSettings.CallCredentials`.
   Take into account that you'd still be using an obsolete member that will eventually dissapear from
   `Google.Api.Gax.Grpc`.


### PR DESCRIPTION
This is done by:

- Marking gRPC per call credentials obsolote. (gRPC sends both the channel and the call credential and if both have x-goog-user-project specified the header will be sent twice).
- Failing if client code tries to explicitly set the x-goog-user-project header.

After this PR, x-goog-user-project header can now only be sent if it is present one crendetial being used for the call.

TODO: Write the information about per call credentials deprecation.