### PR TITLE
feat: send correct x-goog-api-client headers for the diregapic

### DIFF
--- a/Google.Api.Gax.Grpc/Rest/RestMethod.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestMethod.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -131,8 +132,9 @@ namespace Google.Api.Gax.Grpc.Rest
         /// </summary>
         /// <param name="protoRequest">The request, in protobuf representation.</param>
         /// <param name="host">The host to create the request for, or null to use the default host for the client sending the request.</param>
+        /// <param name="headers">The headers to send along with the request</param>
         /// <returns>A request with the URI, method and content populated.</returns>
-        internal HttpRequestMessage CreateRequest(IMessage protoRequest, string host)
+        internal HttpRequestMessage CreateRequest(IMessage protoRequest, string host, List<KeyValuePair<string, string>> headers)
         {
             var transcodingResult = _contentFactory(protoRequest);
 
@@ -143,13 +145,20 @@ namespace Google.Api.Gax.Grpc.Rest
             var uri = host is null ? new Uri(uriPathWithParams, UriKind.Relative) : new UriBuilder { Host = host, Path = uriPathWithParams }.Uri;
             
             var content = transcodingResult.Body is null ? null : new StringContent(transcodingResult.Body, Encoding.UTF8, s_applicationJsonMediaType);
-            
-            return new HttpRequestMessage
+
+            var httpRequestMessage = new HttpRequestMessage
             {
                 RequestUri = uri,
                 Method = _httpMethod,
                 Content = content,
             };
+
+            foreach (var headerKeyValue in headers)
+            {
+                httpRequestMessage.Headers.Add(headerKeyValue.Key, headerKeyValue.Value);
+            }
+            
+            return httpRequestMessage;
         }
 
         /// <summary>

--- a/Google.Api.Gax.Grpc/Rest/RestMethod.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestMethod.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -144,15 +143,13 @@ namespace Google.Api.Gax.Grpc.Rest
             var uri = host is null ? new Uri(uriPathWithParams, UriKind.Relative) : new UriBuilder { Host = host, Path = uriPathWithParams }.Uri;
             
             var content = transcodingResult.Body is null ? null : new StringContent(transcodingResult.Body, Encoding.UTF8, s_applicationJsonMediaType);
-
-            var httpRequestMessage = new HttpRequestMessage
+            
+            return new HttpRequestMessage
             {
                 RequestUri = uri,
                 Method = _httpMethod,
                 Content = content,
             };
-            
-            return httpRequestMessage;
         }
 
         /// <summary>

--- a/Google.Api.Gax.Grpc/Rest/RestMethod.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestMethod.cs
@@ -132,9 +132,8 @@ namespace Google.Api.Gax.Grpc.Rest
         /// </summary>
         /// <param name="protoRequest">The request, in protobuf representation.</param>
         /// <param name="host">The host to create the request for, or null to use the default host for the client sending the request.</param>
-        /// <param name="headers">The headers to send along with the request</param>
         /// <returns>A request with the URI, method and content populated.</returns>
-        internal HttpRequestMessage CreateRequest(IMessage protoRequest, string host, List<KeyValuePair<string, string>> headers)
+        internal HttpRequestMessage CreateRequest(IMessage protoRequest, string host)
         {
             var transcodingResult = _contentFactory(protoRequest);
 
@@ -152,11 +151,6 @@ namespace Google.Api.Gax.Grpc.Rest
                 Method = _httpMethod,
                 Content = content,
             };
-
-            foreach (var headerKeyValue in headers)
-            {
-                httpRequestMessage.Headers.Add(headerKeyValue.Key, headerKeyValue.Value);
-            }
             
             return httpRequestMessage;
         }

--- a/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -66,8 +66,8 @@ namespace Google.Api.Gax
         /// <summary>
         /// Whether the name or value that are supposed to be included in a header are valid
         /// </summary>
-        private static bool IsHeaderNameValueValid(string nameOrValue)
-            => !nameOrValue.Contains(" ") && !nameOrValue.Contains("/");
+        private static bool IsHeaderNameValueValid(string nameOrValue) => 
+            !nameOrValue.Contains(" ") && !nameOrValue.Contains("/");
 
         private static string GetEnvironmentVersion()
         {

--- a/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -43,8 +43,8 @@ namespace Google.Api.Gax
             GaxPreconditions.CheckNotNull(name, nameof(name));
             GaxPreconditions.CheckNotNull(version, nameof(version));
             // Names can't be empty, but versions can. (We use the empty string to indicate an unknown version.)
-            GaxPreconditions.CheckArgument(name.Length > 0 && !name.Contains(" ") && !name.Contains("/"), nameof(name), $"Invalid name: {name}");
-            GaxPreconditions.CheckArgument(!version.Contains(" ") && !version.Contains("/"), nameof(version), $"Invalid version: {version}");
+            GaxPreconditions.CheckArgument(name.Length > 0 && IsHeaderNameValueValid(name), nameof(name), $"Invalid name: {name}");
+            GaxPreconditions.CheckArgument(IsHeaderNameValueValid(version), nameof(version), $"Invalid version: {version}");
             GaxPreconditions.CheckArgument(!_names.Contains(name), nameof(name), "Names in version headers must be unique");
             _names.Add(name);
             _values.Add(version);
@@ -62,6 +62,12 @@ namespace Google.Api.Gax
         /// Appends the .NET environment information to the list.
         /// </summary>
         public VersionHeaderBuilder AppendDotNetEnvironment() => AppendVersion("gl-dotnet", s_environmentVersion.Value);
+        
+        /// <summary>
+        /// Whether the name or value that are supposed to be included in a header are valid
+        /// </summary>
+        private static bool IsHeaderNameValueValid(string nameOrValue)
+            => !nameOrValue.Contains(" ") && !nameOrValue.Contains("/");
 
         private static string GetEnvironmentVersion()
         {
@@ -103,8 +109,7 @@ namespace Google.Api.Gax
                 return null;
             }
         }
-
-
+        
         private static string FormatAssemblyVersion(System.Type type)
         {
             // Prefer AssemblyInformationalVersion, then AssemblyFileVersion,
@@ -112,7 +117,7 @@ namespace Google.Api.Gax
 
             var assembly = type.GetTypeInfo().Assembly;
             var info = assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().FirstOrDefault()?.InformationalVersion;
-            if (info != null)
+            if (info != null && IsHeaderNameValueValid(info)) // Skip informational version if it's not a valid header value
             {
                 return info;
             }


### PR DESCRIPTION
This makes the `x-goog-api-client` header for the diregapic libraries to have a `rest` component and sends the headers with the request.