### PR TITLE
Prototype of logging

### DIFF
--- a/Google.Api.Gax.Grpc/ApiCall.cs
+++ b/Google.Api.Gax.Grpc/ApiCall.cs
@@ -7,6 +7,7 @@
 
 using Google.Protobuf;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -151,11 +152,19 @@ namespace Google.Api.Gax.Grpc
         internal ApiCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
             new ApiCall<TRequest, TResponse>(_asyncCall, _syncCall, callSettings.MergedWith(BaseCallSettings));
 
-        internal ApiCall<TRequest, TResponse> WithRetry(IClock clock, IScheduler scheduler) =>
+        internal ApiCall<TRequest, TResponse> WithRetry(IClock clock, IScheduler scheduler, ILogger logger) =>
             new ApiCall<TRequest, TResponse>(
-                _asyncCall.WithRetry(clock, scheduler),
-                _syncCall.WithRetry(clock, scheduler),
+                _asyncCall.WithRetry(clock, scheduler, logger),
+                _syncCall.WithRetry(clock, scheduler, logger),
                 BaseCallSettings);
+
+        internal ApiCall<TRequest, TResponse> WithLogging(ILogger logger) =>
+            logger is null
+                ? this
+                : new ApiCall<TRequest, TResponse>(
+                    _asyncCall.WithLogging(logger),
+                    _syncCall.WithLogging(logger),
+                    BaseCallSettings);
 
         /// <summary>
         /// Constructs a new <see cref="ApiCall{TRequest, TResponse}"/> that applies an overlay to

--- a/Google.Api.Gax.Grpc/ApiCallLoggingExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallLoggingExtensions.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc
+{
+    internal static class ApiCallLoggingExtensions
+    {
+        // By design, the code is mostly duplicated between the async and sync calls.
+
+        // Async logging
+        internal static Func<TRequest, CallSettings, Task<TResponse>> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, Task<TResponse>> fn, ILogger logger) =>
+            async (request, callSettings) =>
+            {
+                logger?.LogDebug("Starting asynchronous API call.");
+                var result = await fn(request, callSettings).ConfigureAwait(false);
+                logger?.LogDebug("Call completed.");
+                return result;
+            };
+
+        // Sync logging
+        internal static Func<TRequest, CallSettings, TResponse> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, TResponse> fn, ILogger logger) =>
+            (request, callSettings) =>
+            {
+                logger?.LogDebug("Starting synchronous API call.");
+                var result = fn(request, callSettings);
+                logger?.LogDebug("Call completed.");
+                return result;
+            };
+    }
+}

--- a/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
@@ -5,7 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -18,7 +18,7 @@ namespace Google.Api.Gax.Grpc
         // Async retry
         internal static Func<TRequest, CallSettings, Task<TResponse>> WithRetry<TRequest, TResponse>(
             this Func<TRequest, CallSettings, Task<TResponse>> fn,
-            IClock clock, IScheduler scheduler) =>
+            IClock clock, IScheduler scheduler, ILogger logger) =>
             async (request, callSettings) =>
             {
                 RetrySettings retrySettings = callSettings.Retry;
@@ -40,6 +40,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
+                        logger.LogDebug("Backing off before retry");
                         await attempt.BackoffAsync(callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
                     }
                 }
@@ -49,7 +50,7 @@ namespace Google.Api.Gax.Grpc
         // Sync retry
         internal static Func<TRequest, CallSettings, TResponse> WithRetry<TRequest, TResponse>(
             this Func<TRequest, CallSettings, TResponse> fn,
-            IClock clock, IScheduler scheduler) =>
+            IClock clock, IScheduler scheduler, ILogger logger) =>
             (request, callSettings) =>
             {
                 RetrySettings retrySettings = callSettings.Retry;
@@ -71,6 +72,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
+                        logger.LogDebug("Backing off before retry");
                         attempt.Backoff(callSettings.CancellationToken.GetValueOrDefault());
                     }
                 }

