### PR TITLE
Release Google.Api.Gax version 4.0.0-alpha05

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>4.0.0-alpha04</Version>
+    <Version>4.0.0-alpha05</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is *not* intended for public use; it's for the .NET client
libraries team to consume while working on the client libraries
themselves and the generator.