### PR TITLE
chore: Minor optimization for ToCallOptions

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/CallSettingsExtensionsTest.cs
@@ -320,5 +320,19 @@ namespace Google.Api.Gax.Grpc.Tests
             Assert.Same(metadata, setByHandler1);
             Assert.Same(metadata, setByHandler2);
         }
+
+        [Fact]
+        public void ToCallOptions_RequestParamsConcatenated()
+        {
+            var header1 = CallSettings.FromGoogleRequestParamsHeader("x");
+            var header2 = CallSettings.FromGoogleRequestParamsHeader("y");
+            var merged = header1.MergedWith(header2);
+            var options = merged.ToCallOptions(new FakeClock());
+            var metadata = options.Headers;
+            Assert.NotNull(metadata);
+            var entry = Assert.Single(metadata);
+            Assert.Equal(CallSettings.RequestParamsHeader, entry.Key);
+            Assert.Equal($"x{CallSettingsExtensions.RequestParamsSeparator}y", entry.Value);
+        }
     }
 }

--- a/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
+++ b/Google.Api.Gax.Grpc/CallSettingsExtensions.cs
@@ -23,7 +23,7 @@ namespace Google.Api.Gax.Grpc
         /// </summary>
         private const string QuotaProjectHeaderName = "x-goog-user-project";
 
-        private const string RequestParamsSeparator = "&";
+        internal const string RequestParamsSeparator = "&";
 
         /// <summary>
         /// This method merges the settings in <paramref name="overlaid"/> with those in
@@ -208,14 +208,13 @@ namespace Google.Api.Gax.Grpc
                 return default(CallOptions);
             }
 
-            // Workaround for https://github.com/googleapis/google-cloud-dotnet/issues/9396
-            var concatenateRequestParams = CallSettings.FromHeaderMutation(metadata =>
-                CallSettings.MetadataMutations.Concatenate(metadata, CallSettings.RequestParamsHeader, RequestParamsSeparator));
-            callSettings = callSettings.MergedWith(concatenateRequestParams);
-
             var metadata = new Metadata();
             callSettings.HeaderMutation?.Invoke(metadata);
             CheckMetadata(metadata);
+
+            // Workaround for https://github.com/googleapis/google-cloud-dotnet/issues/9396
+            CallSettings.MetadataMutations.Concatenate(metadata, CallSettings.RequestParamsHeader, RequestParamsSeparator);
+
             return new CallOptions(
                 headers: metadata,
                 // Note: extension method which handles a null expiration.


### PR DESCRIPTION
There's no need to create and merge a new CallSettings when we can operate directly on the metadata