### PR TITLE
chore: Add a simple JSON state tracker

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/Rest/JsonStateTrackerTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/JsonStateTrackerTest.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using static Google.Api.Gax.Grpc.Rest.JsonStateTracker;
+
+namespace Google.Api.Gax.Grpc.Rest.Tests;
+
+public class JsonStateTrackerTest
+{
+    [Theory]
+    [InlineData("x")] // Top-level non-array
+    [InlineData("{")] // Top-level object
+    [InlineData("[x")] // Non-object in top array
+    [InlineData("[}")] // Close object in top array
+    [InlineData("[{]")] // Unbalanced array (close top array while in object)
+    [InlineData("[{}x")] // Non-object in top array after first object
+    [InlineData("[{\"\\x")] // String token with invalid escape sequence
+    [InlineData("[],")] // Non-whitespace after top array
+    [InlineData("[]{")] // Non-whitespace after top array
+    [InlineData("[][")] // Non-whitespace after top array
+    public void ErrorsDetected(string json)
+    {
+        // We expect that only the final character causes an error
+        var tracker = new JsonStateTracker();
+
+        for (int i = 0; i < json.Length - 1; i++)
+        {
+            var nextAction = tracker.Push(json[i]);
+            Assert.NotEqual(NextAction.SignalError, nextAction);
+        }
+        Assert.Equal(NextAction.SignalError, tracker.Push(json.Last()));
+    }
+
+    // Note: this test uses the fact that we're really not validating that it's real JSON.
+    // It makes life a lot simpler.
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("   \r\n\t []   \r\n\t ")]
+    [InlineData("[{xyz}]", "{xyz}")]
+    [InlineData("[{abc}, {def}]", "{abc}", "{def}")]
+    [InlineData("[{{nested1}, {nested2}}, {response2}]", "{{nested1}, {nested2}}", "{response2}")]
+    [InlineData("[{[array]}]", "{[array]}")]
+    [InlineData(@"[{""\""\\\/\b\f\n\r\t\uabcd""}]", @"{""\""\\\/\b\f\n\r\t\uabcd""}")] // All valid escapes
+    [InlineData("[{\"}}}}{}{}]]][[[\"}]", "{\"}}}}{}{}]]][[[\"}")] // Braces in strings don't have any meaning
+    public void NormalBehavior(string json, params string[] expectedObjects)
+    {
+        var builder = new StringBuilder();
+        var tracker = new JsonStateTracker();
+        var actualObjects = new List<string>();
+        bool endOfResponses = false;
+        foreach (var c in json)
+        {
+            var nextAction = tracker.Push(c);
+            switch (nextAction)
+            {
+                case NextAction.ParseResponse:
+                    Assert.False(endOfResponses);
+                    builder.Append(c);
+                    actualObjects.Add(builder.ToString());
+                    builder.Clear();
+                    break;
+                case NextAction.BufferAndContinue:
+                    Assert.False(endOfResponses);
+                    builder.Append(c);
+                    break;
+                case NextAction.IgnoreAndContinue:
+                    break;
+                case NextAction.SignalEndOfResponses:
+                    Assert.False(endOfResponses);
+                    endOfResponses = true;
+                    break;
+                default:
+                    Assert.Fail($"Unexpected next action: {nextAction}");
+                    break;
+            }
+        }
+        Assert.True(endOfResponses);
+        Assert.Equal(expectedObjects, actualObjects);
+    }
+}

