### PR TITLE
feat: Allow gRPC adapter detection to be overridden

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using System;
 using Xunit;
 using static Google.Api.Gax.Grpc.IntegrationTests.TestService;
 
@@ -30,5 +31,39 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
             var response = client.DoSimple(new SimpleRequest { Name = "test-call" });
             Assert.Equal("test-call", response.Name);
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [Theory]
+        [InlineData("Grpc.Net.Client")]
+        [InlineData("  Grpc.Net.Client  ")]
+        public void AdapterOverride_GrpcNetClient(string environmentVariable)
+        {
+            var adapter = GrpcAdapter.GetDefaultFromEnvironmentVariable(environmentVariable);
+            Assert.IsAssignableFrom<GrpcNetClientAdapter>(adapter);
+        }
+#endif
+
+        [Theory]
+        [InlineData("Grpc.Core")]
+        [InlineData("  Grpc.Core  ")]
+        public void AdapterOverride_GrpcCore(string environmentVariable)
+        {
+            var adapter = GrpcAdapter.GetDefaultFromEnvironmentVariable(environmentVariable);
+            Assert.IsAssignableFrom<GrpcCoreAdapter>(adapter);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void AdapterOverride_NullOrEmpty(string environmentVariable)
+        {
+            var adapter = GrpcAdapter.GetDefaultFromEnvironmentVariable(environmentVariable);
+            Assert.Null(adapter);
+        }
+
+        [Fact]
+        public void AdapterOverride_Invalid() =>
+            Assert.Throws<InvalidOperationException>(() => GrpcAdapter.GetDefaultFromEnvironmentVariable("garbage"));
     }
 }

--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcNetClientAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcNetClientAdapterTest.cs
@@ -9,7 +9,7 @@ using Grpc.Core;
 using Xunit;
 using static Google.Api.Gax.Grpc.IntegrationTests.TestService;
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 namespace Google.Api.Gax.Grpc.IntegrationTests
 {
     [Collection(nameof(TestServiceFixture))]

--- a/Google.Api.Gax.Grpc/GrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcAdapter.cs
@@ -54,9 +54,13 @@ namespace Google.Api.Gax.Grpc
         private static GrpcAdapter CreateDefaultAdapter() =>
             GetDefaultFromEnvironmentVariable() ?? DetectDefaultPreferringGrpcNetClient();
 
-        private static GrpcAdapter GetDefaultFromEnvironmentVariable()
+        private static GrpcAdapter GetDefaultFromEnvironmentVariable() =>
+            GetDefaultFromEnvironmentVariable(Environment.GetEnvironmentVariable(AdapterOverrideEnvironmentVariable));
+
+        // Visible for testing, and accepting a string for simplicity (to avoid modifying the environment in tests).
+        internal static GrpcAdapter GetDefaultFromEnvironmentVariable(string environmentVariable)
         {
-            var env = Environment.GetEnvironmentVariable(AdapterOverrideEnvironmentVariable)?.Trim();
+            var env = environmentVariable?.Trim();
             return env switch
             {
                 "Grpc.Net.Client" => GrpcNetClientAdapter.Default,


### PR DESCRIPTION
This allows an environment variable with the name
"GRPC_DEFAULT_ADAPTER_OVERRIDE" to determine the adapter to use:
- a value of "Grpc.Core" will use the GrpcCoreAdapter
- a value of "Grpc.Net.Client" will use the GrpcNetClientAdapter
- a missing or empty/whitespace value will use normal detection
- any other value will throw an exception