### PR TITLE
chore: Update dependencies in GAX prior to a release

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax.Grpc\Google.Api.Gax.Grpc.csproj" />
     <ProjectReference Include="..\Google.Api.Gax.Grpc.Testing\Google.Api.Gax.Grpc.Testing.csproj" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
+++ b/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Grpc.Core" Version="[2.46.3, 3.0.0)" />
+    <PackageReference Include="Grpc.Core" Version="[2.46.5, 3.0.0)" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -17,10 +17,10 @@
     <ProjectReference Include="..\Google.Api.CommonProtos\Google.Api.CommonProtos.csproj" />
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Grpc.Auth" Version="[2.46.3, 3.0.0)" />
-    <PackageReference Include="Google.Apis.Auth" Version="[1.56.0, 2.0.0)" />
-    <PackageReference Include="Grpc.Core.Api" Version="[2.46.3, 3.0.0)" />
-    <PackageReference Include="Grpc.Net.Client" Version="[2.46.0, 3.0.0)"/>
+    <PackageReference Include="Grpc.Auth" Version="[2.51.0, 3.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.58.0, 2.0.0)" />
+    <PackageReference Include="Grpc.Core.Api" Version="[2.51.0, 3.0.0)" />
+    <PackageReference Include="Grpc.Net.Client" Version="[2.51.0, 3.0.0)"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="[1.57.0, 2.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.58.0, 2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Note that Grpc.Core is currently essentially frozen at 2.46.5. However, it appears to work fine with Grpc.Core.Api 2.51.0 - and copious integration tests running on Windows will prove that before libraries are released.