### PR TITLE
Release Google.Api.Gax version 4.0.0

### DIFF
--- a/ReleaseVersion.xml
+++ b/ReleaseVersion.xml
@@ -5,6 +5,6 @@
     - divergent versions, but for the moment this keeps things simpler.
     -->
   <PropertyGroup>
-    <Version>4.0.0-alpha05</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As a new major version, GAX v4 contains several breaking changes -
but we do not expect these to affect many users, as they are
typically used by the generated API-specific client libraries.

Most significant changes since 3.7.0:

GAX now targets netstandard2.1 and net462. (Changed from
netstandard2.0 and net461.) Older versions of .NET Core and .NET
Framework are no longer supported by Microsoft.

The default GrpcAdapter implementation is now GrpcNetClientAdapter.
Both GrpcNetClientAdapter and GrpcCoreAdapter are now part of
Google.Api.Gax.Grpc (so the other adapter packages will not be
updated to v4). Grpc.Net.Client is now a dependency of
Google.Api.Gax.Grpc, and GrpcNetClientAdapter is effectively the
default adapter, with a fallback to GrpcCoreAdapter for environments
where GrpcNetClient adapter does not work (such as on most .NET
Framework environments). There is no dependency on Grpc.Core;
GrpcCoreAdapter accesses the classes it needs via reflection. API
client libraries will ship with a conditional dependency on
Grpc.Core, only on .NET Framework. Over time, we expect usage of
Grpc.Core to fall to a level where we can remove support in a new
major version of GAX.

GrpcAdapter itself is more of a black box now, with just a single
public member - the static `GetFallbackAdapter(ServiceMetadata)`
method. This allows for more flexibility to evolve the adapter API
internally over time.

The new `ServiceMetadata` and `ApiMetadata` classes are used to
allow more metadata about an API to be generated, then used by GAX
intelligently, for example to pick the RestGrpcAdapter where
necessary.

Extension methods have been introduced to add GrpcAdapter
implementations into MS-based dependency injection. Doing this with
GrpcNetClientAdapter allows Grpc.Net.Client to use the same
service provider, propagating logging, HttpClientFactories etc.

Client builders now support MS-based dependency injection, usually
via a generated extension method. Where a client is configured using
dependency injection, the credentials, logger and gRPC adapter can
all be obtained from the DI container.

Additionally, gRPC client builders support a new GoogleCredential
property which uses the default scopes, self-signed JWTs and any
configured quota project.

gRPC client builders also expose any channels created in the course
of creating a client, enabling callers to dispose of those channels
appropriately. While the area of resource cleanup is still not where
we want it to be, this is a step in the right direction.

The gRPC call layer of GAX now supports logging, which will enable
a simpler diagnostic process when investigating problems.

GAX no longer has a dependency on the Grpc.Gcp NuGet package, but
includes a refactored version of the same functionality within
Google.Api.Gax.Grpc; this means the Google.Api.Gax.Grpc.Gcp package
will not be updated to v4.