### PR TITLE
Changes and fixes for GAX 4.0.0-alpha03

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/ClientBuilderBaseTest.cs
@@ -352,7 +352,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
                 ChannelCreated = null;
             }
 
-            private protected override ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials)
+            protected override ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials)
             {
                 CredentialsUsedToCreateChannel = credentials;
                 EndpointUsedToCreateChannel = endpoint;

--- a/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallRetryExtensions.cs
@@ -40,7 +40,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
-                        logger.LogDebug("Backing off before retry of method {method}", methodName);
+                        logger?.LogDebug("Backing off before retry of method {method}", methodName);
                         await attempt.BackoffAsync(callSettings.CancellationToken.GetValueOrDefault()).ConfigureAwait(false);
                     }
                 }
@@ -72,7 +72,7 @@ namespace Google.Api.Gax.Grpc
                     }
                     catch (Exception e) when (attempt.ShouldRetry(e))
                     {
-                        logger.LogDebug("Backing off before retry of method {method}", methodName);
+                        logger?.LogDebug("Backing off before retry of method {method}", methodName);
                         attempt.Backoff(callSettings.CancellationToken.GetValueOrDefault());
                     }
                 }

--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -462,7 +462,12 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         protected abstract ChannelPool GetChannelPool();
 
-        private GrpcAdapter EffectiveGrpcAdapter => GrpcAdapter ?? GrpcAdapter.GetFallbackAdapter(ServiceMetadata);
+        /// <summary>
+        /// Returns the effective <see cref="GrpcAdapter"/> for this builder,
+        /// using the <see cref="GrpcAdapter"/> property if that is set, or the appropriate fallback adapter
+        /// for <see cref="ServiceMetadata"/> otherwise.
+        /// </summary>
+        protected GrpcAdapter EffectiveGrpcAdapter => GrpcAdapter ?? GrpcAdapter.GetFallbackAdapter(ServiceMetadata);
 
         /// <summary>
         /// Returns the options to use when creating a channel, taking <see cref="GrpcChannelOptions"/>

--- a/Google.Api.Gax.Grpc/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Grpc/ClientBuilderBase.cs
@@ -612,7 +612,19 @@ namespace Google.Api.Gax.Grpc
             return await BuildAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private protected virtual ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials) =>
