### PR TITLE
fix: Dispose of CancellationTokenSources when a method is "done"

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/Rest/RpcCancellationContextTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/RpcCancellationContextTest.cs
@@ -142,13 +142,23 @@ public class RpcCancellationContextTest
     }
 
     [Fact]
-    public void Dispose_DisposesOfOverallCts()
+    public void Cancel_AfterDisposeSucceeds()
     {
         var callOptionsCts = new CancellationTokenSource();
         var deadlineCts = new CancellationTokenSource();
         var context = RpcCancellationContext.ForTesting("rpc", deadlineCts, callOptionsCts.Token);
         context.Dispose();
-        Assert.Throws<ObjectDisposedException>(context.Cancel);
+        context.Cancel();
+    }
+
+    [Fact]
+    public void Cancel_AfterCancelSucceeds()
+    {
+        var callOptionsCts = new CancellationTokenSource();
+        var deadlineCts = new CancellationTokenSource();
+        var context = RpcCancellationContext.ForTesting("rpc", deadlineCts, callOptionsCts.Token);
+        context.Cancel();
+        context.Cancel();
     }
 
     [Fact]
@@ -167,6 +177,18 @@ public class RpcCancellationContextTest
         var callOptionsCts = new CancellationTokenSource();
         CancellationTokenSource deadlineCts = null;
         var context = RpcCancellationContext.ForTesting("rpc", deadlineCts, callOptionsCts.Token);
+        context.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_AfterDisposeSucceeds()
+    {
+        var callOptionsCts = new CancellationTokenSource();
+        var deadlineCts = new CancellationTokenSource();
+        var context = RpcCancellationContext.ForTesting("rpc", deadlineCts, callOptionsCts.Token);
+        context.Dispose();
+        context.Dispose();
+        context.Dispose();
         context.Dispose();
     }
 

--- a/Google.Api.Gax.Grpc/Rest/RpcCancellationContext.cs
+++ b/Google.Api.Gax.Grpc/Rest/RpcCancellationContext.cs
@@ -133,12 +133,20 @@ internal sealed class RpcCancellationContext : IDisposable
     }
 
     /// <summary>
-    /// Cancels the overall RPC.
+    /// Cancels the overall RPC. This call is ignored if the context has already been disposed.
     /// </summary>
     public void Cancel()
     {
-        // TODO: Handle exceptions from this being disposed?
-        _overallCancellationTokenSource.Cancel();
+        // While we could try to keep track of whether or not it's already been disposed,
+        // that's likely to lead to race conditions (or locks). It's simpler just to attempt
+        // it and swallow the exception. This could avoid some unnecessary hard-to-diagnose
+        // issues, at the slight cost of performance in the rare case where we actually
+        // need to catch the exception.
+        try
+        {
+            _overallCancellationTokenSource.Cancel();
+        }
+        catch (ObjectDisposedException) { }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #652

Release-As: 2.3.0-beta01