### PR TITLE
feat: Use self-signed JWTs in Google.Api.Gax.Rest

### DIFF
--- a/Google.Api.Gax.Rest.Tests/ScopedCredentialProviderTest.cs
+++ b/Google.Api.Gax.Rest.Tests/ScopedCredentialProviderTest.cs
@@ -45,13 +45,25 @@ j5XmfIZhC9k =
         }
 
         [Fact]
-        public void GetCredentials_ScopesApplied()
+        public void GetCredentials_ScopesApplied_UnspecifiedUseJwts()
         {
             var provider = new ScopedCredentialProvider(new[] { "abc" });
             var originalCredentials = CreateServiceCredentials();
             var provided = provider.GetCredentials(originalCredentials);
             // Can't actually test the scopes...
             Assert.NotSame(originalCredentials, provided);
+        }
+
+        [Theory, CombinatorialData]
+        public void GetCredentials_ScopesApplied_UseJwtWithScopesSpecified(bool useJwtWithScopes)
+        {
+            var provider = new ScopedCredentialProvider(new[] { "abc" }, useJwtWithScopes);
+            var originalCredentials = CreateServiceCredentials();
+            var provided = provider.GetCredentials(originalCredentials);
+            Assert.NotSame(originalCredentials, provided);
+            var serviceAccount = provided.UnderlyingCredential as ServiceAccountCredential;
+            Assert.NotNull(serviceAccount);
+            Assert.Equal(useJwtWithScopes, serviceAccount.UseJwtAccessWithScopes);
         }
 
         [Fact]


### PR DESCRIPTION
This is a no-op by default, but allows libraries to create
ScopedCredentialProvider instances that apply self-signed JWTs to
credentials. After updating to a new version of GAX, the three
libraries in google-cloud-dotnet that use this will need trivial
changes to support it.