### PR TITLE
fix: Fix REGAPIC error handling for server-streaming

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/Rest/RestChannelTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Rest/RestChannelTest.cs
@@ -6,9 +6,11 @@
  */
 
 using Google.Api.Gax.Grpc.IntegrationTests;
-using Google.Protobuf;
+using Google.Protobuf.Collections;
 using Grpc.Core;
+using Grpc.Core.Utils;
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -38,6 +40,31 @@ public class RestChannelTest
         Assert.Equal("Error details", exception.Status.Detail);
     }
 
+    [Fact]
+    public async Task Streaming_Success()
+    {
+        var client = CreateClient();
+        var response = client.ServerStreaming(new SimpleRequest { Name = "test" });
+        var elements = await response.ResponseStream.ToListAsync();
+        var expected = new[]
+        {
+            new SimpleResponse { Name = "test0" },
+            new SimpleResponse { Name = "test1" },
+            new SimpleResponse { Name = "test2" },
+        };
+        Assert.Equal(expected, elements);
+    }
+
+    [Fact]
+    public async Task Streaming_Error()
+    {
+        var client = CreateClient();
+        var response = client.ServerStreaming(new SimpleRequest { Name = "error" });
+        var exception = await Assert.ThrowsAsync<RpcException>(() => response.ResponseStream.MoveNext(default));
+        Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
+        Assert.Equal("Error details", exception.Status.Detail);
+    }
+
     private TestServiceClient CreateClient()
     {
         var metadata = TestServiceMetadata.ApiMetadata;
@@ -49,14 +76,18 @@ public class RestChannelTest
 
     private class TestServerHandler : HttpMessageHandler
     {
+        private const string SimplePathPrefix = "/v1/simple/";
+        private const string ServerStreamingPathPrefix = "/v1/serverStreaming/";
+        private const string CustomPathPrefix = "/v1/custom:";
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var uri = request.RequestUri;
             string path = uri.AbsolutePath;
             var response =
-                path.StartsWith("/v1/simple") ? GetSimpleResponse(request)
-                : path.StartsWith("/v1/serverStreaming") ? GetStreamingResponse(request)
-                : path.StartsWith("/v1/custom:") ? GetCustomMethod(request)
+                path.StartsWith(SimplePathPrefix) ? GetSimpleResponse(request)
+                : path.StartsWith(ServerStreamingPathPrefix) ? GetStreamingResponse(request)
+                : path.StartsWith(CustomPathPrefix) ? GetCustomMethod(request)
                 : new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
             return Task.FromResult(response);
         }
@@ -65,7 +96,7 @@ public class RestChannelTest
         {
             var uri = request.RequestUri;
             string path = uri.AbsolutePath;
-            string name = Uri.UnescapeDataString(path.Substring("/v1/simple/".Length));
+            string name = Uri.UnescapeDataString(path.Substring(SimplePathPrefix.Length));
             if (name == "error")
             {
                 return CreateErrorResponseMessage(HttpStatusCode.BadRequest,
@@ -76,7 +107,19 @@ public class RestChannelTest
 
         private HttpResponseMessage GetStreamingResponse(HttpRequestMessage request)
         {
-            return new HttpResponseMessage { StatusCode = HttpStatusCode.NotImplemented };
+            var uri = request.RequestUri;
+            string path = uri.AbsolutePath;
+            string name = Uri.UnescapeDataString(path.Substring(ServerStreamingPathPrefix.Length));
+            if (name == "error")
+            {
+                var repeatedError = new RepeatedField<Error> { CreateError(StatusCode.InvalidArgument, "Error details") };
+                return CreateErrorResponseMessage(HttpStatusCode.BadRequest, repeatedError);
+            }
+
+            var responses = Enumerable.Range(0, 3).Select(index => new SimpleResponse { Name = name + index });
+            var repeated = new RepeatedField<SimpleResponse>();
+            repeated.AddRange(responses);
+            return CreateSuccessResponseMessage(repeated);
         }
 
         private HttpResponseMessage GetCustomMethod(HttpRequestMessage request)
@@ -84,7 +127,7 @@ public class RestChannelTest
             return new HttpResponseMessage { StatusCode = HttpStatusCode.NotImplemented };
         }
 
-        private static HttpResponseMessage CreateSuccessResponseMessage(IMessage message)
+        private static HttpResponseMessage CreateSuccessResponseMessage(object message)
         {
             string json = message.ToString();
             return new HttpResponseMessage
@@ -94,9 +137,21 @@ public class RestChannelTest
             };
         }
 
-        private static HttpResponseMessage CreateErrorResponseMessage(HttpStatusCode httpStatusCode, StatusCode gRpcStatusCode, string message)
+        private static HttpResponseMessage CreateErrorResponseMessage(HttpStatusCode httpStatusCode, StatusCode gRpcStatusCode, string message) =>
+            CreateErrorResponseMessage(httpStatusCode, CreateError(gRpcStatusCode, message));
+
+        private static HttpResponseMessage CreateErrorResponseMessage(HttpStatusCode httpStatusCode, object error)
         {
-            var response = new Error
+            string json = error.ToString();
+            return new HttpResponseMessage
+            {
+                StatusCode = httpStatusCode,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+        }
+
+        private static Error CreateError(StatusCode gRpcStatusCode, string message) =>
+            new Error
             {
                 Error_ = new Error.Types.Status
                 {
@@ -104,13 +159,5 @@ public class RestChannelTest
                     Message = message
                 }
             };
-
-            string json = response.ToString();
-            return new HttpResponseMessage
-            {
-                StatusCode = httpStatusCode,
-                Content = new StringContent(json, Encoding.UTF8, "application/json")
-            };
-        }
     }
 }