+        /// <summary>
+        /// Returns a <see cref="ChannelBase"/> as created by <see cref="EffectiveGrpcAdapter"/>
+        /// for the specified endpoint and credentials, using the gRPC channel options from
+        /// <see cref="GetChannelOptions"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is only useful in very specific situations where a known channel is required;
+        /// <see cref="CreateCallInvoker"/> and its async equivalent are more usually useful.
+        /// </remarks>
+        /// <param name="endpoint">The endpoint of the channel.</param>
+        /// <param name="credentials">The channel credentials.</param>
+        /// <returns>The channel created by the gRPC adapter.</returns>
+        protected virtual ChannelBase CreateChannel(string endpoint, ChannelCredentials credentials) =>
             EffectiveGrpcAdapter.CreateChannel(ServiceMetadata, endpoint, credentials, GetChannelOptions());
 
         private class DelegatedTokenAccess : ITokenAccessWithHeaders

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -19,7 +19,6 @@ namespace Google.Api.Gax.Grpc
     {
         private readonly CallSettings _clientCallSettings;
         private readonly CallSettings _versionCallSettings;
-        private readonly ILogger _logger;
 
         /// <summary>
         /// Constructs a helper from the given settings.
@@ -30,7 +29,7 @@ namespace Google.Api.Gax.Grpc
         public ClientHelper(ServiceSettingsBase settings, ILogger logger)
         {
             GaxPreconditions.CheckNotNull(settings, nameof(settings));
-            _logger = logger;
+            Logger = logger;
             Clock = settings.Clock ?? SystemClock.Instance;
             Scheduler = settings.Scheduler ?? SystemScheduler.Instance;
             _clientCallSettings = settings.CallSettings;
@@ -50,6 +49,11 @@ namespace Google.Api.Gax.Grpc
         /// will return the <see cref="SystemScheduler"/> instance.
         /// </summary>
         public IScheduler Scheduler { get; }
+
+        /// <summary>
+        /// The logger used by this instance, or null if it does not perform logging.
+        /// </summary>
+        public ILogger Logger { get; }
 
         /// <summary>
         /// Builds an <see cref="ApiCall"/> given suitable underlying async and sync calls.
@@ -73,8 +77,8 @@ namespace Google.Api.Gax.Grpc
             // These operations are applied in reverse order.
             // I.e. Version header is added first, then retry is performed.
             return ApiCall.Create(methodName, asyncGrpcCall, syncGrpcCall, baseCallSettings, Clock)
-                .WithLogging(_logger)
-                .WithRetry(Clock, Scheduler, _logger)
+                .WithLogging(Logger)
+                .WithRetry(Clock, Scheduler, Logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -97,7 +101,7 @@ namespace Google.Api.Gax.Grpc
             // These operations are applied in reverse order.
             // I.e. Version header is added first, then retry is performed.
             return ApiServerStreamingCall.Create(methodName, grpcCall, baseCallSettings, Clock)
-                .WithLogging(_logger)
+                .WithLogging(Logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -121,7 +125,7 @@ namespace Google.Api.Gax.Grpc
         {
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiBidirectionalStreamingCall.Create(methodName, grpcCall, baseCallSettings, streamingSettings, Clock)
-                .WithLogging(_logger)
+                .WithLogging(Logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -145,7 +149,7 @@ namespace Google.Api.Gax.Grpc
         {
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiClientStreamingCall.Create(methodName, grpcCall, baseCallSettings, streamingSettings, Clock)
-                .WithLogging(_logger)
+                .WithLogging(Logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
     }

--- a/Google.Api.Gax.Grpc/Gcp/GcpCallInvoker.cs
+++ b/Google.Api.Gax.Grpc/Gcp/GcpCallInvoker.cs
@@ -20,7 +20,7 @@ namespace Google.Api.Gax.Grpc.Gcp
     /// Call invoker which can fan calls out to multiple underlying channels
     /// based on request properties.
     /// </summary>
-    internal sealed class GcpCallInvoker : CallInvoker
+    public sealed class GcpCallInvoker : CallInvoker
     {
         private static int s_clientChannelIdCounter;
 
@@ -41,7 +41,7 @@ namespace Google.Api.Gax.Grpc.Gcp
         private readonly ServiceMetadata _serviceMetadata;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Grpc.Gcp.GcpCallInvoker"/> class.
+        /// Initializes a new instance.
         /// </summary>
         /// <param name="serviceMetadata">The metadata for the service that this call invoker will be used with. Must not be null.</param>
         /// <param name="target">Target of the underlying grpc channels. Must not be null.</param>
@@ -49,7 +49,7 @@ namespace Google.Api.Gax.Grpc.Gcp
         /// <param name="options">Channel options to be used by the underlying grpc channels. Must not be null.</param>
         /// <param name="apiConfig">The API config to apply. Must not be null.</param>
         /// <param name="adapter">The adapter to use to create channels. Must not be null.</param>
-        internal GcpCallInvoker(ServiceMetadata serviceMetadata, string target, ChannelCredentials credentials, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
+        public GcpCallInvoker(ServiceMetadata serviceMetadata, string target, ChannelCredentials credentials, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
         {
             _serviceMetadata = GaxPreconditions.CheckNotNull(serviceMetadata, nameof(serviceMetadata));
             _target = GaxPreconditions.CheckNotNull(target, nameof(target));

--- a/Google.Api.Gax.Grpc/Gcp/GcpCallInvokerPool.cs
+++ b/Google.Api.Gax.Grpc/Gcp/GcpCallInvokerPool.cs
@@ -67,7 +67,7 @@ namespace Google.Api.Gax.Grpc.Gcp
         /// <param name="apiConfig">The API configuration used to determine channel keys. Must not be null.</param>
         /// <param name="adapter">The gRPC adapter to use to create call invokers. Must not be null.</param>
         /// <returns>A call invoker for the specified endpoint.</returns>
-        public CallInvoker GetCallInvoker(string endpoint, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
+        public GcpCallInvoker GetCallInvoker(string endpoint, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
         {
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
             var credentials = _credentialsCache.GetCredentials();
@@ -86,7 +86,7 @@ namespace Google.Api.Gax.Grpc.Gcp
         /// <param name="adapter">The gRPC adapter to use to create call invokers. Must not be null.</param>
         /// <returns>A task representing the asynchronous operation. The value of the completed
         /// task will be a call invoker for the specified endpoint.</returns>
-        public async Task<CallInvoker> GetCallInvokerAsync(string endpoint, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
+        public async Task<GcpCallInvoker> GetCallInvokerAsync(string endpoint, GrpcChannelOptions options, ApiConfig apiConfig, GrpcAdapter adapter)
         {
             GaxPreconditions.CheckNotNull(endpoint, nameof(endpoint));
             GaxPreconditions.CheckNotNull(apiConfig, nameof(apiConfig));

--- a/Google.Api.Gax.Grpc/GrpcAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcAdapter.cs
@@ -38,9 +38,8 @@ namespace Google.Api.Gax.Grpc
             _supportedTransports = supportedTransports;
         }
 
-        // TODO: potentially expose either or both of the methods below if we want, or a
-        // "get the first adapter that supports this service, from the following list, or a fallback"
-        // method.
+        // TODO: potentially expose this if we want, or a "get the first adapter that supports
+        // this service, from the following list, or a fallback" method.
 
         /// <summary>
         /// Returns whether or not this adapter supports the specified service.
@@ -58,7 +57,7 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         /// <param name="serviceMetadata">The descriptor of the API. Must not be null.</param>
         /// <returns>A suitable GrpcAdapter for the given API, preferring the use of the binary gRPC transport where available.</returns>
-        internal static GrpcAdapter GetFallbackAdapter(ServiceMetadata serviceMetadata) =>
+        public static GrpcAdapter GetFallbackAdapter(ServiceMetadata serviceMetadata) =>
             // TODO: Do we need some way of indicating a preference, if the service supports both Rest and Grpc?
             // Probably not: the user code can always specify the adapter in the builder
             serviceMetadata.Transports.HasFlag(ApiTransports.Grpc) ? s_defaultGrpcTransportFactory.Value

--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>4.0.0-alpha02</Version>
+    <Version>4.0.0-alpha03</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This will release GAX 4.0.0-alpha03, at which point another PR in google-cloud-dotnet should get the gax-v4 branch ready to run full unit and integration tests on CI.

(I'm waiting for PubSub tests to complete before creating that PR.)