--- a/Google.Api.Gax.Grpc/Rest/JsonStateTracker.cs
+++ b/Google.Api.Gax.Grpc/Rest/JsonStateTracker.cs
@@ -1,0 +1,240 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System;
+
+namespace Google.Api.Gax.Grpc.Rest;
+
+/// <summary>
+/// Simple state tracker to indicate when a server-streamed response is "done".
+/// </summary>
+/// <remarks>
+/// We expect that:
+/// - The overall response is an array
+/// - The later JSON parser will perform fuller validation (e.g. this code
+///   won't spot that [{[{]}}] is broken.
+///
+/// Note that this is mutable rather than us creating a new instance on each "push"
+/// of a character, because:
+/// - It's not *just* a simple state machine: we count open/close object/arrays
+/// - We could make it a struct containing those counters and a detailed state enum,
+///   it's not obvious that would be easier to use.
+/// </remarks>
+internal sealed class JsonStateTracker
+{
+    private int arrayDepth;
+    private int objectDepth;
+
+    private State state = State.BeforeTopArray;
+
+    /// <summary>
+    /// Pushes a single character, returning the appropriate action to be taken next.
+    /// </summary>
+    public NextAction Push(char c) => state switch
+    {
+        // Errors are unrecoverable.
+        State.Error => NextAction.SignalError,
+        State.BeforeTopArray => PushFromBeforeTopArray(c),
+        State.AfterTopArray => PushFromAfterTopArray(c),
+        State.JustInsideTopArray => PushFromJustInsideTopArray(c),
+        State.WithinObject => PushFromWithinObject(c),
+        State.StringLiteralNoEscape => PushFromStringLiteralNoEscape(c),
+        State.StringLiteralEscape => PushFromStringLiteralAfterEscape(c),
+        _ => throw new InvalidOperationException($"Unknown state {state}")
+    };
+
+    private NextAction PushFromBeforeTopArray(char c)
+    {
+        if (IsJsonWhitespace(c))
+        {
+            return NextAction.IgnoreAndContinue;
+        }
+        if (c == '[')
+        {
+            state = State.JustInsideTopArray;
+            arrayDepth++;
+            return NextAction.IgnoreAndContinue;
+        }
+        state = State.Error;
+        return NextAction.SignalError;
+    }
+
+    private NextAction PushFromAfterTopArray(char c)
+    {
+        if (IsJsonWhitespace(c))
+        {
+            return NextAction.IgnoreAndContinue;
+        }
+        state = State.Error;
+        return NextAction.SignalError;
+    }
+
+    private NextAction PushFromJustInsideTopArray(char c)
+    {
+        switch (c)
+        {
+            case char when IsJsonWhitespace(c):
+            case ',':
+                return NextAction.IgnoreAndContinue;
+            case '{':
+                objectDepth++;
+                state = State.WithinObject;
+                return NextAction.BufferAndContinue;
+            case ']':
+                arrayDepth--;
+                state = State.AfterTopArray;
+                return NextAction.SignalEndOfResponses;
+            default:
+                state = State.Error;
+                return NextAction.SignalError;
+        };
+    }
+
+    private NextAction PushFromWithinObject(char c)
+    {
+        switch (c)
+        {
+            case '{':
+                objectDepth++;
+                break;
+            case '}':
+                objectDepth--;
+                if (objectDepth == 0)
+                {
+                    state = State.JustInsideTopArray;
+                    return NextAction.ParseResponse;
+                }
+                break;
+            case '[':
+                arrayDepth++;
+                break;
+            case ']':
+                arrayDepth--;
+                if (arrayDepth == 0)
+                {
+                    state = State.Error;
+                    return NextAction.SignalError;
+                }
+                break;
+            case '"':
+                state = State.StringLiteralNoEscape;
+                break;
+        }
+        return NextAction.BufferAndContinue;
+    }
+
+    private NextAction PushFromStringLiteralNoEscape(char c)
+    {
+        state = c == '"' ? State.WithinObject
+            : c == '\\' ? State.StringLiteralEscape
+            : State.StringLiteralNoEscape;
+        return NextAction.BufferAndContinue;
+    }
+
+    private NextAction PushFromStringLiteralAfterEscape(char c)
+    {
+        // We don't care what was escaped, so long as it was valid.
+        // (In the case of a hex escape, we don't even care about the
+        // hex digits following it.)
+        if (c == '"' || c == '\\' || c == '/' ||
+            c == 'b' || c == 'f' || c == 'n' ||
+            c == 'r' || c == 't' || c == 'u')
+        {
+            state = State.StringLiteralNoEscape;
+            return NextAction.BufferAndContinue;
+        }
+        state = State.Error;
+        return NextAction.SignalError;
+    }
+
+    private static bool IsJsonWhitespace(char c) =>
+        c == ' ' || c == '\t' || c == '\r' || c == '\n';
+
+    private enum State
+    {
+        /// <summary>
+        /// Before we first see [
+        /// We stay in this state, only accepting whitespace or [ until we see the first [
+        /// </summary>
+        BeforeTopArray,
+
+        /// <summary>
+        /// Between response objects.
+        /// In this state, we only accept:
+        /// - Whitespace (stay in this state)
+        /// - Comma (stay in this state)
+        /// - { (move to Normal state)
+        /// - ] (move to AfterTopArray state)
+        /// </summary>
+        JustInsideTopArray,
+
+        /// <summary>
+        /// Not in a string token, but somewhere within the top-level array.
+        /// </summary>
+        WithinObject,
+
+        /// <summary>
+        /// In a string token, but not directly after a backslash.
+        /// </summary>
+        StringLiteralNoEscape,
+
+        /// <summary>
+        /// In a string token, directly after a backslash.
+        /// (The only permitted characters to follow this are double-quote, backslash, slash, b, f, n, r, t or u.
+        /// Although u should then be followed by four hex digits, we don't enforce that.)
+        /// </summary>
+        StringLiteralEscape,
+
+        /// <summary>
+        /// We have detected an error. This is unrecoverable.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// After the final ]
+        /// We can only accept whitespace after this.
+        /// </summary>
+        AfterTopArray
+    }
+
+    /// <summary>
+    /// The action that should be taken by the caller immediately after a call to <see cref="Push(char)"/>.
+    /// </summary>
+    internal enum NextAction
+    {
+        /// <summary>
+        /// We've received the closing ] at the end of the top level array.
+        /// There should be no further non-whitespace characters.
+        /// </summary>
+        SignalEndOfResponses,
+
+        /// <summary>
+        /// We've received the closing } at the end of an object directly
+        /// within the top level array. Remember that pushed } and parse
+        /// everything remembered since the last response was parsed.
+        /// </summary>
+        ParseResponse,
+
+        /// <summary>
+        /// We've detected an error. Signal this to the higher-level caller.
+        /// We don't have details of the failure. 
+        /// </summary>
+        SignalError,
+
+        /// <summary>
+        /// Continue reading data and pushing it with the <see cref="Push"/> method.
+        /// The character that has been pushed does not need to be retained.
+        /// </summary>
+        IgnoreAndContinue,
+
+        /// <summary>
+        /// Remember the pushed character (because it's part of a top-level object).
+        /// Continue reading data and pushing it with the <see cref="Push"/> method.
+        /// </summary>
+        BufferAndContinue,
+    }
+}


### PR DESCRIPTION
This will allow a small change after #627 has been merged, to allow us to detect the end of a single response, and the end of all responses, more efficiently and easily.

(The aim is for PartialDecodingStreamReader to become simpler, so that it really doesn't need to know about JSON at all.)

The tests look brief, but have 100% coverage other than the "we don't know what this state means" situation (which can't be tested without poking via reflection, of course).