### PR TITLE
Second pass at making GAX more DI-friendly

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.DependencyInjection.cs
+++ b/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.DependencyInjection.cs
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Api.Gax.Grpc.Rest;
+using Google.Apis.Auth.OAuth2;
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public partial class ClientBuilderBaseTest
+    {
+        /// <summary>
+        /// Tests for <see cref="ClientBuilderBase{TClient}.Configure(IServiceProvider)"/>.
+        /// </summary>
+        public class DependencyInjection
+        {
+            [Fact]
+            public void GrpcAdapter_NotSetBefore()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddGrpcNetClientAdapter();
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.IsType<GrpcNetClientAdapter>(builder.GrpcAdapter);
+            }
+
+            [Fact]
+            public void GrpcAdapter_SetBefore()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddGrpcNetClientAdapter();
+                var builder = new FakeBuilder { GrpcAdapter = RestGrpcAdapter.Default };
+                builder.Configure(serviceCollection);
+                Assert.IsType<RestGrpcAdapter>(builder.GrpcAdapter);
+            }
+
+            [Fact]
+            public void CallInvoker_NotSetBefore()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<CallInvoker>(new FakeCallInvoker());
+                serviceCollection.AddGrpcNetClientAdapter();
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.IsType<FakeCallInvoker>(builder.CallInvoker);
+                // Because the CallInvoker was set, nothing else was fetched.
+                Assert.Null(builder.GrpcAdapter);
+            }
+
+            [Fact]
+            public void CallInvoker_SetBefore()
+            {
+                var manual = new FakeCallInvoker();
+                var injected = new FakeCallInvoker();
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<CallInvoker>(injected);
+                serviceCollection.AddGrpcNetClientAdapter();
+                var builder = new FakeBuilder { CallInvoker = manual };
+                builder.Configure(serviceCollection);
+                Assert.Same(manual, builder.CallInvoker);
+                // Because the CallInvoker was set, nothing else was fetched.
+                Assert.Null(builder.GrpcAdapter);
+            }
+
+            [Fact]
+            public void GrpcChannelOptions_NotSetBefore()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton(GrpcChannelOptions.Empty.WithMaxReceiveMessageSize(10));
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Equal(10, builder.GrpcChannelOptions.MaxReceiveMessageSize);
+            }
+
+            [Fact]
+            public void GrpcChannelOptions_SetBefore()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton(GrpcChannelOptions.Empty.WithMaxReceiveMessageSize(10));
+                var builder = new FakeBuilder { GrpcChannelOptions = GrpcChannelOptions.Empty.WithMaxSendMessageSize(20) };
+                builder.Configure(serviceCollection);
+                // The manually-set option is present
+                Assert.Equal(20, builder.GrpcChannelOptions.MaxSendMessageSize);
+                // The injected option isn't present - we don't merge
+                Assert.Null(builder.GrpcChannelOptions.MaxReceiveMessageSize);
+            }
+
+            [Fact]
+            public void CredentialsNotUsedWhenAlreadySet()
+            {
+                var serviceCollection = new ServiceCollection();
+                var dependencyCredential = GoogleCredential.FromJson(s_serviceAccountJson);
+                serviceCollection.AddSingleton(dependencyCredential);
+#pragma warning disable CS0618 // Type or member is obsolete
+                Action<FakeBuilder>[] actions = new Action<FakeBuilder>[]
+                {
+                    builder => builder.ChannelCredentials = ChannelCredentials.Insecure,
+                    builder => builder.JsonCredentials = "{}",
+                    builder => builder.CredentialsPath = "abc",
+                    builder => builder.Credential = GoogleCredential.FromJson(s_serviceAccountJson),
+                    builder => builder.GoogleCredential = GoogleCredential.FromJson(s_serviceAccountJson),
+                    builder => builder.TokenAccessMethod = (_, __) => null,
+                };
+#pragma warning restore CS0618 // Type or member is obsolete
+                foreach (var action in actions)
+                {
+                    var builder = new FakeBuilder();
+                    action(builder);
+                    builder.Configure(serviceCollection);
+                    // Note that in one test we'll set the GoogleCredential to a non-null value, but
+                    // it won't be the same object.
+                    Assert.NotSame(dependencyCredential, builder.GoogleCredential);
+                }
+            }
+
+            [Fact]
+            public void CredentialsPrecedence_ChannelCredentials()
+            {
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton(ChannelCredentials.Insecure);
+                serviceCollection.AddSingleton<ICredential>(GoogleCredential.FromJson(s_serviceAccountJson));
+                serviceCollection.AddSingleton(GoogleCredential.FromJson(s_serviceAccountJson));
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Same(ChannelCredentials.Insecure, builder.ChannelCredentials);
+                Assert.Null(builder.Credential);
+                Assert.Null(builder.GoogleCredential);
+            }
+
+            [Fact]
+            public void CredentialsPrecedence_ICredential()
+            {
+                var credential1 = GoogleCredential.FromJson(s_serviceAccountJson);
+                var credential2 = GoogleCredential.FromJson(s_serviceAccountJson);
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<ICredential>(credential1);
+                serviceCollection.AddSingleton(credential2);
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Null(builder.ChannelCredentials);
+                Assert.Same(credential1, builder.Credential);
+                Assert.Null(builder.GoogleCredential);
+            }
+
+            [Fact]
+            public void CredentialsPrecedence_GoogleCredential()
+            {
+                var credential = GoogleCredential.FromJson(s_serviceAccountJson);
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton(credential);
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Null(builder.ChannelCredentials);
+                Assert.Null(builder.Credential);
+                Assert.Same(credential, builder.GoogleCredential);
+            }
+
+            private class FakeBuilder : ClientBuilderBase<string>
+            {
+                internal FakeBuilder() : base(TestServiceMetadata.TestService)
+                {
+                }
+
+                // Note: this takes an IServiceCollection instead of an IServiceProvider just for the convenience of testing.
+                public void Configure(IServiceCollection collection) => base.Configure(collection.BuildServiceProvider());
+
+                public new GrpcChannelOptions GetChannelOptions() => throw new NotImplementedException();
+                public override string Build() => throw new NotImplementedException();
+                public override Task<string> BuildAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+                protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
+            }
+
+            private class FakeCallInvoker : CallInvoker
+            {
+                public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                    throw new NotImplementedException();
+
+                public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options) =>
+                    throw new NotImplementedException();
+
+                public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                    throw new NotImplementedException();
+
+                public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                    throw new NotImplementedException();
+
+                public override TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request) =>
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetGoogleCredentialTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetGoogleCredentialTest.cs
@@ -28,28 +28,6 @@ namespace Google.Api.Gax.Grpc.Tests
         public class GetGoogleCredentialTest
         {
             private static readonly string[] s_scopes = { "scope1", "scope2" };
-            // Taken from https://github.com/googleapis/google-api-dotnet-client/blob/main/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
-            private static readonly string s_serviceAccountJson = @"{
-""private_key_id"": ""PRIVATE_KEY_ID"",
-""private_key"": ""-----BEGIN PRIVATE KEY-----
-MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAJJM6HT4s6btOsfe
-2x4zrzrwSUtmtR37XTTi0sPARTDF8uzmXy8UnE5RcVJzEH5T2Ssz/ylX4Sl/CI4L
-no1l8j9GiHJb49LSRjWe4Yx936q0Xj9H0R1HTxvjUPqwAsTwy2fKBTog+q1frqc9
-o8s2r6LYivUGDVbhuUzCaMJsf+x3AgMBAAECgYEAi0FTXsu/zRswAUGaViQiHjrL
-uU65BSHXNVjV/2fLNEKnGWGqpli68z1IXY+S2nwbUak7rnGsq9/0F6jtsW+hZbLk
-KXUOuuExpeC5Kd6ngWX/f2jqmhlUabiQijU9cVk7pMq8EHkRtvlosnMTUAEzempu
-QUPwn1PZHhmJkBvZ4lECQQDCErrxl+e3BwUDcS0yVEEmCNSG6xdXs2878b8rzbe7
-3Mmi6SuuOLi3PU92J+j+f/MOdtYrk13mEDdYmd5dhrt5AkEAwPvDEsDT/W4y4h5n
-gv1awGBA5aLFE1JNWM/Gwn4D1cGpEDHKFREaBtxMDCASpHJuw8r7zUywpKhmBZcf
-GS37bwJANdSAKfbafLfjuhqwUJ9yGpykZm/a36aTmerp/bpn1iHdg+RtCzwMcDb/
-TWSwibbvsflgWmHbz657y4WSWhq+8QJAWrpCNN/ZCk2zuGDo80lfUBAwkoVat8G6
-wWU1oZyS+vzIGef+hLb8kHsjeZPej9eIwZ39kcBbT54oELrCkRjwGwJAQ8V2A7lT
-ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
-4Z5p2prkjWTLcA==
------END PRIVATE KEY-----"",
-""client_email"": ""CLIENT_EMAIL"",
-""client_id"": ""CLIENT_ID"",
-""type"": ""service_account""}";
 
             [Fact]
             public async Task JsonCredentials_Valid()

