### PR TITLE
fix: Allow slashes in single-star wildcard fields (gRPC transcoding)

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -18,18 +18,18 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             { "x/y:custom", new RuleTestRequest(), "x/y:custom" },
             { "firstPart/{x}/secondPart/{y}", new RuleTestRequest { X = "x1", Y = "y2" }, "firstPart/x1/secondPart/y2" },
             { "combined/{x}-{y}/end", new RuleTestRequest { X = "xx", Y = "yy" }, "combined/xx-yy/end" },
+            { "pattern/{x}", new RuleTestRequest { X = "abc/def" }, "pattern/abc%2Fdef" },
+            { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def/ghi" }, "pattern/abc/def%2Fghi" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def" }, "pattern/abc/def" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/New York" }, "pattern/abc/New%20York" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/caf\u00e9" }, "pattern/abc/caf%C3%A9" },
             { "pattern/{x=abc/**}", new RuleTestRequest { X = "abc/def/ghi" }, "pattern/abc/def/ghi" },
+            { "pattern/{x=abc/*/ghi}", new RuleTestRequest { X = "abc/def/ghi" }, "pattern/abc/def/ghi" },
             { "pattern/{x=**}", new RuleTestRequest { X = "abc/New York" }, "pattern/abc/New%20York" },
             { "nested/{nested.a}", new RuleTestRequest { Nested = new RuleTestRequest.Types.Nested { A = "aaa" } }, "nested/aaa" },
             { "before/{int}/end", new RuleTestRequest { Int = 5 }, "before/5/end" },
             // The nested field isn't present, so this doesn't match.
             { "nested/{nested.a}/end", new RuleTestRequest(), null },
-            // Single star fields don't match slashes
-            { "pattern/{x}", new RuleTestRequest { X = "abc/def" }, null },
-            { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def/ghi" }, null },
         });
 
         private static TheoryData<string, string, string> ConvertTheoryData(TheoryData<string, RuleTestRequest, string> theoryData)