--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -9,6 +9,7 @@ using Google.Apis.Auth.OAuth2;
 using Grpc.Auth;
 using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,6 +36,11 @@ namespace Google.Api.Gax.Grpc
         /// The endpoint to connect to, or null to use the default endpoint.
         /// </summary>
         public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The logger factory to use to create a logger for the client, if any.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; }
 
         /// <summary>
         /// The scopes to use, or null to use the default scopes.
@@ -137,6 +143,7 @@ namespace Google.Api.Gax.Grpc
             GrpcAdapter = source.GrpcAdapter;
             QuotaProject = source.QuotaProject;
             UseJwtAccessWithScopes = source.UseJwtAccessWithScopes;
+            LoggerFactory = source.LoggerFactory;
 
             // Note that we may be copying from one type that supports emulators (e.g. FirestoreDbBuilder)
             // to another type that doesn't (e.g. FirestoreClientBuilder). That ends up in a slightly odd situation,
@@ -155,6 +162,7 @@ namespace Google.Api.Gax.Grpc
             GaxPreconditions.CheckNotNull(source, nameof(source));
             UserAgent = source.UserAgent;
             GrpcAdapter = source.GrpcAdapter;
+            LoggerFactory = source.LoggerFactory;
         }
 
         /// <summary>
@@ -490,6 +498,7 @@ namespace Google.Api.Gax.Grpc
         {
             GaxPreconditions.CheckNotNull(provider, nameof(provider));
             GrpcAdapter = provider.GetService<GrpcAdapter>();
+            LoggerFactory = provider.GetService<ILoggerFactory>();
             // TODO: potentially use this in the same way as a default GoogleCredential, with scopes, JWT access etc.
             if (provider.GetService<GoogleCredential>() is ITokenAccess credential)
             {

--- a/Google.Api.Gax.Grpc/GaxGrpcServiceCollectionExtensions.cs
+++ b/Google.Api.Gax.Grpc/GaxGrpcServiceCollectionExtensions.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Api.Gax.Grpc;
+using Grpc.Net.Client;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for dependency injection.
+    /// </summary>
+    public static class GaxGrpcServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a singleton <see cref="GrpcNetClientAdapter"/> to the given service collection,
+        /// using the default with any additional options configured via <paramref name="optionsConfigurer"/>.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="optionsConfigurer"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddGrpcNetClientAdapter(this IServiceCollection services, Action<IServiceProvider, global::Grpc.Net.Client.GrpcChannelOptions> optionsConfigurer) =>
+            services.AddSingleton<GrpcAdapter>(provider => GrpcNetClientAdapter.Default.WithAdditionalOptions(options => optionsConfigurer(provider, options)));
+
+        /// <summary>
+        /// Adds a singleton <see cref="GrpcNetClientAdapter"/> to the given service collection,
+        /// such that any <see cref="GrpcChannel"/> created uses the service provider from
+        /// created this service collection. This enables logging, for example.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddGrpcNetClientAdapter(this IServiceCollection services) =>
+            services.AddSingleton<GrpcAdapter>(provider => GrpcNetClientAdapter.Default.WithAdditionalOptions(options => options.ServiceProvider = provider));
+    }
+}

--- a/Google.Api.Gax.Rest/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Rest/ClientBuilderBase.cs
@@ -8,6 +8,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Http;
 using Google.Apis.Services;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using System.Net.Http;
@@ -20,7 +21,7 @@ namespace Google.Api.Gax.Rest
     /// Base class for API-specific builders.
     /// </summary>
     /// <typeparam name="TClient">The type of client created by this builder.</typeparam>