--- a/Google.Api.Gax.Grpc.Tests/Rest/ReadHttpResponseMessageTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/ReadHttpResponseMessageTest.cs
@@ -76,6 +76,14 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
         }
 
         [Fact]
+        public void CreateRpcStatus_ArrayStatus()
+        {
+            // Note: the NotFound is ignored here, because the Code in the status is used instead.
+            var actualStatus = ReadHttpResponseMessage.CreateRpcStatus(HttpStatusCode.NotFound, $"[ {s_sampleJson} ]");
+            Assert.Equal(s_sampleStatus, actualStatus);
+        }
+
+        [Fact]
         public void CreateRpcStatus_NoGrpcStatusCode()
         {
             // This is what some Compute responses look like. There's no gRPC status code,

--- a/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
+++ b/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
@@ -109,6 +109,14 @@ namespace Google.Api.Gax.Grpc.Rest
             }
             try
             {
+                // Error response messages for streaming APIs are embedded within arrays.
+                // If we detect that the content looks like a JSON array, extract it and parse
+                // expecting a single object.
+                if (content.StartsWith("[") && content.EndsWith("]"))
+                {
+                    content = content.Substring(1, content.Length - 2);
+                }
+
                 var errorFromMetadata = s_responseMetadataParser.Parse<Error>(content);
                 var error = errorFromMetadata.Error_;
                 // If we got a JSON object that can be parsed as an Error, but doesn't include a nested "error" field,

--- a/Google.Api.Gax.Grpc/Rest/RestChannel.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestChannel.cs
@@ -81,36 +81,6 @@ namespace Google.Api.Gax.Grpc.Rest
         }
 
         /// <summary>
