### PR TITLE
feat: Improve consistency of AddGrpcNetClientAdapter methods

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/GaxGrpcServiceCollectionExtensionsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/GaxGrpcServiceCollectionExtensionsTest.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using Xunit;
+
+namespace Google.Api.Gax.Grpc.Tests;
+
+// Although we can create the adapter on .NET Framework, we can't really test the option propagation.
+#if NETCOREAPP3_1_OR_GREATER
+public class GaxGrpcServiceCollectionExtensionsTest
+{
+    [Fact]
+    public void AddGrpcNetClientAdapter_NullAction()
+    {
+        var loggerProvider = new MemoryLoggerProvider();
+        var serviceProvider = new ServiceCollection()
+            .AddLogging(builder => builder.AddProvider(loggerProvider).SetMinimumLevel(LogLevel.Debug))
+            .AddGrpcNetClientAdapter(null)
+            .BuildServiceProvider();
+        CreateAdapterAndChannelThenAssertLog(serviceProvider, loggerProvider);
+    }
+
+    [Fact]
+    public void AddGrpcNetClientAdapter_WithAction()
+    {
+        var loggerProvider = new MemoryLoggerProvider();
+        bool actionCalled = false;
+        var serviceProvider = new ServiceCollection()
+            .AddLogging(builder => builder.AddProvider(loggerProvider).SetMinimumLevel(LogLevel.Debug))
+            .AddGrpcNetClientAdapter((provider, options) => actionCalled = true)
+            .BuildServiceProvider();
+
+        Assert.False(actionCalled);
+        CreateAdapterAndChannelThenAssertLog(serviceProvider, loggerProvider);
+        Assert.True(actionCalled);
+    }
+
+    [Fact]
+    public void AddGrpcNetClientAdapter_NoAction()
+    {
+        var loggerProvider = new MemoryLoggerProvider();
+        var serviceProvider = new ServiceCollection()
+            .AddLogging(builder => builder.AddProvider(loggerProvider).SetMinimumLevel(LogLevel.Debug))
+            .AddGrpcNetClientAdapter()
+            .BuildServiceProvider();
+        CreateAdapterAndChannelThenAssertLog(serviceProvider, loggerProvider);
+    }
+
+    private void CreateAdapterAndChannelThenAssertLog(IServiceProvider serviceProvider, MemoryLoggerProvider loggerProvider)
+    {
+        // A URI with a path in triggers a diagnostic log entry when constructing a channel.
+        string testUri = "http://ignored.com/withpath";
+
+        var adapter = serviceProvider.GetRequiredService<GrpcAdapter>();
+        Assert.IsType<GrpcNetClientAdapter>(adapter);
+
+        adapter.CreateChannel(TestServiceMetadata.TestService, testUri, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
+        var logEntries = loggerProvider.GetLogEntries("Grpc.Net.Client.GrpcChannel");
+        var logEntry = Assert.Single(logEntries);
+        Assert.Contains(testUri, logEntry.Message);
+    }
+}
+#endif

--- a/Google.Api.Gax.Grpc/GrpcNetClientAdapter.cs
+++ b/Google.Api.Gax.Grpc/GrpcNetClientAdapter.cs
@@ -7,7 +7,6 @@
 
 using Grpc.Core;
 using Grpc.Net.Client;
-using Microsoft.Extensions.Logging;
 using System;
 
 namespace Google.Api.Gax.Grpc
@@ -37,8 +36,9 @@ namespace Google.Api.Gax.Grpc
         /// The options configurer is called after creating the <see cref="global::Grpc.Net.Client.GrpcChannelOptions"/> from
         /// other settings, but before creating the <see cref="GrpcChannel"/>.
         /// </summary>
-        /// <param name="configure">A configuration delegate to apply to instances of <see cref="global::Grpc.Net.Client.GrpcChannelOptions"/>
-        /// before they are provided to a <see cref="GrpcChannel"/>, after any configuration applied by this adapter.
+        /// <param name="configure">An optional configuration delegate to apply to instances of <see cref="global::Grpc.Net.Client.GrpcChannelOptions"/>
+        /// before they are provided to a <see cref="GrpcChannel"/>, after any configuration applied by this adapter. May be null,
+        /// in which case a new instance is returned but with the same option configurer as this one.
         /// </param>
         /// <returns>A new adapter based on this one, but with an additional channel options configuration action.</returns>
         public GrpcNetClientAdapter WithAdditionalOptions(Action<global::Grpc.Net.Client.GrpcChannelOptions> configure) =>


### PR DESCRIPTION
While there was reason for the inconsistency, it would still have
provided an odd user experience when going from one overload to
another.