### PR TITLE
feat: Exposes Google.Apis.Http.IHttpClientFactory in Rest.ClientBuilderBase

### DIFF
--- a/Google.Api.Gax.Rest.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Rest.IntegrationTests/ClientBuilderBaseTest.cs
@@ -240,6 +240,14 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             Assert.Throws<InvalidOperationException>(builder.ValidateForTest);
         }
 
+        [Fact]
+        public async Task HttpClientFactory()
+        {
+            var factory = new HttpClientFactory();
+            var builder = new SampleClientBuilder { HttpClientFactory = factory };
+            await ValidateResultAsync(builder, initializer => Assert.Same(factory, initializer.HttpClientFactory));
+        }
+
         private async Task ValidateResultAsync(SampleClientBuilder builder, Action<BaseClientService.Initializer> validator)
         {
             var initializer = builder.Build();

--- a/Google.Api.Gax.Rest/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Rest/ClientBuilderBase.cs
@@ -65,6 +65,31 @@ namespace Google.Api.Gax.Rest
         public string QuotaProject { get; set; }
 
         /// <summary>
+        /// An <see cref="IHttpClientFactory"/> that will be used to obtain
+        /// <see cref="ConfigurableHttpClient"/> for making API Http calls.
+        /// May be null, in which case an <see cref="Apis.Http.HttpClientFactory"/>
+        /// will be used.
+        /// </summary>
+        /// <remarks>
+        /// If you want to use custom HTTP clients, for instance, if you need to set a proxy,
+        /// you may do so by either
+        /// <list type="bullet">
+        /// <item>
+        /// Extending <see cref="Apis.Http.HttpClientFactory"/>. Refer to
+        /// <see cref="Apis.Http.HttpClientFactory" /> documentation for more information.
+        /// </item>
+        /// <item>
+        /// On .NET Core 2.1 and above, using <see cref="HttpClientFromMessageHandlerFactory"/>
+        /// in combination with <code>System.Net.Http.IHttpClientFactory</code>. Refer to
+        /// <see cref="HttpClientFromMessageHandlerFactory"/> documentation and
+        /// https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
+        /// for more information.
+        /// </item>
+        /// </list>
+        /// </remarks>
+        public IHttpClientFactory HttpClientFactory { get; set; }
+
+        /// <summary>
         /// Creates a new instance with no settings.
         /// </summary>
         protected ClientBuilderBase()
@@ -118,7 +143,8 @@ namespace Google.Api.Gax.Rest
                 HttpClientInitializer = clientInitializer,
                 ApiKey = ApiKey,
                 ApplicationName = ApplicationName ?? GetDefaultApplicationName(),
-                BaseUri = BaseUri
+                BaseUri = BaseUri,
+                HttpClientFactory = HttpClientFactory
             };
             initializer.VersionHeaderBuilder
                 .AppendAssemblyVersion("gccl", GetType())

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -16,6 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="[1.48.0, 2.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.51.0, 2.0.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
See googleapis/google-api-dotnet-client#1864

After this has been merged and release, users can either reference the new Gax version directly or wait for an update Storage release. Then their code should look something like this:

```cs
// Users implementation of Google.Apis.Http.IHttpClientFactory.
var proxiedHttpClientFactory = new ProxyHttpClientFactory(proxy);

var scopes = new string[] { "https://www.googleapis.com/auth/devstorage.full_control" };
var serviceCredentialFromFile = (ServiceAccountCredential) GoogleCredential.FromFile(sa_file).UnderlyingCredential;
var initializer = new ServiceAccountCredential.Initializer(serviceCredentialFromFile.Id)
{
    ProjectId = serviceCredentialFromFile.ProjectId,
    Key = serviceCredentialFromFile.Key,
    User = serviceCredentialFromFile.User
    HttpClientFactory = proxiedHttpClientFactory,
    Scopes = scopes
};
var credential = GoogleCredential.FromServiceAccountCredential(new ServiceAccountCredential(initializer));

var clientBuilder = new StorageClientBuilder
{
    Credential = credential,
    // All HTTP client instances for API calls will be obtained from this factory
    HttpClientFactory = proxiedHttpClientFactory
}

var client = clientBuilder.Build();
```

Notice also that once googleapis/google-api-dotnet-client#1851 is in, setting a proxy for a credential will be much more simple as well.