### PR TITLE
Initial attempt at a Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "ignorePaths": [
+    "Google.Api.CommonProtos/**",
+    "Google.Api.Gax/**",
+    "Google.Api.Gax.Grpc/**",
+    "Google.Api.Gax.Grpc.GrpcCore/**",
+    "Google.Api.Gax.Grpc.GrpcNetClient/**",
+    "Google.Api.Gax.Grpc.Testing/**",
+    "Google.Api.Gax.Grpc.Rest/**"    
+  ],
+  "schedule": ["before 8am"],
+  "timezone": "Europe/London"
+}


### PR DESCRIPTION
The intention is to allow Renovate to manage tools projects, tests
etc - but we manage the dependencies in our production projects.