### PR TITLE
feat: Expose HTTP to gRPC status code conversions in REGAPIC

### DIFF
--- a/Google.Api.Gax.Grpc/Rest/RestGrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestGrpcAdapter.cs
@@ -8,7 +8,6 @@
 using Google.Protobuf.Reflection;
 using Grpc.Core;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Google.Api.Gax.Grpc.Rest
 {
@@ -36,6 +35,46 @@ namespace Google.Api.Gax.Grpc.Rest
         /// <returns></returns>
         public static RestGrpcAdapter Create(IEnumerable<FileDescriptor> fileDescriptors) =>
             new RestGrpcAdapter(RestServiceCollection.Create(fileDescriptors));
+
+        /// <summary>
+        /// Converts an HTTP status code into the corresponding gRPC status code.
+        /// Note that there is not a 1:1 correspondence between status code; multiple
+        /// HTTP status codes can map to the same gRPC status code.
+        /// </summary>
+        /// <param name="httpStatusCode">The HTTP status code to convert</param>
+        /// <returns>The converted gRPC status code.</returns>
+        public static StatusCode ConvertHttpStatusCode(int httpStatusCode) =>
+            (httpStatusCode / 100) switch
+            {
+                // All 2xx responses map to OK
+                2 => StatusCode.OK,
+
+                // 4xx defaults to FailedPrecondition, with specific exceptions
+                4 => httpStatusCode switch
+                {
+                    400 => StatusCode.InvalidArgument,
+                    401 => StatusCode.Unauthenticated,
+                    403 => StatusCode.PermissionDenied,
+                    404 => StatusCode.NotFound,
+                    409 => StatusCode.Aborted,
+                    416 => StatusCode.OutOfRange,
+                    429 => StatusCode.ResourceExhausted,
+                    499 => StatusCode.Cancelled,
+                    _ => StatusCode.FailedPrecondition,
+                },
+
+                // 5xx defaults to Internal, with specific exceptions
+                5 => httpStatusCode switch
+                {
+                    501 => StatusCode.Unimplemented,
+                    503 => StatusCode.Unavailable,
+                    504 => StatusCode.DeadlineExceeded,
+                    _ => StatusCode.Internal
+                },
+
+                // Anything else (including all 1xx and 3xx) maps to Unknown
+                _ => StatusCode.Unknown
+            };
     }
 }
 #endif


### PR DESCRIPTION
This will allow custom LROs to be converted to standard ones more accurately.