### PR TITLE
fix: Change default for UseSelfSignedJwtsWithScopes in REST to false

### DIFF
--- a/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.Defaults.cs
+++ b/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.Defaults.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using Xunit;
+
+namespace Google.Api.Gax.Rest.Tests;
+
+public partial class ClientBuilderBaseTest
+{
+    [Fact]
+    public void UseSelfSignedJwts_DisabledByDefault()
+    {
+        var builder = new DefaultsTestBuilder();
+        Assert.False(builder.UseJwtAccessWithScopes);
+    }
+
+    /// <summary>
+    /// Builder with no custom behavior, which purely exists to check defaults.
+    /// </summary>
+    private class DefaultsTestBuilder : ClientBuilderBase<string>
+    {
+        public override string Build() =>
+            throw new NotImplementedException();
+
+        public override Task<string> BuildAsync(CancellationToken cancellationToken = default) =>
+            throw new NotImplementedException();
+
+        protected override string GetDefaultApplicationName() =>
+            throw new NotImplementedException();
+
+        protected override ScopedCredentialProvider GetScopedCredentialProvider() =>
+            throw new NotImplementedException();
+    }
+}

--- a/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.cs
@@ -5,16 +5,6 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 
-using Google.Apis.Auth.OAuth2;
-using Microsoft.Extensions.DependencyInjection;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Xunit;
-
 namespace Google.Api.Gax.Rest.Tests
 {
     /// <summary>

--- a/Google.Api.Gax.Rest/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Rest/ClientBuilderBase.cs
@@ -103,10 +103,12 @@ namespace Google.Api.Gax.Rest
         /// Returns whether or not self-signed JWTs will be used over OAuth tokens when OAuth scopes are explicitly set.        
         /// </summary>
         /// <remarks>
-        /// In the base implementation, this defaults to <c>true</c>. Subclasses may add code in their own constructors
-        /// to make the default effectively <c>false</c>, however.
+        /// In the base implementation, this defaults to <c>false</c> for maximum compatibility.
+        /// Subclasses which provide clients for services which support self-signed JWTs with scopes
+        /// may change this property value on construction, effectively changing the default to <c>true</c>
+        /// from the perspective of user code.
         /// </remarks>
-        public bool UseJwtAccessWithScopes { get; set; } = true;
+        public bool UseJwtAccessWithScopes { get; set; } = false;
 
         /// <summary>
         /// Creates a new instance with no settings.


### PR DESCRIPTION
This addresses a backward compatibility issue when an existing client library is used with an updated version of GAX. (There's no opportunity for the client library to change the default in that case.)