### PR TITLE
feat: Add logging for gRPC clients

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ClientHelperTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ClientHelperTest.cs
@@ -21,10 +21,10 @@ namespace Google.Api.Gax.Grpc.Tests
             var helper = new ClientHelper(new DummySettings
             {
                 CallSettings = clientSettings
-            });
+            }, loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerNonStreaming();
             var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(
-                server.MethodAsync, server.MethodSync, null);
+                server.MethodAsync, server.MethodSync, null, "Method");
             apiCall.Sync(null, null);
             Assert.Equal(clientSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -36,9 +36,9 @@ namespace Google.Api.Gax.Grpc.Tests
             var helper = new ClientHelper(new DummySettings
             {
                 CallSettings = clientSettings
-            });
+            }, loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerServerStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, "Method");
             apiCall.Call(null, null);
             Assert.Equal(clientSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -50,9 +50,9 @@ namespace Google.Api.Gax.Grpc.Tests
             var helper = new ClientHelper(new DummySettings
             {
                 CallSettings = clientSettings
-            });
+            }, loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerBidiStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null, "Method");
             apiCall.Call(null);
             Assert.Equal(clientSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -64,9 +64,9 @@ namespace Google.Api.Gax.Grpc.Tests
             var helper = new ClientHelper(new DummySettings
             {
                 CallSettings = clientSettings
-            });
+            }, loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerClientStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null, "Method");
             apiCall.Call(null);
             Assert.Equal(clientSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -75,10 +75,10 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildApiCall_PerMethodSettings()
         {
             var perMethodSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerNonStreaming();
             var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(
-                server.MethodAsync, server.MethodSync, perMethodSettings);
+                server.MethodAsync, server.MethodSync, perMethodSettings, "Method");
             apiCall.Sync(null, null);
             Assert.Equal(perMethodSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -87,9 +87,9 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildServerStreamingApiCall_PerMethodSettings()
         {
             var perMethodSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerServerStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, perMethodSettings);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, perMethodSettings, "Method");
             apiCall.Call(null, null);
             Assert.Equal(perMethodSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -98,10 +98,10 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildBidiStreamingApiCall_PerMethodSettings()
         {
             var perMethodSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerBidiStreaming();
             var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(
-                server.Call, perMethodSettings, null);
+                server.Call, perMethodSettings, null, "Method");
             apiCall.Call(null);
             Assert.Equal(perMethodSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -110,10 +110,10 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildClientStreamingApiCall_PerMethodSettings()
         {
             var perMethodSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerClientStreaming();
             var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(
-                server.Call, perMethodSettings, null);
+                server.Call, perMethodSettings, null, "Method");
             apiCall.Call(null);
             Assert.Equal(perMethodSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -122,10 +122,10 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildApiCall_PerCallSettings()
         {
             var perCallSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerNonStreaming();
             var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(
-                server.MethodAsync, server.MethodSync, null);
+                server.MethodAsync, server.MethodSync, null, "Method");
             apiCall.Sync(null, perCallSettings);
             Assert.Equal(perCallSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -134,9 +134,9 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildServerStreamingApiCall_PerCallSettings()
         {
             var perCallSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerServerStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, "Method");
             apiCall.Call(null, perCallSettings);
             Assert.Equal(perCallSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -145,9 +145,9 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildBidiStreamingApiCall_PerCallSettings()
         {
             var perCallSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerBidiStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null, "Method");
             apiCall.Call(perCallSettings);
             Assert.Equal(perCallSettings.CancellationToken, server.CallOptions.CancellationToken);
         }
@@ -156,9 +156,9 @@ namespace Google.Api.Gax.Grpc.Tests
         public void BuildClientStreamingApiCall_PerCallSettings()
         {
             var perCallSettings = CallSettings.FromCancellationToken(new CancellationTokenSource().Token);
-            var helper = new ClientHelper(new DummySettings());
+            var helper = new ClientHelper(new DummySettings(), loggerFactory: null, baseCategoryName: null);
             var server = new DummyServerClientStreaming();
-            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null);
+            var apiCall = helper.BuildApiCall<SimpleRequest, SimpleResponse>(server.Call, null, null, "Method");
             apiCall.Call(perCallSettings);
             Assert.Equal(perCallSettings.CancellationToken, server.CallOptions.CancellationToken);
         }

--- a/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
+++ b/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Grpc.Core" Version="[2.41.0, 3.0.0)" />
   </ItemGroup>

--- a/Google.Api.Gax.Grpc.Tests/RetryTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/RetryTest.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Threading;
 using Google.Api.Gax.Grpc.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Google.Api.Gax.Grpc.Tests
 {
@@ -43,7 +44,7 @@ namespace Google.Api.Gax.Grpc.Tests
         private Task<SimpleResponse> Call(
             bool async, FakeScheduler scheduler, Server server, SimpleRequest request, CallSettings callSettings)
         {
-            var retryingCallable = server.Callable.WithRetry(scheduler.Clock, scheduler);
+            var retryingCallable = server.Callable.WithRetry(scheduler.Clock, scheduler, NullLogger.Instance);
             return Call(async, retryingCallable, request, callSettings);
         }
 

--- a/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace Google.Api.Gax.Grpc
@@ -71,5 +72,11 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
             new ApiBidirectionalStreamingCall<TRequest, TResponse>(_call, callSettings.MergedWith(BaseCallSettings), StreamingSettings);
+
+        internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithLogging(ILogger logger) =>
+            logger is null
+                ? this
+                : new ApiBidirectionalStreamingCall<TRequest, TResponse>(_call.WithLogging(logger), BaseCallSettings, StreamingSettings);
+
     }
 }

--- a/Google.Api.Gax.Grpc/ApiCallLoggingExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallLoggingExtensions.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc
+{
+    internal static class ApiCallLoggingExtensions
+    {
+        // By design, the code is mostly duplicated between the async and sync calls.
+
+        #region Unary calls
+        // Async call
+        internal static Func<TRequest, CallSettings, Task<TResponse>> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, Task<TResponse>> fn, ILogger logger) =>
+            async (request, callSettings) =>
+            {
+                logger?.LogTrace("Starting asynchronous API call.");
+                var result = await fn(request, callSettings).ConfigureAwait(false);
+                logger?.LogTrace("Call completed.");
+                return result;
+            };
+
+        // Sync call
+        internal static Func<TRequest, CallSettings, TResponse> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, TResponse> fn, ILogger logger) =>
+            (request, callSettings) =>
+            {
+                logger?.LogTrace("Starting synchronous API call.");
+                var result = fn(request, callSettings);
+                logger?.LogTrace("Call completed.");
+                return result;
+            };
+        #endregion
+
+        #region Server streaming
+        // Async call
+        internal static Func<TRequest, CallSettings, Task<AsyncServerStreamingCall<TResponse>>> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, Task<AsyncServerStreamingCall<TResponse>>> fn, ILogger logger) =>
+            async (request, callSettings) =>
+            {
+                logger?.LogTrace("Starting asynchronous API call.");
+                var result = await fn(request, callSettings).ConfigureAwait(false);
+                logger?.LogTrace("Initial call completed.");
+                return result;
+            };
+
+        // Sync call
+        internal static Func<TRequest, CallSettings, AsyncServerStreamingCall<TResponse>> WithLogging<TRequest, TResponse>(
+            this Func<TRequest, CallSettings, AsyncServerStreamingCall<TResponse>> fn, ILogger logger) =>
+            (request, callSettings) =>
+            {
+                logger?.LogTrace("Starting synchronous API call.");
+                var result = fn(request, callSettings);
+                logger?.LogTrace("Initial call completed.");
+                return result;
+            };
+        #endregion
+
+        #region Client streaming
+        internal static Func<CallSettings, AsyncClientStreamingCall<TRequest, TResponse>> WithLogging<TRequest, TResponse>(
+            this Func<CallSettings, AsyncClientStreamingCall<TRequest, TResponse>> fn, ILogger logger) =>
+            callSettings =>
+            {
+                logger?.LogTrace("Starting client streaming API call.");
+                return fn(callSettings);
+            };
+        #endregion
+
+        #region Bidi streaming
+        internal static Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> WithLogging<TRequest, TResponse>(
+            this Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> fn, ILogger logger) =>
+            callSettings =>
+            {
+                logger?.LogTrace("Starting duplex streaming API call.");
+                return fn(callSettings);
+            };
+        #endregion
+    }
+}

