### PR TITLE
Improve derivation of GKE container name from mountinfo

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -119,7 +119,7 @@ namespace Google.Api.Gax.Grpc.Tests
             {
                 NamespaceJson = namespaceJson,
                 PodJson = podJson,
-                MountInfo = new[] { "/var/lib/kubelet/pods/podid/containers/containername/ /dev/termination-log" }
+                MountInfo = new[] { "1 2 3 /var/lib/kubelet/pods/podid/containers/containername/ /dev/termination-log xyz" }
             };
             var platform = new Platform(GkePlatformDetails.TryLoad(metadataJson, kubernetesData));
             var resource = MonitoredResourceBuilder.FromPlatform(platform);


### PR DESCRIPTION
If we find exactly one entry in mountinfo that looks like it should
give us the container name, but we don't know what the pod UID is, we
can assume it's correct. We still verify that it's correct if we
*do* know what the pod UID is.

Note that if there are multiple mountinfo entries that look like
they could give us the information, we *could* pick the one that has
the right pod UID if we wanted (and if we know the pod UID, and
there's only one matching entry) but we're in unexpected territory
anyway at that point - if we see it happening in the wild, we can
judge whether that would be a good idea or not.

Fixes #411