### PR TITLE
Automatically include REGAPIC in alpha releases

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,6 @@ rm -rf {src,test,testing}/*/bin {src,test,testing}/*/obj
 export Configuration=Release
 export ContinuousIntegrationBuild=true
 
-echo CLI args: $DOTNET_BUILD_ARGS
-
 echo Building
 dotnet build -nologo -clp:NoSummary -v quiet Gax.sln
 

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -33,6 +33,12 @@ git clone https://github.com/googleapis/gax-dotnet.git releasebuild -c core.auto
 cd releasebuild
 git checkout $commit
 
+# Automatically include the REGAPIC code for alpha releases
+if grep -q '0-alpha' ReleaseVersion.xml
+then
+  export REGAPIC=true
+fi
+
 ./build.sh
 
 # Turn the multi-line output of git tag --points-at into space-separated list of projects


### PR DESCRIPTION
This should make it easier to iterate on REGAPIC code.

(The change to build.sh is just to remove a pointless echo that had been irritating me.)