### PR TITLE
Added support dotnet core 5 for CommonProtos

### DIFF
--- a/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
+++ b/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Version>2.4.0</Version>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Packaging information -->


### PR DESCRIPTION
We are faced with the problem that we have long gone from dotnet standard, and everywhere we use dotnet core 5