--- a/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
@@ -5,7 +5,7 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -18,7 +18,7 @@ namespace Google.Api.Gax.Grpc
         // Async retry
         internal static Func<TRequest, CallSettings, Task<TResponse>> WithRetry<TRequest, TResponse>(
             this Func<TRequest, CallSettings, Task<TResponse>> fn,
-            IClock clock, IScheduler scheduler) =>
+            IClock clock, IScheduler scheduler, ILogger logger) =>
             async (request, callSettings) =>
             {
                 RetrySettings retrySettings = callSettings.Retry;
@@ -40,6 +40,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
+                        logger.LogDebug("Backing off before retry");
                         await attempt.BackoffAsync(callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
                     }
                 }
@@ -49,7 +50,7 @@ namespace Google.Api.Gax.Grpc
         // Sync retry
         internal static Func<TRequest, CallSettings, TResponse> WithRetry<TRequest, TResponse>(
             this Func<TRequest, CallSettings, TResponse> fn,
-            IClock clock, IScheduler scheduler) =>
+            IClock clock, IScheduler scheduler, ILogger logger) =>
             (request, callSettings) =>
             {
                 RetrySettings retrySettings = callSettings.Retry;
@@ -71,6 +72,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
+                        logger.LogDebug("Backing off before retry");
                         attempt.Backoff(callSettings.CancellationToken.GetValueOrDefault());
                     }
                 }

