### PR TITLE
Release Google.Api.Gax version 3.6.0-beta03

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.6.0-beta02</Version>
+    <Version>3.6.0-beta03</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes since 3.6.0-beta02:

- Expose HTTP to gRPC status code mapping for REGAPIC. (This is the purpose of this release.)
- Use self-signed JWTs in Google.Api.Gax.Rest