### PR TITLE
Release Google.Api.CommonProtos version 2.7.0

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Changes since 2.6.0 are mostly documentation changes, but with a few additions such as `Service.publishing`.