### PR TITLE
Fix ClientBuilderBase integration tests

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
@@ -283,9 +283,10 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             public static string DefaultEndpoint { get; } = "default.nowhere.com";
             public static string[] DefaultScopes { get; } = new[] { "scope1", "scope2" };
             public ChannelPool ChannelPool { get; } = new ChannelPool(DefaultScopes);
-            public static GrpcChannelOptions DefaultOptions = GrpcChannelOptions.Empty
-                .WithKeepAliveTime(TimeSpan.FromMinutes(1))
-                .WithEnableServiceConfigResolution(false);
+
+            // The default options are private in ClientBuilderBase, but we can access them by getting the effective
+            // options if we don't apply any modifications.
+            public static GrpcChannelOptions DefaultOptions => new SampleClientBuilder().GetChannelOptions();
 
             public string EndpointUsedToCreateChannel { get; private set; }
             public ChannelCredentials CredentialsUsedToCreateChannel { get; private set; }


### PR DESCRIPTION
This also avoids future issues of the same nature - we obtain the
default settings programmatically instead of having to keep the two
in sync.