-    public abstract class ClientBuilderBase<TClient>
+    public abstract class ClientBuilderBase<TClient> : IClientBuilder<TClient>
     {
         /// <summary>
         /// The path to the credentials file to use, or null if credentials are being provided in a different way.
@@ -229,6 +230,21 @@ namespace Google.Api.Gax.Rest
         /// Builds the resulting client asynchronously.
         /// </summary>
         public abstract Task<TClient> BuildAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Populates properties based on those set via dependency injection.
+        /// </summary>
+        /// <param name="provider">The service provider to request dependencies from.</param>
+        public void PopulateFromServices(IServiceProvider provider)
+        {
+            GaxPreconditions.CheckNotNull(provider, nameof(provider));
+            // TODO: What about GetService<ICredential>?
+            if (provider.GetService<GoogleCredential>() is GoogleCredential credential)
+            {
+                Credential = credential;
+            }
+            // TODO: Other things
+        }
 
         /// <summary>
         /// Class to be used to set the quota project on request headers when

--- a/Google.Api.Gax/GaxServiceCollectionExtensions.cs
+++ b/Google.Api.Gax/GaxServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Api.Gax;
+using System;
+using System.Reflection;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods enabling dependency injection of Google API clients.
+    /// </summary>
+    public static class GaxServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the given Google API client type as a singleton, configuring it with any dependencies injected (e.g. credentials,
+        /// gRPC adapter). The client type must be annotated with <see cref="GoogleApiClientAttribute"/>;
+        /// the implementation creates an instance of the indicated <see cref="IClientBuilder{TClient}"/>,
+        /// populates it from the service-provider, and builds it.
+        /// </summary>
+        /// <typeparam name="TClient"></typeparam>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddGoogleApiClient<TClient>(this IServiceCollection services) where TClient : class
+        {
+            // TODO: Error checking, efficiency etc.
+            // TODO: Should we actually inherit this so we can inject an "impl"?
+            var attribute = typeof(TClient).GetCustomAttribute<GoogleApiClientAttribute>(inherit: false);
+            var builder = (IClientBuilder<TClient>) Activator.CreateInstance(attribute.BuilderType);
+            return services.AddSingleton(provider =>
+            {
+                builder.PopulateFromServices(provider);
+                return builder.Build();
+            });
+        }
+    }
+}

--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/Google.Api.Gax/GoogleApiClientAttribute.cs
+++ b/Google.Api.Gax/GoogleApiClientAttribute.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// Attribute to indicate that a class represents a Google API client which can be
+    /// instantiated via the given builder type. (This would be generated.)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class GoogleApiClientAttribute : Attribute
+    {
+        /// <summary>
+        /// The builder type for the client.
+        /// </summary>
+        public Type BuilderType { get; set; }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="builderType"></param>
+        public GoogleApiClientAttribute(Type builderType)
+        {
+            BuilderType = builderType;
+        }
+    }
+}

--- a/Google.Api.Gax/IClientBuilder.cs
+++ b/Google.Api.Gax/IClientBuilder.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// Interface implemented by all clients that use REST, enabling dependency injection.
+    /// (This doesn't help for Google.Apis.Xyz.)
+    /// </summary>
+    /// <typeparam name="TClient"></typeparam>
+    public interface IClientBuilder<TClient>
+    {
+        /// <summary>
+        /// Builds the client synchronously
+        /// </summary>
+        /// <returns></returns>
+        TClient Build();
+
+        /// <summary>
+        /// Builds the client asynchronously
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<TClient> BuildAsync(CancellationToken cancellationToken);
+
+        // TODO: change the return type to IClientBuilder<TClient> for simpler method chaining?
+
+        /// <summary>
+        /// Populates the builder via dependency injection.
+        /// </summary>
+        /// <param name="provider"></param>
+        void PopulateFromServices(IServiceProvider provider);
+    }
+}


### PR DESCRIPTION
This is for #543, and builds on #542.

It would require some changes in client generation, so we need to decide this before shipping GAX v4.

Currently it doesn't log very much - just "call starting", "call finished", "backing off before retry" but we could definitely add more.