--- a/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
+++ b/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
@@ -64,7 +64,7 @@
     },
 
     {
-      "name": "SimpleNonMatchingRequest_SlashInSingleStarPatternField",
+      "name": "SimpleMatchingRequest_SlashInSingleStarPatternField",
       "details": "A rule expecting a match for the name field",
       "inlineRule": {
         "get": "/collections/{name=*}"
@@ -73,11 +73,14 @@
       "request": {
         "name": "abc/def"
       },
-      "nonmatchingRequest": "Name field contains a slash, for pattern of {name=*}"
+      "success": {
+        "method": "GET",
+        "uri": "/collections/abc%2Fdef"
+      }
     },
 
     {
-      "name": "SimpleNonMatchingRequest_SlashInImplicitSingleStarPatternField",
+      "name": "SimpleMatchingRequest_SlashInImplicitSingleStarPatternField",
       "details": "A rule which matches the name field, which contains a slash",
       "inlineRule": {
         "get": "/collections/{name}"
@@ -86,7 +89,10 @@
       "request": {
         "name": "abc/def"
       },
-      "nonmatchingRequest": "Name field contains a slash, for pattern of {name}"
+      "success": {
+        "method": "GET",
+        "uri": "/collections/abc%2Fdef"
+      }      
     },
 
     {

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -126,8 +126,8 @@ internal sealed class HttpRulePathPattern
         internal string JsonFieldPath { get; }
 
         private readonly Regex _validationRegex;
+        private readonly Func<Match, string> _formatter;
         private readonly Func<IMessage, string> _propertyAccessor;
-        private readonly bool _multiSegmentEscaping;
 
         /// <summary>
         /// Creates a segment representing the given field text, with respect to
@@ -144,8 +144,7 @@ internal sealed class HttpRulePathPattern
             string[] bits = fieldText.Split(s_fieldPathPatternSeparator, 2);
             string fieldPath = bits[0];
             string pattern = bits.Length == 2 ? bits[1] : "*";
-            _multiSegmentEscaping = pattern.Contains("/") || pattern.Contains("**");
-            _validationRegex = ParsePattern(pattern);
+            (_validationRegex, _formatter) = ParsePattern(pattern);
 
             string[] fieldNames = fieldPath.Split(s_fieldPathSeparator);
 
@@ -218,31 +217,48 @@ internal sealed class HttpRulePathPattern
                 return field;
             }
 
-            static Regex ParsePattern(string pattern)
+            static (Regex, Func<Match, string>) ParsePattern(string pattern)
             {
                 var builder = new StringBuilder("^"); // We want to match the whole string
+                Action<Match, StringBuilder> formatBuilder = null;
                 int currentIndex = 0;
+                int groupIndex = 1;
                 while (currentIndex < pattern.Length)
                 {
                     int starStart = pattern.IndexOf('*', currentIndex);
+                    // Handle the literal between the previous star (if any) and the start of the next one.
+                    // If starStart==-1, this is any trailing literal at the end of the pattern.
+                    string literal = pattern.Substring(currentIndex, (starStart == -1 ? pattern.Length : starStart) - currentIndex);
+                    if (literal != "")
+                    {
+                        builder.Append(Regex.Escape(literal));
+                        formatBuilder += (match, sb) => sb.Append(literal);
+                    }
                     if (starStart < 0)
                     {
                         break;
                     }
-                    builder.Append(Regex.Escape(pattern.Substring(currentIndex, starStart - currentIndex)));
+
                     int starEnd = starStart + 1;
                     while (starEnd < pattern.Length && pattern[starEnd] == '*')
                     {
                         starEnd++;
                     }
                     int starCount = starEnd - starStart;
+                    // Deliberately local to have a different variable per iteration, as it's captured in the lambda expression.
+                    int matchGroupIndex = groupIndex;
+                    groupIndex++;
+                    // We match any characters within the regex, regardless of number of stars. It just affects
+                    // how the value is escaped. This uses a reluctant matcher, which means x/*/** (which is more likely
+                    // than x/**/*) will match x/a/b/c as "*=a" and then "**=b/c" which is probably the best result.
+                    builder.Append("(.+?)");
                     switch (starCount)
                     {
                         case 1:
-                            builder.Append("[^/]+");
+                            formatBuilder += (match, sb) => sb.Append(Uri.EscapeDataString(match.Groups[matchGroupIndex].Value));
                             break;
                         case 2:
-                            builder.Append(".+");
+                            formatBuilder += (match, sb) => sb.Append(string.Join("/", match.Groups[matchGroupIndex].Value.Split('/').Select(segment => Uri.EscapeDataString(segment))));
                             break;
                         default:
                             throw new ArgumentException($"Resource pattern '{pattern}' is invalid");
@@ -250,21 +266,29 @@ internal sealed class HttpRulePathPattern
                     currentIndex = starEnd;
                 }
                 builder.Append("$"); // We want to match the whole string
-                return new Regex(builder.ToString(), RegexOptions.Compiled);
+                Func<Match, string> formatter = match =>
+                {
+                    var sb = new StringBuilder("");
+                    formatBuilder(match, sb);
+                    return sb.ToString();
+                };
+                return (new Regex(builder.ToString(), RegexOptions.Compiled), formatter);
             }
         }
 
         public string TryFormat(IMessage request)
         {
             string result = _propertyAccessor(request);
-            if (result is null || _validationRegex?.IsMatch(result) == false)
+            if (result is null)
             {
                 return null;
             }
-            string escaped = _multiSegmentEscaping
-                ? string.Join("/", result.Split('/').Select(segment => Uri.EscapeDataString(segment)))
-                : Uri.EscapeDataString(result);
-            return escaped;
+            Match match = _validationRegex.Match(result);
+            if (!match.Success)
+            {
+                return null;
+            }
+            return _formatter(match);
         }
     }
 


### PR DESCRIPTION
I'm still trying to get more clarification about this, but it seems to me that both `*` and `**` should be allowed to match all characters; the difference is that "*" should only end up with a single URL segment after encoding, so it changes how we format the result.

As both `*` and `**` can be included in a single pattern, this commit also changes how escaping is controlled. Each group within the final regex is now escaped separately, either escaping slashes or not based on whether the wildcard was `*` or `**`.

Additionally, this change handles patterns with trailing literals (e.g. `abc/*/def`).