--- a/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
+++ b/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
@@ -9,8 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)"/>
+    <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Google.Api.Gax.Grpc/GaxGrpcServiceCollectionExtensions.cs
+++ b/Google.Api.Gax.Grpc/GaxGrpcServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Api.Gax.Grpc;
+using Google.Api.Gax.Grpc.Rest;
+using Grpc.Net.Client;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for dependency injection.
+    /// </summary>
+    public static class GaxGrpcServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a singleton <see cref="GrpcNetClientAdapter"/> to the given service collection
+        /// as the preferred <see cref="GrpcAdapter"/> implementation,
+        /// using the default instance with any additional options configured via <paramref name="optionsConfigurer"/>.
+        /// Note that unlike the <see cref="AddGrpcNetClientAdapter(IServiceCollection)"/> overload without an action,
+        /// this does not implicitly set the <see cref="Grpc.Net.Client.GrpcChannelOptions.ServiceProvider"/> to the provider.
+        /// </summary>
+        /// <param name="services">The service collection to add the adapter to.</param>
+        /// <param name="optionsConfigurer">The configuration action to perform on each <see cref="Grpc.Net.Client.GrpcChannelOptions"/>
+        /// when it is used by the adapter to construct a channel.</param>
+        /// <returns>The same service collection reference, for method chaining.</returns>
+        public static IServiceCollection AddGrpcNetClientAdapter(this IServiceCollection services, Action<IServiceProvider, Grpc.Net.Client.GrpcChannelOptions> optionsConfigurer) =>
+            services.AddSingleton<GrpcAdapter>(provider => GrpcNetClientAdapter.Default.WithAdditionalOptions(options => optionsConfigurer(provider, options)));
+
+        /// <summary>
+        /// Adds a singleton <see cref="GrpcNetClientAdapter"/> to the given service collection
+        /// as the preferred <see cref="GrpcAdapter"/> implementation,
+        /// such that any <see cref="GrpcChannel"/> created uses the service provider from
+        /// created this service collection. This enables logging, for example.
+        /// </summary>
+        /// <param name="services">The service collection to add the adapter to.</param>
+        /// <returns>The same service collection reference, for method chaining.</returns>
+        public static IServiceCollection AddGrpcNetClientAdapter(this IServiceCollection services) =>
+            services.AddSingleton<GrpcAdapter>(provider => GrpcNetClientAdapter.Default.WithAdditionalOptions(options => options.ServiceProvider = provider));
+
+        /// <summary>
+        /// Adds a singleton <see cref="GrpcCoreAdapter"/> to the given service collection
+        /// as the preferred <see cref="GrpcAdapter"/> implementation.
+        /// </summary>
+        /// <param name="services">The service collection to add the adapter to.</param>
+        /// <returns>The same service collection reference, for method chaining.</returns>
+        public static IServiceCollection AddGrpcCoreAdapter(this IServiceCollection services) =>
+            // Note: this is still lazy, to avoid initializing Grpc.Core earlier than necessary.
+            services.AddSingleton<GrpcAdapter>(provider => GrpcCoreAdapter.Instance);
+
+        /// <summary>
+        /// Adds a singleton <see cref="RestGrpcAdapter"/> to the given service collection
+        /// as the preferred <see cref="GrpcAdapter"/> implementation.
+        /// </summary>
+        /// <param name="services">The service collection to add the adapter to.</param>
+        /// <returns>The same service collection reference, for method chaining.</returns>
+        public static IServiceCollection AddGrpcRestAdapter(this IServiceCollection services) =>
+            services.AddSingleton<GrpcAdapter>(RestGrpcAdapter.Default);
+    }
+}

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -21,5 +21,6 @@
     <PackageReference Include="Google.Apis.Auth" Version="[1.56.0, 2.0.0)" />
     <PackageReference Include="Grpc.Core.Api" Version="[2.41.0, 3.0.0)" />
     <PackageReference Include="Grpc.Net.Client" Version="[2.41.0, 3.0.0)"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.DependencyInjection.cs
