### PR TITLE
fix: Handle unexpected REST responses

### DIFF
--- a/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
+++ b/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
@@ -108,7 +108,12 @@ namespace Google.Api.Gax.Grpc.Rest
                 }
                 var status = new Rpc.Status
                 {
-                    Code = (int) error.Status_,
+                    // Sometimes the status field in the JSON isn't populated; fall back to the
+                    // translation of the HTTP response code. (We could potentially use error.Code,
+                    // but that should always be the same as the status code of the HTTP response
+                    // anyway, and this way we don't have to do things conditionally on whether error.Code
+                    // is populated or not.)
+                    Code = error.Status_ == Rpc.Code.Ok ? (int) grpcStatusCode : (int) error.Status_,
                     Message = error.Message,
                     Details = { error.Details }
                 };


### PR DESCRIPTION
If the response is valid JSON but doesn't contain a gRPC status code, we should use the translation of the HTTP status code.