### PR TITLE
Fix badge by simplifying workflow name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build on push/PR
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![GitHub Actions status](https://img.shields.io/github/workflow/status/googleapis/gax-dotnet/Build%20push)](https://github.com/googleapis/gax-dotnet/actions?query=workflow%3A%22Build+push%22)
+[![GitHub Actions
+status](https://img.shields.io/github/workflow/status/googleapis/gax-dotnet/Build)](https://github.com/googleapis/gax-dotnet/actions?query=workflow%3ABuild)
 
 Google API Extensions for .NET
 ===


### PR DESCRIPTION
Including slashes in the workflow name makes it hard to get the
badge working.