### PR TITLE
Make the single public Grpc-Rest class conditionally defined

### DIFF
--- a/CommonProperties.Test.xml
+++ b/CommonProperties.Test.xml
@@ -3,6 +3,9 @@
 
   <!-- Build information -->
   <PropertyGroup>
+    <!-- Exclude REGAPIC (Google.Api.Grpc.Rest) unless the REGAPIC property is set to "true" -->
+    <DefineConstants Condition="'$(REGAPIC)' == 'true'">REGAPIC</DefineConstants>
+
     <AssemblyOriginatorKeyFile>../Gax.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <NoWarn>1701;1702;1705;xUnit2013;AD0001</NoWarn>

--- a/CommonProperties.xml
+++ b/CommonProperties.xml
@@ -6,6 +6,10 @@
 
   <!-- Build information -->
   <PropertyGroup>
+
+    <!-- Exclude REGAPIC (Google.Api.Grpc.Rest) unless the REGAPIC property is set to "true" -->
+    <DefineConstants Condition="'$(REGAPIC)' == 'true'">REGAPIC</DefineConstants>
+
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../Gax.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Google.Api.Gax.Grpc/Rest/RestGrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestGrpcAdapter.cs
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file or at
  * https://developers.google.com/open-source/licenses/bsd
  */
-
+#if REGAPIC
 using Google.Protobuf.Reflection;
 using Grpc.Core;
 using System.Collections.Generic;
@@ -38,3 +38,4 @@ namespace Google.Api.Gax.Grpc.Rest
             new RestGrpcAdapter(RestServiceCollection.Create(fileDescriptors));
     }
 }
+#endif


### PR DESCRIPTION
With this in place, we can merge the regapic branch into master:

- Normal releases of GAX are fine (the presence of some internal
  classes isn't a problem)
- Releasing a version of GAX containing REGAPIC (e.g. another alpha)
  is fairly simple - we'd need to permit the REGAPIC environment
  variable to be set in the Kokoro job, but that's all we need
- Most REGAPIC development can still proceed without GrpcRestAdapter
- To develop *with* GrpcRestAdapter, just set REGAPIC=true and then
  start the solution from the command line