### PR TITLE
feat: Add extension methods to access extra error information

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/RpcExceptionExtensionsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/RpcExceptionExtensionsTest.cs
@@ -1,0 +1,167 @@
+﻿/*
+ * Copyright 2021 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Rpc;
+using Grpc.Core;
+using System;
+using Xunit;
+
+using Status = Google.Rpc.Status;
+using GrpcStatus = Grpc.Core.Status;
+using Google.Protobuf.WellKnownTypes;
+using Google.Protobuf;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class RpcExceptionExtensionsTest
+    {
+        private static readonly GrpcStatus s_status = new GrpcStatus(StatusCode.InvalidArgument, "Bad request");
+
+        [Fact]
+        public void NullArgument_AllMethodsThrow()
+        {
+            RpcException ex = null;
+            Assert.Throws<ArgumentNullException>(() => ex.GetRpcStatus());
+            Assert.Throws<ArgumentNullException>(() => ex.GetBadRequest());
+            Assert.Throws<ArgumentNullException>(() => ex.GetErrorInfo());
+            Assert.Throws<ArgumentNullException>(() => ex.GetStatusDetail<BadRequest>());
+        }
+
+        [Fact]
+        public void NoTrailers_AllMethodsReturnNull()
+        {
+            RpcException ex = new RpcException(s_status);
+            AssertAllMethodsReturnNull(ex);
+        }
+
+        [Fact]
+        public void IrrelevantTrailer_AllMethodsReturnNull()
+        {
+            var metadata = new Metadata();
+            metadata.Add("key", "value");
+            RpcException ex = new RpcException(s_status, metadata);
+            AssertAllMethodsReturnNull(ex);
+        }
+
+        [Fact]
+        public void InvalidProtobufStatusTrailer_AllMethodsReturnNull()
+        {
+            var metadata = new Metadata();
+            metadata.Add(RpcExceptionExtensions.StatusDetailsTrailerName, new byte[] { 1, 2, 3, 4 });
+            RpcException ex = new RpcException(s_status, metadata);
+            AssertAllMethodsReturnNull(ex);
+        }
+
+        [Fact]
+        public void ValidTrailer_GetRpcStatus()
+        {
+            var status = new Status
+            {
+                Code = 123,
+                Message = "This is a message",
+            };
+
+            var metadata = new Metadata();
+            metadata.Add(RpcExceptionExtensions.StatusDetailsTrailerName, status.ToByteArray());
+            RpcException ex = new RpcException(s_status, metadata);
+            Assert.Equal(status, ex.GetRpcStatus());
+            // We don't have any details
+            Assert.Null(ex.GetBadRequest());
+            Assert.Null(ex.GetErrorInfo());
+            Assert.Null(ex.GetStatusDetail<DebugInfo>());
+        }
+
+        [Fact]
+        public void ValidTrailer_ArbitraryMessages()
+        {
+            var debugInfo = new DebugInfo
+            {
+                Detail = "This is some debugging information"
+            };
+            var requestInfo = new RequestInfo
+            {
+                RequestId = "request-id"
+            };
+            var badRequest = new BadRequest
+            {
+                FieldViolations = { new BadRequest.Types.FieldViolation { Description = "Negative", Field = "speed" } }
+            };
+            var status = new Status
+            {
+                Code = 123,
+                Message = "This is a message",
+                Details =
+                {
+                    Any.Pack(debugInfo),
+                    Any.Pack(requestInfo),
+                    Any.Pack(badRequest)
+                }
+            };
+
+            var metadata = new Metadata();
+            metadata.Add("key-1", "value1");
+            metadata.Add(RpcExceptionExtensions.StatusDetailsTrailerName, status.ToByteArray());
+            metadata.Add("other-info-bin", new byte[] { 1, 2, 3 });
+            metadata.Add("key-2", "value2");
+            RpcException ex = new RpcException(s_status, metadata);
+
+            Assert.Equal(badRequest, ex.GetBadRequest());
+            Assert.Null(ex.GetErrorInfo());
+            Assert.Equal(debugInfo, ex.GetStatusDetail<DebugInfo>());
+            Assert.Equal(requestInfo, ex.GetStatusDetail<RequestInfo>());
+            Assert.Equal(badRequest, ex.GetStatusDetail<BadRequest>());
+        }
+
+        [Fact]
+        public void GetErrorInfo_Present()
+        {
+            var errorInfo = new ErrorInfo
+            {
+                Domain = "googleapis.com",
+                Reason = "broken"
+            };
+            var status = new Status
+            {
+                Code = 123,
+                Message = "This is a message",
+                Details =
+                {
+                    Any.Pack(errorInfo),
+                }
+            };
+            var metadata = new Metadata();
+            metadata.Add(RpcExceptionExtensions.StatusDetailsTrailerName, status.ToByteArray());
+
+            RpcException ex = new RpcException(s_status, metadata);
+            Assert.Equal(errorInfo, ex.GetErrorInfo());
+        }
+
+        [Fact]
+        public void GetStatusDetail_BadlyPackedMessage()
+        {
+            var debugInfo = new DebugInfo { Detail = "Debug information" };
+            var any = Any.Pack(debugInfo);
+            any.Value = ByteString.CopyFromUtf8("This isn't valid data!");
+
+            var status = new Status { Details = { any } };
+            var metadata = new Metadata();
+            metadata.Add(RpcExceptionExtensions.StatusDetailsTrailerName, status.ToByteArray());
+            RpcException ex = new RpcException(s_status, metadata);
+
+            Assert.Equal(status, ex.GetRpcStatus());
+            Assert.Null(ex.GetStatusDetail<DebugInfo>());
+        }
+
+        private void AssertAllMethodsReturnNull(RpcException ex)
+        {
+            Assert.Null(ex.GetRpcStatus());
+            Assert.Null(ex.GetBadRequest());
+            Assert.Null(ex.GetErrorInfo());
+            Assert.Null(ex.GetStatusDetail<DebugInfo>());
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc/RpcExceptionExtensions.cs
+++ b/Google.Api.Gax.Grpc/RpcExceptionExtensions.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * Copyright 2021 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Google.Rpc;
+using Grpc.Core;
+using System.Linq;
+using Status = Google.Rpc.Status;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Utility extension methods to make it easier to retrieve extended error information from an <see cref="RpcException"/>.
+    /// </summary>
+    public static class RpcExceptionExtensions
+    {
+        // Visible for testing.
+        internal const string StatusDetailsTrailerName = "grpc-status-details-bin";
+
+        /// <summary>
+        /// Retrieves the <see cref="Status"/> message containing extended error information
+        /// from the trailers in an <see cref="RpcException"/>, if present.
+        /// </summary>
+        /// <param name="ex">The RPC exception to retrieve details from. Must not be null.</param>
+        /// <returns>The <see cref="Status"/> message specified in the exception, or null
+        /// if there is no such information.</returns>
+        public static Rpc.Status GetRpcStatus(this RpcException ex) =>
+            DecodeTrailer(GetTrailer(ex, StatusDetailsTrailerName), Status.Parser);
+
+        /// <summary>
+        /// Retrieves the <see cref="BadRequest"/> message containing extended error information
+        /// from the trailers in an <see cref="RpcException"/>, if present.
+        /// </summary>
+        /// <param name="ex">The RPC exception to retrieve details from. Must not be null.</param>
+        /// <returns>The <see cref="BadRequest"/> message specified in the exception, or null
+        /// if there is no such information.</returns>
+        public static BadRequest GetBadRequest(this RpcException ex) => GetStatusDetail<BadRequest>(ex);
+
+        /// <summary>
+        /// Retrieves the <see cref="ErrorInfo"/> message containing extended error information
+        /// from the trailers in an <see cref="RpcException"/>, if present.
+        /// </summary>
+        /// <param name="ex">The RPC exception to retrieve details from. Must not be null.</param>
+        /// <returns>The <see cref="ErrorInfo"/> message specified in the exception, or null
+        /// if there is no such information.</returns>
+        public static ErrorInfo GetErrorInfo(this RpcException ex) => GetStatusDetail<ErrorInfo>(ex);
+
+        /// <summary>
+        /// Retrieves the error details of type <typeparamref name="T"/> from the <see cref="Status"/>
+        /// message associated with an <see cref="RpcException"/>, if any.
+        /// </summary>
+        /// <typeparam name="T">The message type to decode from within the error details.</typeparam>
+        /// <param name="ex">The RPC exception to retrieve details from. Must not be null.</param>
+        /// <returns></returns>
+        public static T GetStatusDetail<T>(this RpcException ex) where T : class, IMessage<T>, new()
+        {
+            var status = GetRpcStatus(ex);
+            if (status is null)
+            {
+                return null;
+            }
+            var expectedName = new T().Descriptor.FullName;
+            var any = status.Details.FirstOrDefault(a => Any.GetTypeName(a.TypeUrl) == expectedName);
+            if (any is null)
+            {
+                return null;
+            }
+            try
+            {
+                return any.Unpack<T>();
+            }
+            catch
+            {
+                // If the message is malformed, just report there's no information.
+                return null;
+            }
+        }
+
+        private static Metadata.Entry GetTrailer(RpcException ex, string key)
+        {
+            GaxPreconditions.CheckNotNull(ex, nameof(ex));
+            return ex.Trailers.FirstOrDefault(t => t.Key == key);
+        }
+
+        private static T DecodeTrailer<T>(Metadata.Entry entry, MessageParser<T> parser) where T : class, IMessage<T>
+        {
+            if (entry is null)
+            {
+                return null;
+            }
+            try
+            {
+                return parser.ParseFrom(entry.ValueBytes);
+            }
+            catch
+            {
+                // If the message is malformed, just report there's no information.
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extension methods are the least breaking option here: we don't
control the exception type (because we've always allowed
RpcException to just be thrown directly). While we could add a new
subclass of RpcException, that would have knock-on effects for
anything else that's already extending RpcException.

Any attempt to access extended information that is missing or
present but invalid will return null.