### PR TITLE
Google.Api.Gax version 3.5.0-beta01

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.5.0-alpha01</Version>
+    <Version>3.5.0-beta01</Version>
   </PropertyGroup>
 </Project>

--- a/buildrelease.sh
+++ b/buildrelease.sh
@@ -33,8 +33,8 @@ git clone https://github.com/googleapis/gax-dotnet.git releasebuild -c core.auto
 cd releasebuild
 git checkout $commit
 
-# Automatically include the REGAPIC code for alpha releases
-if grep -q '0-alpha' ReleaseVersion.xml
+# Automatically include the REGAPIC code for alpha/beta releases
+if grep -q '0-alpha' ReleaseVersion.xml || grep -q '0-beta' ReleaseVersion.xml
 then
   export REGAPIC=true
 fi


### PR DESCRIPTION
The purpose of this release is to allow testing of updated REGAPIC code.

Changes since 3.5.0-alpha01:

- Include more error information in REGAPIC errors
- Dependency updates
- Setting the default gRPC max-receive-size to 2GB