+++ b/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.DependencyInjection.cs
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Rest.Tests
+{
+    public partial class ClientBuilderBaseTest
+    {
+        /// <summary>
+        /// Tests for <see cref="ClientBuilderBase{TClient}.Configure(IServiceProvider)"/>.
+        /// </summary>
+        public class DependencyInjection
+        {
+            [Fact]
+            public void HttpClientFactory_NotSetBefore()
+            {
+                var factory = new HttpClientFactory();
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<IHttpClientFactory>(factory);
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Same(factory, builder.HttpClientFactory);
+            }
+
+            [Fact]
+            public void HttpClientFactory_SetBefore()
+            {
+                var manual = new HttpClientFactory();
+                var dependency = new HttpClientFactory();
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<IHttpClientFactory>(dependency);
+                var builder = new FakeBuilder { HttpClientFactory = manual };
+                builder.Configure(serviceCollection);
+                Assert.Same(manual, builder.HttpClientFactory);
+            }
+
+            [Fact]
+            public void CredentialsNotUsedWhenAlreadySet()
+            {
+                var serviceCollection = new ServiceCollection();
+                var dependencyCredential = GoogleCredential.FromJson(s_serviceAccountJson);
+                serviceCollection.AddSingleton(dependencyCredential);
+#pragma warning disable CS0618 // Type or member is obsolete
+                Action<FakeBuilder>[] actions = new Action<FakeBuilder>[]
+                {
+                    builder => builder.JsonCredentials = "{}",
+                    builder => builder.CredentialsPath = "abc",
+                    builder => builder.Credential = GoogleCredential.FromJson(s_serviceAccountJson),
+                    builder => builder.GoogleCredential = GoogleCredential.FromJson(s_serviceAccountJson),
+                };
+#pragma warning restore CS0618 // Type or member is obsolete
+                foreach (var action in actions)
+                {
+                    var builder = new FakeBuilder();
+                    action(builder);
+                    builder.Configure(serviceCollection);
+                    // Note that in one test we'll set the GoogleCredential to a non-null value, but
+                    // it won't be the same object.
+                    Assert.NotSame(dependencyCredential, builder.GoogleCredential);
+                }
+            }
+
+            [Fact]
+            public void CredentialsPrecedence_ICredential()
+            {
+                var credential1 = GoogleCredential.FromJson(s_serviceAccountJson);
+                var credential2 = GoogleCredential.FromJson(s_serviceAccountJson);
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton<ICredential>(credential1);
+                serviceCollection.AddSingleton(credential2);
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Same(credential1, builder.Credential);
+                Assert.Null(builder.GoogleCredential);
+            }
+
+            [Fact]
+            public void CredentialsPrecedence_GoogleCredential()
+            {
+                var credential = GoogleCredential.FromJson(s_serviceAccountJson);
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddSingleton(credential);
+                var builder = new FakeBuilder();
+                builder.Configure(serviceCollection);
+                Assert.Null(builder.Credential);
+                Assert.Same(credential, builder.GoogleCredential);
+            }
+
+            private class FakeBuilder : ClientBuilderBase<string>
+            {
+                // Note: this takes an IServiceCollection instead of an IServiceProvider just for the convenience of testing.
+                public void Configure(IServiceCollection collection) => base.Configure(collection.BuildServiceProvider());
+
+                public override string Build() =>
+                    throw new NotImplementedException();
+
+                public override Task<string> BuildAsync(CancellationToken cancellationToken = default) =>
+                    throw new NotImplementedException();
+
+                protected override string GetDefaultApplicationName() =>
+                    throw new NotImplementedException();
+
+                protected override ScopedCredentialProvider GetScopedCredentialProvider() =>
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.cs
@@ -1,11 +1,21 @@
 ﻿/*
- * Copyright 2020 Google Inc. All Rights Reserved.
+ * Copyright 2022 Google Inc. All Rights Reserved.
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file or at
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-namespace Google.Api.Gax.Grpc.Tests
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Api.Gax.Rest.Tests
 {
     /// <summary>
     /// Placeholder for the nested test classes (in separate files).

--- a/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
+++ b/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
@@ -10,10 +10,17 @@
 
   <ItemGroup>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Rest\Google.Api.Gax.Rest.csproj" />
     <ProjectReference Include="..\Google.Api.Gax.Testing\Google.Api.Gax.Testing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="ClientBuilderBaseTest.DependencyInjection.cs">
+      <DependentUpon>ClientBuilderBaseTest.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -17,5 +17,6 @@
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
     <PackageReference Include="Google.Apis.Auth" Version="[1.56.0, 2.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
End-user code:

```csharp
builder.Services.AddGrpcNetClientAdapter();
builder.Services.AddGoogleTranslationServiceClient();
```

Translation service code:

```csharp
namespace Google.Cloud.Translate.V3
{
    public partial class TranslationServiceClientBuilder
    {
        internal static TranslationServiceClient ConfigureAndBuild(IServiceProvider provider, Action<TranslationServiceClientBuilder> configure)
        {
            var builder = new TranslationServiceClientBuilder();
            configure?.Invoke(builder);
            builder.Configure(provider);
            return builder.Build();
        }
    }
}

namespace Microsoft.Extensions.DependencyInjection
{
    using Google.Cloud.Translate.V3;

    public static class TranslationServiceClientExtensions
    {
        public static IServiceCollection AddGoogleTranslationServiceClient(this IServiceCollection collection, Action<TranslationServiceClientBuilder> configure) =>
            collection.AddSingleton(provider => TranslationServiceClientBuilder.ConfigureAndBuild(provider, configure));

        public static IServiceCollection AddGoogleTranslationServiceClient(this IServiceCollection collection) =>
            AddGoogleTranslationServiceClient(collection, null);
    }
}
```