--- a/Google.Api.Gax.Grpc/ApiClientStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiClientStreamingCall.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace Google.Api.Gax.Grpc
@@ -69,5 +70,10 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         internal ApiClientStreamingCall<TRequest, TResponse> WithMergedBaseCallSettings(CallSettings callSettings) =>
             new ApiClientStreamingCall<TRequest, TResponse>(_call, callSettings.MergedWith(BaseCallSettings), StreamingSettings);
+
+        internal ApiClientStreamingCall<TRequest, TResponse> WithLogging(ILogger logger) =>
+            logger is null
+                ? this
+                : new ApiClientStreamingCall<TRequest, TResponse>(_call.WithLogging(logger), BaseCallSettings, StreamingSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
@@ -6,6 +6,7 @@
  */
 
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -128,5 +129,10 @@ namespace Google.Api.Gax.Grpc
                     : null; // CallSettings.Merge handles null correctly.
             });
         }
+
+        internal ApiServerStreamingCall<TRequest, TResponse> WithLogging(ILogger logger) =>
+            logger is null
+                ? this
+                : new ApiServerStreamingCall<TRequest, TResponse>(_asyncCall.WithLogging(logger), _syncCall.WithLogging(logger), BaseCallSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -9,6 +9,7 @@ using Google.Apis.Auth.OAuth2;
 using Grpc.Auth;
 using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,6 +41,11 @@ namespace Google.Api.Gax.Grpc
         /// The endpoint to connect to, or null to use the default endpoint.
         /// </summary>
         public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The logger factory to use to create a logger for the client, if any.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; }
 
         /// <summary>
         /// The scopes to use, or null to use the default scopes.
