### PR TITLE
Experimental: First pass at bidi streaming routing

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ApiBidirectionalStreamingCallTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ApiBidirectionalStreamingCallTest.cs
@@ -21,7 +21,7 @@ namespace Google.Api.Gax.Grpc.Tests
                 CallSettings.FromRetry(new RetrySettings(5, TimeSpan.Zero, TimeSpan.Zero, 1.0, e => false, RetrySettings.RandomJitter)),
                 new BidirectionalStreamingSettings(100),
                 new FakeClock());
-            Assert.Throws<InvalidOperationException>(() => apiCall.Call(null));
+            Assert.Throws<InvalidOperationException>(() => apiCall.Call(0, null));
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Google.Api.Gax.Grpc.Tests
                 CallSettings.FromExpiration(Expiration.FromTimeout(TimeSpan.FromSeconds(100))),
                 new BidirectionalStreamingSettings(100),
                 new FakeClock());
-            Assert.Null(apiCall.Call(null));
+            Assert.Null(apiCall.Call(0, null));
         }
     }
 }

--- a/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
@@ -19,7 +19,7 @@ namespace Google.Api.Gax.Grpc
             IClock clock)
         {
             return new ApiBidirectionalStreamingCall<TRequest, TResponse>(
-                cs => grpcCall(cs.ValidateNoRetry().ToCallOptions(clock)),
+                (_, cs) => grpcCall(cs.ValidateNoRetry().ToCallOptions(clock)),
                 baseCallSettings,
                 streamingSettings);
         }