-        /// Creates an HTTP request, adds headers from CallOptions, and sends the request.
-        /// </summary>
-        /// <typeparam name="TRequest">The type of request</typeparam>
-        /// <param name="restMethod">The RPC being called; used to convert the request</param>
-        /// <param name="host">Override for the endpoint, if any</param>
-        /// <param name="options">The gRPC call options, used for headers and cancellation</param>
-        /// <param name="request">The RPC request</param>
-        /// <param name="httpCompletionOption">The option indicating at what point the method should complete,
-        /// <param name="cancellationToken">The cancellation token for the RPC.</param>
-        /// within HTTP response processing</param>
-        private async Task<HttpResponseMessage> SendAsync<TRequest>(
-            RestMethod restMethod, string host, CallOptions options, TRequest request,
-            HttpCompletionOption httpCompletionOption, CancellationToken cancellationToken)
-        {
-            // Ideally, add the header in the client builder instead of in the ServiceSettingsBase...
-            var httpRequest = restMethod.CreateRequest((IMessage)request, host);
-            foreach (var headerKeyValue in (options.Headers ?? Enumerable.Empty<Metadata.Entry>())
-                .Where(mh => !mh.IsBinary)
-                .Where(mh => mh.Key != VersionHeaderBuilder.HeaderName))
-            {
-                httpRequest.Headers.Add(headerKeyValue.Key, headerKeyValue.Value);
-            }
-
-            httpRequest.Headers.Add(VersionHeaderBuilder.HeaderName, RestVersion);
-
-            await AddAuthHeadersAsync(httpRequest, restMethod, cancellationToken).ConfigureAwait(false);
-            return await _httpClient.SendAsync(httpRequest, httpCompletionOption, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Equivalent to <see cref="CallInvoker.AsyncServerStreamingCall{TRequest, TResponse}(Method{TRequest, TResponse}, string, CallOptions, TRequest)"/>.
         /// </summary>
         public AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TResponse, TRequest>(Method<TRequest, TResponse> method, string host, CallOptions options, TRequest request)
@@ -159,6 +129,36 @@ namespace Google.Api.Gax.Grpc.Rest
                 statusResponseSource.SetResult(errorResponse);
                 throw new RpcException(errorResponse.GetStatus(), errorResponse.GetTrailers());
             }
+        }
+
+        /// <summary>
+        /// Creates an HTTP request, adds headers from CallOptions, and sends the request.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of request</typeparam>
+        /// <param name="restMethod">The RPC being called; used to convert the request</param>
+        /// <param name="host">Override for the endpoint, if any</param>
+        /// <param name="options">The gRPC call options, used for headers and cancellation</param>
+        /// <param name="request">The RPC request</param>
+        /// <param name="httpCompletionOption">The option indicating at what point the method should complete,
+        /// <param name="cancellationToken">The cancellation token for the RPC.</param>
+        /// within HTTP response processing</param>
+        private async Task<HttpResponseMessage> SendAsync<TRequest>(
+            RestMethod restMethod, string host, CallOptions options, TRequest request,
+            HttpCompletionOption httpCompletionOption, CancellationToken cancellationToken)
+        {
+            // Ideally, add the header in the client builder instead of in the ServiceSettingsBase...
+            var httpRequest = restMethod.CreateRequest((IMessage)request, host);
+            foreach (var headerKeyValue in (options.Headers ?? Enumerable.Empty<Metadata.Entry>())
+                .Where(mh => !mh.IsBinary)
+                .Where(mh => mh.Key != VersionHeaderBuilder.HeaderName))
+            {
+                httpRequest.Headers.Add(headerKeyValue.Key, headerKeyValue.Value);
+            }
+
+            httpRequest.Headers.Add(VersionHeaderBuilder.HeaderName, RestVersion);
+
+            await AddAuthHeadersAsync(httpRequest, restMethod, cancellationToken).ConfigureAwait(false);
+            return await _httpClient.SendAsync(httpRequest, httpCompletionOption, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<ReadHttpResponseMessage> ReadResponseAsync(Task<HttpResponseMessage> msgTask)


### PR DESCRIPTION
This is ready for review, but I want to do more real-world testing against various services (PubSub, Spanner, BQ Storage, Bigtable) before merging.