@@ -160,6 +166,7 @@ namespace Google.Api.Gax.Grpc
             GrpcAdapter = source.GrpcAdapter;
             QuotaProject = source.QuotaProject;
             UseJwtAccessWithScopes = source.UseJwtAccessWithScopes;
+            LoggerFactory = source.LoggerFactory;
 
             // Note that we may be copying from one type that supports emulators (e.g. FirestoreDbBuilder)
             // to another type that doesn't (e.g. FirestoreClientBuilder). That ends up in a slightly odd situation,
@@ -178,6 +185,7 @@ namespace Google.Api.Gax.Grpc
             GaxPreconditions.CheckNotNull(source, nameof(source));
             UserAgent = source.UserAgent;
             GrpcAdapter = source.GrpcAdapter;
+            LoggerFactory = source.LoggerFactory;
         }
 
         /// <summary>
@@ -537,6 +545,7 @@ namespace Google.Api.Gax.Grpc
         {
             GaxPreconditions.CheckNotNull(provider, nameof(provider));
 
+            LoggerFactory ??= provider.GetService<ILoggerFactory>();
             CallInvoker ??= provider.GetService<CallInvoker>();
             if (CallInvoker is object)
             {

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -7,6 +7,7 @@
 
 using Google.Protobuf;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace Google.Api.Gax.Grpc
@@ -18,15 +19,21 @@ namespace Google.Api.Gax.Grpc
     {
         private readonly CallSettings _clientCallSettings;
         private readonly CallSettings _versionCallSettings;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly string _baseCategoryName;
 
         /// <summary>
         /// Constructs a helper from the given settings.
         /// Behavior is undefined if settings are changed after construction.
         /// </summary>
         /// <param name="settings">The service settings.</param>
-        public ClientHelper(ServiceSettingsBase settings)
+        /// <param name="loggerFactory">The logger factory to use for API calls</param>
+        /// <param name="baseCategoryName">The base name of the category (typically the name of the client class)</param>
+        public ClientHelper(ServiceSettingsBase settings, ILoggerFactory loggerFactory, string baseCategoryName)
         {
             GaxPreconditions.CheckNotNull(settings, nameof(settings));
+            _loggerFactory = loggerFactory;
+            _baseCategoryName = baseCategoryName;
             Clock = settings.Clock ?? SystemClock.Instance;
             Scheduler = settings.Scheduler ?? SystemScheduler.Instance;
             _clientCallSettings = settings.CallSettings;
@@ -55,19 +62,23 @@ namespace Google.Api.Gax.Grpc
         /// <param name="asyncGrpcCall">The underlying synchronous gRPC call.</param>
         /// <param name="syncGrpcCall">The underlying asynchronous gRPC call.</param>
         /// <param name="perMethodCallSettings">The default method call settings.</param>
+        /// <param name="methodName">The method name, used to construct a logger category.</param>
         /// <returns>An API call to proxy to the RPC calls</returns>
         public ApiCall<TRequest, TResponse> BuildApiCall<TRequest, TResponse>(
             Func<TRequest, CallOptions, AsyncUnaryCall<TResponse>> asyncGrpcCall,
             Func<TRequest, CallOptions, TResponse> syncGrpcCall,
-            CallSettings perMethodCallSettings)
+            CallSettings perMethodCallSettings,
+            string methodName)
             where TRequest : class, IMessage<TRequest>
             where TResponse : class, IMessage<TResponse>
         {
+            var logger = _loggerFactory?.CreateLogger($"{_baseCategoryName}.{methodName}");
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             // These operations are applied in reverse order.
             // I.e. Version header is added first, then retry is performed.
             return ApiCall.Create(asyncGrpcCall, syncGrpcCall, baseCallSettings, Clock)
-                .WithRetry(Clock, Scheduler)
+                .WithLogging(logger)
+                .WithRetry(Clock, Scheduler, logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -78,17 +89,20 @@ namespace Google.Api.Gax.Grpc
         /// <typeparam name="TResponse">Response type, which must be a protobuf message.</typeparam>
         /// <param name="grpcCall">The underlying gRPC server streaming call.</param>
         /// <param name="perMethodCallSettings">The default method call settings.</param>
+        /// <param name="methodName">The method name, used to construct a logger category.</param>
         /// <returns>An API call to proxy to the RPC calls</returns>
         public ApiServerStreamingCall<TRequest, TResponse> BuildApiCall<TRequest, TResponse>(
             Func<TRequest, CallOptions, AsyncServerStreamingCall<TResponse>> grpcCall,
-            CallSettings perMethodCallSettings)
+            CallSettings perMethodCallSettings, string methodName)
             where TRequest : class, IMessage<TRequest>
             where TResponse : class, IMessage<TResponse>
         {
+            var logger = _loggerFactory?.CreateLogger($"{_baseCategoryName}.{methodName}");
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             // These operations are applied in reverse order.
             // I.e. Version header is added first, then retry is performed.
             return ApiServerStreamingCall.Create(grpcCall, baseCallSettings, Clock)
+                .WithLogging(logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -100,16 +114,20 @@ namespace Google.Api.Gax.Grpc
         /// <param name="grpcCall">The underlying gRPC duplex streaming call.</param>
         /// <param name="perMethodCallSettings">The default method call settings.</param>
         /// <param name="streamingSettings">The default streaming settings.</param>
+        /// <param name="methodName">The method name, used to construct a logger category.</param>
         /// <returns>An API call to proxy to the RPC calls</returns>
         public ApiBidirectionalStreamingCall<TRequest, TResponse> BuildApiCall<TRequest, TResponse>(
             Func<CallOptions, AsyncDuplexStreamingCall<TRequest, TResponse>> grpcCall,
             CallSettings perMethodCallSettings,
-            BidirectionalStreamingSettings streamingSettings)
+            BidirectionalStreamingSettings streamingSettings,
+            string methodName)
             where TRequest : class, IMessage<TRequest>
             where TResponse : class, IMessage<TResponse>
         {
+            var logger = _loggerFactory?.CreateLogger($"{_baseCategoryName}.{methodName}");
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiBidirectionalStreamingCall.Create(grpcCall, baseCallSettings, streamingSettings, Clock)
+                .WithLogging(logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -121,16 +139,20 @@ namespace Google.Api.Gax.Grpc
         /// <param name="grpcCall">The underlying gRPC client streaming call.</param>
         /// <param name="perMethodCallSettings">The default method call settings.</param>
         /// <param name="streamingSettings">The default streaming settings.</param>
+        /// <param name="methodName">The method name, used to construct a logger category.</param>
         /// <returns>An API call to proxy to the RPC calls</returns>
         public ApiClientStreamingCall<TRequest, TResponse> BuildApiCall<TRequest, TResponse>(
             Func<CallOptions, AsyncClientStreamingCall<TRequest, TResponse>> grpcCall,
             CallSettings perMethodCallSettings,
-            ClientStreamingSettings streamingSettings)
+            ClientStreamingSettings streamingSettings,
+            string methodName)
             where TRequest : class, IMessage<TRequest>
             where TResponse : class, IMessage<TResponse>
         {
+            var logger = _loggerFactory?.CreateLogger($"{_baseCategoryName}.{methodName}");
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiClientStreamingCall.Create(grpcCall, baseCallSettings, streamingSettings, Clock)
+                .WithLogging(logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
     }


### PR DESCRIPTION
We might well want to add some more logging into the streaming calls
in the future.

If we go ahead with this, we'll need to make corresponding generator
changes - they're likely to be relatively straightforward, but
affect a lot of generated test code.

At the moment there's no testing for logging actually being
performed. To do that, we really want an in-memory logger like the
one from the Functions Framework - I could copy that code,
potentially.