### PR TITLE
fix: Fix gRPC transcoding of single-star path templates

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -18,8 +18,6 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             { "x/y:custom", new RuleTestRequest(), "x/y:custom" },
             { "firstPart/{x}/secondPart/{y}", new RuleTestRequest { X = "x1", Y = "y2" }, "firstPart/x1/secondPart/y2" },
             { "combined/{x}-{y}/end", new RuleTestRequest { X = "xx", Y = "yy" }, "combined/xx-yy/end" },
-            { "pattern/{x}", new RuleTestRequest { X = "abc/def" }, "pattern/abc%2Fdef" },
-            { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def/ghi" }, "pattern/abc/def%2Fghi" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def" }, "pattern/abc/def" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/New York" }, "pattern/abc/New%20York" },
             { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/caf\u00e9" }, "pattern/abc/caf%C3%A9" },
@@ -30,6 +28,9 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             { "before/{int}/end", new RuleTestRequest { Int = 5 }, "before/5/end" },
             // The nested field isn't present, so this doesn't match.
             { "nested/{nested.a}/end", new RuleTestRequest(), null },
+            // Single star fields don't match slashes
+            { "pattern/{x}", new RuleTestRequest { X = "abc/def" }, null },
+            { "pattern/{x=abc/*}", new RuleTestRequest { X = "abc/def/ghi" }, null },
         });
 
         private static TheoryData<string, string, string> ConvertTheoryData(TheoryData<string, RuleTestRequest, string> theoryData)

--- a/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
+++ b/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
@@ -64,7 +64,7 @@
     },
 
     {
-      "name": "SimpleMatchingRequest_SlashInSingleStarPatternField",
+      "name": "SimpleNonMatchingRequest_SlashInSingleStarPatternField",
       "details": "A rule expecting a match for the name field",
       "inlineRule": {
         "get": "/collections/{name=*}"
@@ -73,14 +73,11 @@
       "request": {
         "name": "abc/def"
       },
-      "success": {
-        "method": "GET",
-        "uri": "/collections/abc%2Fdef"
-      }
+      "nonmatchingRequest": "Name field contains a slash, for pattern of {name=*}"
     },
 
     {
-      "name": "SimpleMatchingRequest_SlashInImplicitSingleStarPatternField",
+      "name": "SimpleNonMatchingRequest_SlashInImplicitSingleStarPatternField",
       "details": "A rule which matches the name field, which contains a slash",
       "inlineRule": {
         "get": "/collections/{name}"
@@ -89,10 +86,7 @@
       "request": {
         "name": "abc/def"
       },
-      "success": {
-        "method": "GET",
-        "uri": "/collections/abc%2Fdef"
-      }
+      "nonmatchingRequest": "Name field contains a slash, for pattern of {name=*}"
     },
 
     {

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -240,16 +240,15 @@ internal sealed class HttpRulePathPattern
                     // Deliberately local to have a different variable per iteration, as it's captured in the lambda expression.
                     int matchGroupIndex = groupIndex;
                     groupIndex++;
-                    // We match any characters within the regex, regardless of number of stars. It just affects
-                    // how the value is escaped. This uses a reluctant matcher, which means x/*/** (which is more likely
-                    // than x/**/*) will match x/a/b/c as "*=a" and then "**=b/c" which is probably the best result.
-                    builder.Append("(.+?)");
                     switch (starCount)
                     {
                         case 1:
+                            builder.Append("([^/]+)");
+                            // We won't have any slashes in the value, so we don't need to split then join.
                             formatBuilder += (match, sb) => sb.Append(Uri.EscapeDataString(match.Groups[matchGroupIndex].Value));
                             break;
                         case 2:
+                            builder.Append("(.+)");
                             formatBuilder += (match, sb) => sb.Append(string.Join("/", match.Groups[matchGroupIndex].Value.Split('/').Select(segment => Uri.EscapeDataString(segment))));
                             break;
                         default:


### PR DESCRIPTION
This has gone back and forth, but we've now had confirmation that `"abc/def"` is not a valid value for `name` in a path template of `"v1/{name}"` for example.