### PR TITLE
Refactor gRPC adapter support

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/ChannelPoolTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ChannelPoolTest.cs
@@ -5,8 +5,6 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 using Grpc.Core;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,13 +12,13 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
 {
     public class ChannelPoolTest
     {
-        private static readonly IEnumerable<string> EmptyScopes = Enumerable.Empty<string>();
         private static readonly GrpcAdapter Grpc = GrpcCoreAdapter.Instance;
+        private static readonly ServiceMetadata ServiceMetadata = TestServiceMetadata.TestService;
 
         [Fact]
         public void SameEndpoint_SameChannel()
         {
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(Grpc, fixture.Endpoint, GrpcChannelOptions.Empty);
@@ -32,7 +30,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void DifferentEndpoint_DifferentChannel()
         {
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (TestServiceFixture fixture1 = new TestServiceFixture(), fixture2 = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(Grpc, fixture1.Endpoint, GrpcChannelOptions.Empty);
@@ -46,7 +44,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         {
             var options1 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
             var options2 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(Grpc, fixture.Endpoint, options1);
@@ -60,7 +58,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         {
             var options1 = GrpcChannelOptions.Empty.WithCustomOption("x", 5);
             var options2 = GrpcChannelOptions.Empty.WithCustomOption("x", 6);
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(Grpc, fixture.Endpoint, options1);
@@ -72,7 +70,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public async Task ShutdownAsync_ShutsDownChannel()
         {
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (var fixture = new TestServiceFixture())
             {
                 var channel = (Channel) pool.GetChannel(Grpc, fixture.Endpoint, GrpcChannelOptions.Empty);
@@ -85,7 +83,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void ShutdownAsync_EmptiesPool()
         {
-            var pool = new ChannelPool(EmptyScopes, false);
+            var pool = new ChannelPool(ServiceMetadata);
             using (var fixture = new TestServiceFixture())
             {
                 var channel1 = pool.GetChannel(Grpc, fixture.Endpoint, GrpcChannelOptions.Empty);

--- a/Google.Api.Gax.Grpc.IntegrationTests/Gcp/FakeChannel.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Gcp/FakeChannel.cs
@@ -15,12 +15,13 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
     /// </summary>
     internal class FakeChannel : ChannelBase
     {
+        public ServiceMetadata ServiceMetadata { get; }
         public ChannelCredentials Credentials { get; }
         public GrpcChannelOptions Options { get; }
 
-
-        public FakeChannel(string target, ChannelCredentials credentials, GrpcChannelOptions options) : base(target)
-        {
+        public FakeChannel(ServiceMetadata serviceMetadata, string target, ChannelCredentials credentials, GrpcChannelOptions options) : base(target)
+{
+            ServiceMetadata = serviceMetadata;
             Credentials = credentials;
             Options = options;
         }

--- a/Google.Api.Gax.Grpc.IntegrationTests/Gcp/FakeGrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Gcp/FakeGrpcAdapter.cs
@@ -16,7 +16,11 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
     /// </summary>
     internal class FakeGrpcAdapter : GrpcAdapter
     {
-        protected override ChannelBase CreateChannelImpl(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
-            new FakeChannel(endpoint, credentials, options);
+        internal FakeGrpcAdapter(ApiTransports transports = ApiTransports.Grpc) : base(transports)
+        {
+        }
+
+        private protected override ChannelBase CreateChannelImpl(ServiceMetadata serviceMetadata, string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
+            new FakeChannel(serviceMetadata, endpoint, credentials, options);
     }
 }

--- a/Google.Api.Gax.Grpc.IntegrationTests/Gcp/GrpcCallInvokerPoolTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Gcp/GrpcCallInvokerPoolTest.cs
@@ -5,6 +5,8 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
+using Google.Api.Gax.Grpc.IntegrationTests;
+using Google.Protobuf.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -16,12 +18,11 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
     {
         private static readonly GrpcAdapter FakeAdapter = new FakeGrpcAdapter();
         private static readonly ApiConfig Config1 = new ApiConfig { ChannelPool = new ChannelPoolConfig { MaxSize = 5 } };
-        private static readonly IEnumerable<string> EmptyScopes = Enumerable.Empty<string>();
 
         [Fact]
         public void SameEndpointAndOptions_SameCallInvoker()
         {
-            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var pool = new GcpCallInvokerPool(TestServiceMetadata.TestService);
             var options = GrpcChannelOptions.Empty.WithPrimaryUserAgent("abc");
             var callInvoker1 = pool.GetCallInvoker("endpoint", options, Config1, FakeAdapter);
             var callInvoker2 = pool.GetCallInvoker("endpoint", options, Config1, FakeAdapter);
@@ -31,7 +32,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
         [Fact]
         public void SameEndpointAndEqualOptions_SameCallInvoker()
         {
-            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var pool = new GcpCallInvokerPool(TestServiceMetadata.TestService);
             var options1 = GrpcChannelOptions.Empty.WithPrimaryUserAgent("abc");
             var options2 = GrpcChannelOptions.Empty.WithPrimaryUserAgent("abc");
             var callInvoker1 = pool.GetCallInvoker("endpoint", options1, Config1, FakeAdapter);
@@ -42,7 +43,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
         [Fact]
         public void DifferentEndpoint_DifferentCallInvoker()
         {
-            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var pool = new GcpCallInvokerPool(TestServiceMetadata.TestService);
             var options = GrpcChannelOptions.Empty.WithPrimaryUserAgent("abc");
             var callInvoker1 = pool.GetCallInvoker("endpoint1", options, Config1, FakeAdapter);
             var callInvoker2 = pool.GetCallInvoker("endpoint2", options, Config1, FakeAdapter);
@@ -52,7 +53,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
         [Fact]
         public void DifferentOptions_DifferentCallInvoker()
         {
-            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var pool = new GcpCallInvokerPool(TestServiceMetadata.TestService);
             var options1 = GrpcChannelOptions.Empty.WithPrimaryUserAgent("abc");
             var options2 = GrpcChannelOptions.Empty.WithPrimaryUserAgent("def");
             var callInvoker1 = pool.GetCallInvoker("endpoint", options1, Config1, FakeAdapter);
@@ -67,7 +68,7 @@ namespace Google.Api.Gax.Grpc.Gcp.IntegrationTests
         [Fact]
         public void ShutdownAsync_EmptiesPool()
         {
-            var pool = new GcpCallInvokerPool(EmptyScopes);
+            var pool = new GcpCallInvokerPool(TestServiceMetadata.TestService);
             var callInvoker1 = pool.GetCallInvoker("endpoint", options: null, Config1, FakeAdapter);
             // Note: *not* waiting for this to complete.
             pool.ShutdownChannelsAsync();

--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
@@ -22,11 +22,11 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void CreateChannelMakeCall()
         {
-            var adapter = GrpcAdapter.DefaultAdapter;
+            var adapter = GrpcAdapter.GetFallbackAdapter(TestServiceMetadata.TestService);
             // This is unfortunate, but required for the test.
             // ("localhost:12345" is only valid in Grpc.Core; "http://localhost:12345" is only valid in Grpc.Net.Client.)
             var endpoint = adapter is GrpcNetClientAdapter ? _fixture.HttpEndpoint : _fixture.Endpoint;
-            var channel = adapter.CreateChannel(endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
+            var channel = adapter.CreateChannel(TestServiceMetadata.TestService, endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
             var client = new TestServiceClient(channel);
             var response = client.DoSimple(new SimpleRequest { Name = "test-call" });
             Assert.Equal("test-call", response.Name);

--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcCoreAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcCoreAdapterTest.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using System;
 using Xunit;
 using static Google.Api.Gax.Grpc.IntegrationTests.TestService;
 
@@ -21,7 +22,8 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void CreateChannelMakeCall()
         {
-            var channel = GrpcCoreAdapter.Instance.CreateChannel(_fixture.Endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
+            var channel = GrpcCoreAdapter.Instance.CreateChannel(TestServiceMetadata.TestService, _fixture.Endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
+
             var client = new TestServiceClient(channel);
             var response = client.DoSimple(new SimpleRequest { Name = "test-call" });
             Assert.Equal("test-call", response.Name);
@@ -33,11 +35,16 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         public void PrimaryUserAgentOption()
         {
             var options = GrpcChannelOptions.Empty.WithPrimaryUserAgent("test-user-agent");
-            var channel = GrpcCoreAdapter.Instance.CreateChannel(_fixture.Endpoint, ChannelCredentials.Insecure, options);
+            var channel = GrpcCoreAdapter.Instance.CreateChannel(TestServiceMetadata.TestService, _fixture.Endpoint, ChannelCredentials.Insecure, options);
             var client = new TestServiceClient(channel);
             var response = client.EchoHeaders(new EchoHeadersRequest());
             var userAgent = response.Headers["user-agent"].StringValue;
             Assert.StartsWith("test-user-agent", userAgent);
         }
+
+        [Fact]
+        public void FailsForRestOnlyDescriptor() =>
+            Assert.Throws<ArgumentException>(() =>
+                GrpcCoreAdapter.Instance.CreateChannel(TestServiceMetadata.TestService.WithTransports(ApiTransports.Rest), _fixture.Endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty));
     }
 }

--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcNetClientAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcNetClientAdapterTest.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using System;
 using Xunit;
 using static Google.Api.Gax.Grpc.IntegrationTests.TestService;
 
@@ -22,11 +23,17 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void CreateChannelMakeCall()
         {
-            var channel = GrpcNetClientAdapter.Default.CreateChannel(_fixture.HttpEndpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
+            var channel = GrpcNetClientAdapter.Default.CreateChannel(TestServiceMetadata.TestService, _fixture.HttpEndpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
             var client = new TestServiceClient(channel);
             var response = client.DoSimple(new SimpleRequest { Name = "test-call" });
             Assert.Equal("test-call", response.Name);
         }
+
+        [Fact]
+        public void FailsForRestOnlyDescriptor() =>
+            Assert.Throws<ArgumentException>(() =>
+                GrpcCoreAdapter.Instance.CreateChannel(TestServiceMetadata.TestService.WithTransports(ApiTransports.Rest),
+                    _fixture.Endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty));
     }
 }
 #endif

--- a/Google.Api.Gax.Grpc.IntegrationTests/TestServiceMetadata.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/TestServiceMetadata.cs
@@ -1,0 +1,23 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+namespace Google.Api.Gax.Grpc.IntegrationTests
+{
+    internal static class TestServiceMetadata
+    {
+        internal static ApiMetadata ApiMetadata { get; } =
+            new ApiMetadata("Google.Api.Gax.Grpc.IntegrationTests", new[] { TestServiceReflection.Descriptor });
+        internal static ServiceMetadata TestService { get; } =
+            new ServiceMetadata(IntegrationTests.TestService.Descriptor, "service1.googleapis.com", new[] { "scope1" }, true, ApiTransports.Grpc, ApiMetadata);
+
+        internal static ServiceMetadata WithTransports(this ServiceMetadata metadata, ApiTransports transports) =>
+            new ServiceMetadata(metadata.ServiceDescriptor, metadata.DefaultEndpoint, metadata.DefaultScopes, metadata.SupportsScopedJwts, transports, metadata.ApiMetadata);
+
+        internal static ServiceMetadata WithSupportsScopedJwts(this ServiceMetadata metadata, bool supportsScopedJwts) =>
+            new ServiceMetadata(metadata.ServiceDescriptor, metadata.DefaultEndpoint, metadata.DefaultScopes, supportsScopedJwts, metadata.Transports, metadata.ApiMetadata);
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/ApiMetadataTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ApiMetadataTest.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf.Reflection;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    public class ApiMetadataTest
+    {
+        [Fact]
+        public void ConstructorWithDescriptorsProvider_LazyEvaluation()
+        {
+            var sequence = new CountingSequence();
+            var descriptor = new ApiMetadata("Test", sequence);
+            // By the time the constructor returns, it's already evaluated the sequence.
+            Assert.Equal(1, sequence.EvaluationCount);
+
+            // Fetching the first time doesn't change the evaluation count
+            var protobufDescriptors = descriptor.ProtobufDescriptors;
+            Assert.Equal(1, sequence.EvaluationCount);
+
+            // Using the returned list doesn't change the evaluation count
+            Assert.Equal(0, protobufDescriptors.Count());
+            Assert.Equal(1, sequence.EvaluationCount);
+
+            // Fetching a second time doesn't change the evaluation count
+            protobufDescriptors = descriptor.ProtobufDescriptors;
+            Assert.Equal(1, sequence.EvaluationCount);
+        }
+
+        [Fact]
+        public void ConstructorWithDescriptors_SingleImmediateEvaluation()
+        {
+            var sequence = new CountingSequence();
+            var descriptor = new ApiMetadata("Test", () => sequence);
+            Assert.Equal(0, sequence.EvaluationCount);
+
+            // Fetching the first time immediately evaluates the sequence
+            var protobufDescriptors = descriptor.ProtobufDescriptors;
+            Assert.Equal(1, sequence.EvaluationCount);
+
+            // Using the returned list doesn't change the evaluation count
+            Assert.Equal(0, protobufDescriptors.Count());
+            Assert.Equal(1, sequence.EvaluationCount);
+
+            // Fetching a second time doesn't change the evaluation count
+            protobufDescriptors = descriptor.ProtobufDescriptors;
+            Assert.Equal(1, sequence.EvaluationCount);
+        }
+
+        private class CountingSequence : IEnumerable<FileDescriptor>
+        {
+            public int EvaluationCount { get; private set; } = 0;
+
+            public IEnumerator<FileDescriptor> GetEnumerator()
+            {
+                EvaluationCount++;
+                yield break;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetEmulatorEnvironmentTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetEmulatorEnvironmentTest.cs
@@ -5,6 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
+using Google.Protobuf.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -223,7 +224,7 @@ namespace Google.Api.Gax.Grpc.Tests
 
             private class FakeBuilder : ClientBuilderBase<string>
             {
-                internal FakeBuilder(EmulatorDetection detection) =>
+                internal FakeBuilder(EmulatorDetection detection) : base(TestServiceMetadata.TestService) =>
                     EmulatorDetection = detection;
 
                 /// <summary>
@@ -234,12 +235,9 @@ namespace Google.Api.Gax.Grpc.Tests
                         key => environment.TryGetValue(key, out var value) ? value : null);
 
                 public new GrpcChannelOptions GetChannelOptions() => base.GetChannelOptions();
-                protected override GrpcAdapter DefaultGrpcAdapter => throw new NotImplementedException();
                 public override string Build() => throw new NotImplementedException();
                 public override Task<string> BuildAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
                 protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
-                protected override string GetDefaultEndpoint() => throw new NotImplementedException();
-                protected override IReadOnlyList<string> GetDefaultScopes() => throw new NotImplementedException();
             }
         }
     }

--- a/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetGoogleCredentialTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ClientBuilderBaseTest.GetGoogleCredentialTest.cs
@@ -6,6 +6,7 @@
  */
 
 using Google.Apis.Auth.OAuth2;
+using Google.Protobuf.Reflection;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -128,21 +129,15 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
 
             private class FakeBuilder : ClientBuilderBase<string>
             {
-                public IReadOnlyList<string> DefaultScopes { get; }
-
                 internal FakeBuilder(string[] defaultScopes, bool useJwtAccessWithScopes)
+                    : base(TestServiceMetadata.TestService.WithSupportsScopedJwts(useJwtAccessWithScopes).WithDefaultScopes(defaultScopes))
                 {
-                    UseJwtAccessWithScopes = useJwtAccessWithScopes;
-                    Scopes = defaultScopes;
                 }
 
                 public new GrpcChannelOptions GetChannelOptions() => throw new NotImplementedException();
-                protected override GrpcAdapter DefaultGrpcAdapter => throw new NotImplementedException();
                 public override string Build() => throw new NotImplementedException();
                 public override Task<string> BuildAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
                 protected override ChannelPool GetChannelPool() => throw new NotImplementedException();
-                protected override string GetDefaultEndpoint() => throw new NotImplementedException();
-                protected override IReadOnlyList<string> GetDefaultScopes() => DefaultScopes;
             }
         }
     }

--- a/Google.Api.Gax.Grpc.Tests/TestApiMetadata.cs
+++ b/Google.Api.Gax.Grpc.Tests/TestApiMetadata.cs
@@ -1,0 +1,16 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf.Reflection;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    internal static class TestApiMetadata
+    {
+        internal static ApiMetadata Test { get; } = new ApiMetadata(nameof(Test), new FileDescriptor[0]);
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/TestMessages.g.cs
+++ b/Google.Api.Gax.Grpc.Tests/TestMessages.g.cs
@@ -31,7 +31,10 @@ namespace Google.Api.Gax.Grpc {
             "bXBsZVJlc3BvbnNlEgwKBG5hbWUYAiABKAkiTAoUUGFnZVN0cmVhbWluZ1Jl",
             "cXVlc3QSEgoKcGFnZV90b2tlbhgBIAEoCRIRCglwYWdlX3NpemUYAiABKAUS",
             "DQoFY2hlY2sYAyABKAkiPwoVUGFnZVN0cmVhbWluZ1Jlc3BvbnNlEg0KBWl0",
-            "ZW1zGAEgAygFEhcKD25leHRfcGFnZV90b2tlbhgCIAEoCWIGcHJvdG8z"));
+            "ZW1zGAEgAygFEhcKD25leHRfcGFnZV90b2tlbhgCIAEoCTJiCgtUZXN0U2Vy",
+            "dmljZRJTCghEb1NpbXBsZRIiLmdvb2dsZS5hcGkuZ2F4LmdycGMuU2ltcGxl",
+            "UmVxdWVzdBojLmdvb2dsZS5hcGkuZ2F4LmdycGMuU2ltcGxlUmVzcG9uc2Vi",
+            "BnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {

--- a/Google.Api.Gax.Grpc.Tests/TestServiceMetadata.cs
+++ b/Google.Api.Gax.Grpc.Tests/TestServiceMetadata.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Collections.Generic;
+
+namespace Google.Api.Gax.Grpc.Tests
+{
+    internal static class TestServiceMetadata
+    {
+        internal static ApiMetadata ApiMetadata { get; } =
+            new ApiMetadata("Google.Api.Gax.Grpc.Tests", new[] { TestMessagesReflection.Descriptor });
+        internal static ServiceMetadata TestService { get; } =
+            new ServiceMetadata(TestMessagesReflection.Descriptor.Services[0], "service1.googleapis.com", new[] { "scope1" }, true, ApiTransports.Grpc, ApiMetadata);
+
+        internal static ServiceMetadata WithTransports(this ServiceMetadata metadata, ApiTransports transports) =>
+            new ServiceMetadata(metadata.ServiceDescriptor, metadata.DefaultEndpoint, metadata.DefaultScopes, metadata.SupportsScopedJwts, transports, metadata.ApiMetadata);
+
+        internal static ServiceMetadata WithSupportsScopedJwts(this ServiceMetadata metadata, bool supportsScopedJwts) =>
+            new ServiceMetadata(metadata.ServiceDescriptor, metadata.DefaultEndpoint, metadata.DefaultScopes, supportsScopedJwts, metadata.Transports, metadata.ApiMetadata);
+
+        internal static ServiceMetadata WithDefaultScopes(this ServiceMetadata metadata, IEnumerable<string> defaultScopes) =>
+            new ServiceMetadata(metadata.ServiceDescriptor, metadata.DefaultEndpoint, defaultScopes, metadata.SupportsScopedJwts, metadata.Transports, metadata.ApiMetadata);
+    }
+}

--- a/Google.Api.Gax.Grpc.Tests/test_messages.proto
+++ b/Google.Api.Gax.Grpc.Tests/test_messages.proto
@@ -9,6 +9,10 @@ syntax = "proto3";
 
 package google.api.gax.grpc;
 
+service TestService {
+  rpc DoSimple(SimpleRequest) returns (SimpleResponse);
+}
+
 // Messages required for testing
 
 message BundlingRequest {

--- a/Google.Api.Gax.Grpc/ApiMetadata.cs
+++ b/Google.Api.Gax.Grpc/ApiMetadata.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Provides metadata about an API. This is expected to be constructed with a single instance
+    /// per API; equality is by simple identity.
+    /// </summary>
+    public sealed partial class ApiMetadata
+    {
+        private Lazy<IReadOnlyList<FileDescriptor>> _fileDescriptorsProvider;
+
+        /// <summary>
+        /// The protobuf descriptors used by this API.
+        /// </summary>
+        public IReadOnlyList<FileDescriptor> ProtobufDescriptors => _fileDescriptorsProvider.Value;
+
+        private Lazy<TypeRegistry> _typeRegistryProvider;
+
+        /// <summary>
+        /// A type registry containing all the types in <see cref="ProtobufDescriptors"/>.
+        /// </summary>
+        public TypeRegistry TypeRegistry => _typeRegistryProvider.Value;
+
+        /// <summary>
+        /// The name of the API (typically the fully-qualified name of the client library package).
+        /// This is never null or empty.
+        /// </summary>
+        public string Name { get; }
+
+        private ApiMetadata(string name)
+        {
+            GaxPreconditions.CheckNotNullOrEmpty(name, nameof(name));
+            Name = name;
+            _typeRegistryProvider = new Lazy<TypeRegistry>(() => TypeRegistry.FromFiles(ProtobufDescriptors));
+        }
+
+        /// <summary>
+        /// Creates an API descriptor from a sequence of file descriptors.
+        /// </summary>
+        /// <remarks>
+        /// The sequence is evaluated once, on construction.
+        /// </remarks>
+        /// <param name="name">The name of the API. Must not be null or empty.</param>
+        /// <param name="descriptors">The protobuf descriptors of the API. Must not be null.</param>
+        public ApiMetadata(string name, IEnumerable<FileDescriptor> descriptors) : this(name)
+        {
+            var actualDescriptors = descriptors.ToList().AsReadOnly();
+            _fileDescriptorsProvider = new Lazy<IReadOnlyList<FileDescriptor>>(() => actualDescriptors);
+        }
+
+        /// <summary>
+        /// Creates an API descriptor which lazily requests the protobuf descriptors when <see cref="ProtobufDescriptors"/> is first called.
+        /// </summary>
+        /// <param name="name">The name of the API. Must not be null or empty.</param>
+        /// <param name="descriptorsProvider">A provider function for the protobuf descriptors of the API. Must not be null, and must not
+        /// return a null value. This will only be called once by this API descriptor, when first requested.</param>
+        public ApiMetadata(string name, Func<IEnumerable<FileDescriptor>> descriptorsProvider) : this(name)
+        {
+            Func<IReadOnlyList<FileDescriptor>> function = () => descriptorsProvider().ToList().AsReadOnly();
+            _fileDescriptorsProvider = new Lazy<IReadOnlyList<FileDescriptor>>(function, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+    }
+}

--- a/Google.Api.Gax.Grpc/Gcp/GcpCallInvoker.cs
+++ b/Google.Api.Gax.Grpc/Gcp/GcpCallInvoker.cs
@@ -38,22 +38,25 @@ namespace Google.Api.Gax.Grpc.Gcp
         private readonly ChannelCredentials _credentials;
         private readonly GrpcChannelOptions _channelOptions;
         private readonly GrpcAdapter _adapter;
+        private readonly ServiceMetadata _serviceMetadata;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
         /// </summary>
+        /// <param name="serviceMetadata">The metadata for the service that this call invoker will be used with. Must not be null.</param>
         /// <param name="target">Target of the underlying grpc channels. Must not be null.</param>
         /// <param name="credentials">Credentials to secure the underlying grpc channels. Must not be null.</param>
         /// <param name="options">Channel options to be used by the underlying grpc channels. Must not be null.</param>
         /// <param name="apiConfig">The API config to apply. Must not be null.</param>
         /// <param name="adapter">The adapter to use to create channels. Must not be null.</param>
-        internal GcpCallInvoker(string target, ChannelCredentials credentials, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
+        internal GcpCallInvoker(ServiceMetadata serviceMetadata, string target, ChannelCredentials credentials, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
         {
-            this._target = GaxPreconditions.CheckNotNull(target, nameof(target));
-            this._credentials = GaxPreconditions.CheckNotNull(credentials, nameof(credentials));
-            this._adapter = GaxPreconditions.CheckNotNull(adapter, nameof(adapter));
-            this._apiConfig = GaxPreconditions.CheckNotNull(apiConfig, nameof(apiConfig)).Clone();
+            _serviceMetadata = GaxPreconditions.CheckNotNull(serviceMetadata, nameof(serviceMetadata));
+            _target = GaxPreconditions.CheckNotNull(target, nameof(target));
+            _credentials = GaxPreconditions.CheckNotNull(credentials, nameof(credentials));
             _channelOptions = GaxPreconditions.CheckNotNull(options, nameof(options));
+            _apiConfig = GaxPreconditions.CheckNotNull(apiConfig, nameof(apiConfig)).Clone();
+            _adapter = GaxPreconditions.CheckNotNull(adapter, nameof(adapter));
 
             GaxPreconditions.CheckArgument(this._apiConfig.ChannelPool is object, nameof(apiConfig), "Invalid API config: no channel pool settings");
             _affinityByMethod = InitAffinityByMethodIndex(this._apiConfig);
@@ -110,7 +113,7 @@ namespace Google.Api.Gax.Grpc.Gcp
                     // Creates a new gRPC channel.
                     // TODO: Logging?
                     // GrpcEnvironment.Logger.Info("Grpc.Gcp creating new channel");
-                    ChannelBase channel = _adapter.CreateChannel(_target, _credentials, _channelOptions.WithCustomOption(ClientChannelId, Interlocked.Increment(ref s_clientChannelIdCounter)));
+                    ChannelBase channel = _adapter.CreateChannel(_serviceMetadata, _target, _credentials, _channelOptions.WithCustomOption(ClientChannelId, Interlocked.Increment(ref s_clientChannelIdCounter)));
                     ChannelRef channelRef = new ChannelRef(channel, count);
                     _channelRefs.Add(channelRef);
                     return channelRef;

--- a/Google.Api.Gax.Grpc/Gcp/GcpCallInvokerPool.cs
+++ b/Google.Api.Gax.Grpc/Gcp/GcpCallInvokerPool.cs
@@ -26,27 +26,20 @@ namespace Google.Api.Gax.Grpc.Gcp
 
         private readonly DefaultChannelCredentialsCache _credentialsCache;
 
+        private readonly ServiceMetadata _serviceMetadata;
         private readonly Dictionary<Key, GcpCallInvoker> _callInvokers = new Dictionary<Key, GcpCallInvoker>();
         private readonly object _lock = new object();
 
         /// <summary>
-        /// Creates a call invoker pool which will apply the specified scopes to the default application credentials
-        /// if they require any.
+        /// Creates a call invoker pool which will use the given service metadata to determine scopes
+        /// and self-signed JWT support.
         /// </summary>
-        /// <param name="scopes">The scopes to apply. Must not be null, and must not contain null references. May be empty.</param>
-        public GcpCallInvokerPool(IEnumerable<string> scopes) : this(scopes, false)
+        /// <param name="serviceMetadata">The metadata for the service that this pool will be used with. Must not be null.</param>
+        public GcpCallInvokerPool(ServiceMetadata serviceMetadata)
         {
+            _serviceMetadata = GaxPreconditions.CheckNotNull(serviceMetadata, nameof(serviceMetadata));
+            _credentialsCache = new DefaultChannelCredentialsCache(serviceMetadata);
         }
-
-        /// <summary>
-        /// Creates a call invoker pool which will apply the specified scopes to the default application credentials
-        /// if they require any.
-        /// </summary>
-        /// <param name="scopes">The scopes to apply. Must not be null, and must not contain null references. May be empty.</param>
-        /// <param name="useJwtAccessWithScopes">A flag preferring use of self-signed JWTs over OAuth tokens 
-        /// when OAuth scopes are explicitly set.</param>
-        public GcpCallInvokerPool(IEnumerable<string> scopes, bool useJwtAccessWithScopes) =>
-            _credentialsCache = new DefaultChannelCredentialsCache(scopes, useJwtAccessWithScopes);
 
         /// <summary>
         /// Shuts down all the open channels of all currently-allocated call invokers asynchronously. This does not prevent
@@ -112,7 +105,7 @@ namespace Google.Api.Gax.Grpc.Gcp
             {
                 if (!_callInvokers.TryGetValue(key, out GcpCallInvoker callInvoker))
                 {
-                    callInvoker = new GcpCallInvoker(endpoint, credentials, effectiveOptions, apiConfig, adapter);
+                    callInvoker = new GcpCallInvoker(_serviceMetadata, endpoint, credentials, effectiveOptions, apiConfig, adapter);
                     _callInvokers[key] = callInvoker;
                 }
                 return callInvoker;

--- a/Google.Api.Gax.Grpc/GrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcAdapter.cs
@@ -5,6 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
+using Google.Api.Gax.Grpc.Rest;
 using Grpc.Core;
 using Grpc.Net.Client;
 using System;
@@ -13,46 +14,90 @@ using System.Threading;
 namespace Google.Api.Gax.Grpc
 {
     /// <summary>
-    /// Interoperability layer for the aspects of gRPC that aren't covered by Grpc.Core.Api.
+    /// Interoperability layer for different gRPC transports. Concrete subclasses are
+    /// <see cref="GrpcCoreAdapter"/>, <see cref="GrpcNetClientAdapter"/> and <see cref="RestGrpcAdapter"/>.
     /// </summary>
+    /// <remarks>
+    /// This is an abstract class with all concrete subclasses internal, and internal abstract methods
+    /// to prevent instantiation elsewhere. (The abstraction itself may change over time.)
+    /// </remarks>
     public abstract class GrpcAdapter
     {
         private const string AdapterOverrideEnvironmentVariable = "GRPC_DEFAULT_ADAPTER_OVERRIDE";
 
-        private static readonly Lazy<GrpcAdapter> s_defaultFactory = new Lazy<GrpcAdapter>(CreateDefaultAdapter, LazyThreadSafetyMode.PublicationOnly);
+        /// <summary>
+        /// The lazily-evaluated adapter to use for services with ApiTransports.Grpc.
+        /// </summary>
+        private static readonly Lazy<GrpcAdapter> s_defaultGrpcTransportFactory =
+            new Lazy<GrpcAdapter>(CreateDefaultGrpcTransportAdapter, LazyThreadSafetyMode.PublicationOnly);
+
+        private readonly ApiTransports _supportedTransports;
+
+        private protected GrpcAdapter(ApiTransports supportedTransports)
+        {
+            _supportedTransports = supportedTransports;
+        }
+
+        // TODO: potentially expose either or both of the methods below if we want, or a
+        // "get the first adapter that supports this service, from the following list, or a fallback"
+        // method.
+
+        /// <summary>
+        /// Returns whether or not this adapter supports the specified service.
+        /// </summary>
+        /// <param name="serviceMetadata">The service metadata. Must not be null.</param>
+        /// <returns><c>true</c> if this adapter supports the given service; <c>false</c> otherwise.</returns>
+        internal bool SupportsApi(ServiceMetadata serviceMetadata)
+        {
+            GaxPreconditions.CheckNotNull(serviceMetadata, nameof(serviceMetadata));
+            return (serviceMetadata.Transports & _supportedTransports) != 0;
+        }
+
+        /// <summary>
+        /// Returns a fallback provider suitable for the given API
+        /// </summary>
+        /// <param name="serviceMetadata">The descriptor of the API. Must not be null.</param>
+        /// <returns>A suitable GrpcAdapter for the given API, preferring the use of the binary gRPC transport where available.</returns>
+        internal static GrpcAdapter GetFallbackAdapter(ServiceMetadata serviceMetadata) =>
+            // TODO: Do we need some way of indicating a preference, if the service supports both Rest and Grpc?
+            // Probably not: the user code can always specify the adapter in the builder
+            serviceMetadata.Transports.HasFlag(ApiTransports.Grpc) ? s_defaultGrpcTransportFactory.Value
+            : serviceMetadata.Transports.HasFlag(ApiTransports.Rest) ? RestGrpcAdapter.Default
+            : throw new ArgumentException("No known adapters support the given service.");
 
         /// <summary>
         /// Creates a channel for the given endpoint, using the given credentials and options.
         /// </summary>
+        /// <param name="serviceMetadata">The metadata for the service. Must not be null.</param>
         /// <param name="endpoint">The endpoint to connect to. Must not be null.</param>
         /// <param name="credentials">The channel credentials to use. Must not be null.</param>
         /// <param name="options">The channel options to use. Must not be null.</param>
         /// <returns>A channel for the specified settings.</returns>
-        public ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options)
+        internal ChannelBase CreateChannel(ServiceMetadata serviceMetadata, string endpoint, ChannelCredentials credentials, GrpcChannelOptions options)
         {
+            if (!SupportsApi(serviceMetadata))
+            {
+                throw new ArgumentException($"API {serviceMetadata.Name} does not have any transports in common with {GetType().Name}");
+            }
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
             GaxPreconditions.CheckNotNull(credentials, nameof(credentials));
             GaxPreconditions.CheckNotNull(options, nameof(options));
-            return CreateChannelImpl(endpoint, credentials, options);
+            return CreateChannelImpl(serviceMetadata, endpoint, credentials, options);
         }
 
         /// <summary>
         /// Creates a channel for the given endpoint, using the given credentials and options. All parameters
         /// are pre-validated to be non-null.
         /// </summary>
+        /// <param name="apiMetadata"></param>
         /// <param name="endpoint">The endpoint to connect to. Will not be null.</param>
         /// <param name="credentials">The channel credentials to use. Will not be null.</param>
         /// <param name="options">The channel options to use. Will not be null.</param>
         /// <returns>A channel for the specified settings.</returns>
-        protected abstract ChannelBase CreateChannelImpl(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options);
+        private protected abstract ChannelBase CreateChannelImpl(ServiceMetadata apiMetadata, string endpoint, ChannelCredentials credentials, GrpcChannelOptions options);
 
-        /// <summary>
-        /// Returns the default gRPC adapter based on the available gRPC implementations.
-        /// </summary>
-        public static GrpcAdapter DefaultAdapter => s_defaultFactory.Value;
-
-        private static GrpcAdapter CreateDefaultAdapter() =>
-            GetDefaultFromEnvironmentVariable() ?? DetectDefaultPreferringGrpcNetClient();
+        private static GrpcAdapter CreateDefaultGrpcTransportAdapter() =>
+            GetDefaultFromEnvironmentVariable() ?? DetectDefaultGrpcTransportAdapterPreferringGrpcNetClient();
 
         private static GrpcAdapter GetDefaultFromEnvironmentVariable() =>
             GetDefaultFromEnvironmentVariable(Environment.GetEnvironmentVariable(AdapterOverrideEnvironmentVariable));
@@ -72,7 +117,7 @@ namespace Google.Api.Gax.Grpc
         }
 
         // TODO: Is this really what we want? Definitely simple, but not great in other ways...
-        private static GrpcAdapter DetectDefaultPreferringGrpcNetClient()
+        private static GrpcAdapter DetectDefaultGrpcTransportAdapterPreferringGrpcNetClient()
         {
             try
             {
@@ -84,5 +129,6 @@ namespace Google.Api.Gax.Grpc
                 return GrpcCoreAdapter.Instance;
             }
         }
+
     }
 }

--- a/Google.Api.Gax.Grpc/GrpcCoreAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcCoreAdapter.cs
@@ -47,12 +47,12 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         public static GrpcCoreAdapter Instance { get; } = new GrpcCoreAdapter();
 
-        private GrpcCoreAdapter()
+        private GrpcCoreAdapter() : base(ApiTransports.Grpc)
         {
         }
 
         /// <inheritdoc />
-        protected override ChannelBase CreateChannelImpl(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
+        private protected override ChannelBase CreateChannelImpl(ServiceMetadata serviceMetadata, string endpoint, ChannelCredentials credentials, GrpcChannelOptions options) =>
             channelFactory.Value.Invoke(endpoint, credentials, options);
 
         /// <summary>

--- a/Google.Api.Gax.Grpc/GrpcNetClientAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcNetClientAdapter.cs
@@ -24,12 +24,12 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         public static GrpcNetClientAdapter Default { get; } = new GrpcNetClientAdapter();
 
-        private GrpcNetClientAdapter()
+        private GrpcNetClientAdapter() : base(ApiTransports.Grpc)
         {
         }
 
         /// <inheritdoc />
-        protected override ChannelBase CreateChannelImpl(string endpoint, ChannelCredentials credentials, GrpcChannelOptions options)
+        private protected override ChannelBase CreateChannelImpl(ServiceMetadata serviceMetadata, string endpoint, ChannelCredentials credentials, GrpcChannelOptions options)
         {
             var grpcNetClientOptions = ConvertOptions(credentials, options);
             var address = ConvertEndpoint(endpoint);

--- a/Google.Api.Gax.Grpc/ServiceMetadata.cs
+++ b/Google.Api.Gax.Grpc/ServiceMetadata.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Google.Protobuf.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Api.Gax.Grpc
+{
+    /// <summary>
+    /// Provides metadata about a single service within an API.
+    /// Often most of these aspects will be the same across multiple services,
+    /// but they can be specified with different values in the original proto, so
+    /// they are specified individually here. This class is expected to be constructed
+    /// with a single instance per service; equality is by simple identity.
+    /// </summary>
+    public sealed class ServiceMetadata
+    {
+        /// <summary>
+        /// The protobuf service descriptor for this service. This is never null.
+        /// </summary>
+        public ServiceDescriptor ServiceDescriptor { get; }
+
+        /// <summary>
+        /// The name of the service within the API, e.g. "Subscriber". This is never null or empty.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The default endpoint for the service. This may be null, if a service has no default endpoint.
+        /// </summary>
+        public string DefaultEndpoint { get; }
+
+        /// <summary>
+        /// The default scopes for the service. This will never be null, but may be empty.
+        /// This will never contain any null references.
+        /// This will never change after construction.
+        /// </summary>
+        public IReadOnlyList<string> DefaultScopes { get; }
+
+        /// <summary>
+        /// Whether this service supports scoped JWT access (in which case
+        /// this is preferred by default over OAuth tokens).
+        /// </summary>
+        public bool SupportsScopedJwts { get; }
+
+        /// <summary>
+        /// The metadata for the API this is part of. This is never null.
+        /// </summary>
+        public ApiMetadata ApiMetadata { get; }
+
+        /// <summary>
+        /// The transports supported by this service.
+        /// </summary>
+        public ApiTransports Transports { get; }
+
+        /// <summary>
+        /// Constructs a new instance for a given service.
+        /// </summary>
+        /// <param name="serviceDescriptor">The protobuf descriptor for the service.</param>
+        /// <param name="defaultEndpoint">The default endpoint to connect to.</param>
+        /// <param name="defaultScopes">The default scopes for the service. Must not be null, and must not contain any null elements. May be empty.</param>
+        /// <param name="supportsScopedJwts">Whether the service supports scoped JWTs as credentials.</param>
+        /// <param name="transports">The transports supported by this service.</param>
+        /// <param name="apiMetadata">The metadata for this API, including all of the services expected to be available at the same endpoint, and all associated protos.</param>
+        public ServiceMetadata(ServiceDescriptor serviceDescriptor, string defaultEndpoint, IEnumerable<string> defaultScopes, bool supportsScopedJwts, ApiTransports transports, ApiMetadata apiMetadata)
+        {
+            ServiceDescriptor = GaxPreconditions.CheckNotNull(serviceDescriptor, nameof(serviceDescriptor));
+            Name = serviceDescriptor.Name;
+            GaxPreconditions.CheckArgument(Name.Length > 0, nameof(serviceDescriptor), "Service has an empty name");
+            DefaultEndpoint = defaultEndpoint;
+            DefaultScopes = GaxPreconditions.CheckNotNull(defaultScopes, nameof(defaultScopes)).ToList().AsReadOnly();
+            GaxPreconditions.CheckArgument(!DefaultScopes.Any(x => x == null), nameof(defaultScopes), "Scopes must not contain any null references");
+            SupportsScopedJwts = supportsScopedJwts;
+            Transports = transports;
+            ApiMetadata = GaxPreconditions.CheckNotNull(apiMetadata, nameof(apiMetadata));
+        }
+    }
+}

--- a/Google.Api.Gax/ApiTransports.cs
+++ b/Google.Api.Gax/ApiTransports.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax
+{
+    /// <summary>
+    /// The transports that can be used to make calls to an API.
+    /// </summary>
+    [Flags]
+    public enum ApiTransports
+    {
+        /// <summary>
+        /// No transports specified.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Native gRPC support via binary protobuf serialization.
+        /// </summary>
+        Grpc = 1,
+
+        /// <summary>
+        /// "REST"-like support via JSON.
+        /// </summary>
+        Rest = 2
+    }
+}

--- a/generateprotos.sh
+++ b/generateprotos.sh
@@ -93,9 +93,7 @@ rm -rf $OUTDIR
          -I. --plugin=protoc-gen-grpc=$GRPC_PLUGIN *.proto)
 
 (cd Google.Api.Gax.Grpc.Tests;
- $PROTOC --csharp_opt=file_extension=.g.cs --csharp_out=. \
-         --grpc_opt=file_suffix=Grpc.g.cs --grpc_out=. -I. \
-         --plugin=protoc-gen-grpc=$GRPC_PLUGIN *.proto)
+ $PROTOC --csharp_opt=file_extension=.g.cs --csharp_out=. -I. *.proto)
 
 (cd Google.Api.Gax.Grpc.Tests/Rest;
  $PROTOC --csharp_opt=file_extension=.g.cs --csharp_out=. -I. *.proto)


### PR DESCRIPTION
With this in place:

- A single RestGrpcAdapter can be used for multiple APIs (handy for dependency injection)
- Services can "advertise" which transports they support, allowing automatic selection of adapters
- Service metadata is provided to ClientBuilderBase through a constructor, removing the need most abstract methods