### PR TITLE
Google.Api.Gax version 3.5.0

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.5.0-beta01</Version>
+    <Version>3.5.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes since 3.4.0:

- Set the gRPC max-receive-size to 2GB by default
- Support for self-signed JWTs in gRPC client builders