### PR TITLE
Set the gRPC max-receive-size to 2GB by default

### DIFF
--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -24,7 +24,8 @@ namespace Google.Api.Gax.Grpc
     {
         private static readonly GrpcChannelOptions s_defaultOptions = GrpcChannelOptions.Empty
             .WithKeepAliveTime(TimeSpan.FromMinutes(1))
-            .WithEnableServiceConfigResolution(false);
+            .WithEnableServiceConfigResolution(false)
+            .WithMaxReceiveMessageSize(int.MaxValue);
 
         /// <summary>
         /// The endpoint to connect to, or null to use the default endpoint.


### PR DESCRIPTION
Some APIs require large receive limits, and this change is in line
with other languages.