@@ -34,7 +34,7 @@ namespace Google.Api.Gax.Grpc
     public sealed class ApiBidirectionalStreamingCall<TRequest, TResponse>
     {
         internal ApiBidirectionalStreamingCall(
-            Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> call,
+            Func<TRequest, CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> call,
             CallSettings baseCallSettings,
             BidirectionalStreamingSettings streamingSettings)
         {
@@ -43,11 +43,11 @@ namespace Google.Api.Gax.Grpc
             StreamingSettings = streamingSettings;
         }
 
-        private readonly Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> _call;
+        private readonly Func<TRequest, CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> _call;
 
         /// <summary>
         /// The base <see cref="CallSettings"/> for this API call; these can be further overridden by providing
-        /// a <c>CallSettings</c> to <see cref="Call"/>.
+        /// a <c>CallSettings</c> to <see cref="Call(CallSettings)" /> or <see cref="Call(TRequest, CallSettings)"/>.
         /// </summary>
         public CallSettings BaseCallSettings { get; }
 
@@ -57,13 +57,24 @@ namespace Google.Api.Gax.Grpc
         public BidirectionalStreamingSettings StreamingSettings { get; }
 
         /// <summary>
-        /// Initializes a streaming RPC call.
+        /// Initializes a streaming RPC call with no sample request.
         /// </summary>
         /// <param name="perCallCallSettings">The call settings to apply to this specific call,
         /// overriding defaults where necessary.</param>
         /// <returns>A gRPC duplex streaming call object.</returns>
+        [Obsolete("This overload will be removed in the next major version")]
         public AsyncDuplexStreamingCall<TRequest, TResponse> Call(CallSettings perCallCallSettings) =>
-            _call(BaseCallSettings.MergedWith(perCallCallSettings).ValidateNoRetry());
+            Call(default, perCallCallSettings);
+
+        /// <summary>
+        /// Initializes a streaming RPC call.
+        /// </summary>
+        /// <param name="sampleRequest">A sample request which may be used to extract initial headers.</param>
+        /// <param name="perCallCallSettings">The call settings to apply to this specific call,
+        /// overriding defaults where necessary.</param>
+        /// <returns>A gRPC duplex streaming call object.</returns>
+        public AsyncDuplexStreamingCall<TRequest, TResponse> Call(TRequest sampleRequest, CallSettings perCallCallSettings) =>
+            _call(sampleRequest, BaseCallSettings.MergedWith(perCallCallSettings).ValidateNoRetry());
 
         /// <summary>
         /// Returns a new API call using the original base call settings merged with <paramref name="callSettings"/>.
@@ -71,5 +82,59 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
             new ApiBidirectionalStreamingCall<TRequest, TResponse>(_call, callSettings.MergedWith(BaseCallSettings), StreamingSettings);
+
+        /// <summary>
+        /// Constructs a new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> that applies an overlay to
+        /// the underlying <see cref="CallSettings"/>. If a value exists in both the original and
+        /// the overlay, the overlay takes priority.
+        /// </summary>
+        /// <param name="callSettingsOverlayFn">Function that builds the overlay <see cref="CallSettings"/>.</param>
+        /// <returns>A new <see cref="ApiServerStreamingCall{TRequest, TResponse}"/> with the overlay applied.</returns>
+        public ApiBidirectionalStreamingCall<TRequest, TResponse> WithCallSettingsOverlay(Func<TRequest, CallSettings> callSettingsOverlayFn) =>
+            new ApiBidirectionalStreamingCall<TRequest, TResponse>(
+                (req, cs) => _call(req, cs.MergedWith(callSettingsOverlayFn(req))),
+                BaseCallSettings,
+                StreamingSettings);
+
+        /// <summary>
+        /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an x-goog-request-params header to each request,
+        /// using the specified parameter name and a value derived from the request.
+        /// </summary>
+        /// <remarks>Values produced by the function are URL-encoded; it is expected that <paramref name="parameterName"/> is already URL-encoded.</remarks>
+        /// <param name="parameterName">The parameter name in the header. Must not be null.</param>
+        /// <param name="valueSelector">A function to call on each request, to determine the value to specify in the header.
+        /// The parameter must not be null, but may return null.</param>
+        /// <returns>A new <see cref="ApiCall{TRequest, TResponse}"/> which applies the header on each request.</returns>
+        public ApiBidirectionalStreamingCall<TRequest, TResponse> WithGoogleRequestParam(string parameterName, Func<TRequest, string> valueSelector)
+        {
+            GaxPreconditions.CheckNotNull(parameterName, nameof(parameterName));
+            GaxPreconditions.CheckNotNull(valueSelector, nameof(valueSelector));
+            return WithCallSettingsOverlay(request => CallSettings.FromGoogleRequestParamsHeader(parameterName, request is null ? null : valueSelector(request)));
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an x-goog-request-params header to each request,
+        /// using the <see cref="RoutingHeaderExtractor{TRequest}"/>.
+        /// </summary>
+        /// <remarks>Values produced by the function are URL-encoded.</remarks>
+        /// <param name="extractor">The <see cref="RoutingHeaderExtractor{TRequest}"/> that extracts the value of the routing header from a request.</param>
+        /// <returns>>A new <see cref="ApiCall{TRequest, TResponse}"/> which applies the header on each request.</returns>
+        public ApiBidirectionalStreamingCall<TRequest, TResponse> WithExtractedGoogleRequestParam(RoutingHeaderExtractor<TRequest> extractor)
+        {
+            GaxPreconditions.CheckNotNull(extractor, nameof(extractor));
+
+            return WithCallSettingsOverlay(request =>
+            {
+                if (request is null)
+                {
+                    return null;
+                }
+                var headerValue = extractor.ExtractHeader(request);
+
+                return !string.IsNullOrWhiteSpace(headerValue)
+                    ? CallSettings.FromGoogleRequestParamsHeader(headerValue)
+                    : null; // CallSettings.Merge handles null correctly.
+            });
+        }
     }
 }

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -109,7 +109,7 @@ namespace Google.Api.Gax.Grpc
             where TResponse : class, IMessage<TResponse>
         {
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
-            return ApiBidirectionalStreamingCall.Create(grpcCall, baseCallSettings, streamingSettings, Clock)
+            return ApiBidirectionalStreamingCall.Create(options => grpcCall(options), baseCallSettings, streamingSettings, Clock)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>3.7.0-beta01</Version>
+    <Version>3.7.0-streaming-routing-02</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This basically allows a "sample request" to be passed in the initial call. That request is only used for extracting routing headers.
I think this would work, but requires significant documentation.