### PR TITLE
chore: Remove testing with .NET Core 3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,6 @@ jobs:
     - name: Check out our repo
       uses: actions/checkout@v3
 
-    # We need just the .NET Core 3.1 runtime for testing    
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
-
-    # We build with .NET Core 6.0 SDK
     - name: Setup .NET Core 6.0
       uses: actions/setup-dotnet@v3
       with:

--- a/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
+++ b/Google.Api.CommonProtos.Tests/Google.Api.CommonProtos.Tests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Google.Api.Gax.Grpc.IntegrationTests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
+++ b/Google.Api.Gax.Grpc.Tests/Google.Api.Gax.Grpc.Tests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Rest.IntegrationTests/Google.Api.Gax.Rest.IntegrationTests.csproj
+++ b/Google.Api.Gax.Rest.IntegrationTests/Google.Api.Gax.Rest.IntegrationTests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
+++ b/Google.Api.Gax.Rest.Tests/Google.Api.Gax.Rest.Tests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Google.Api.Gax.Tests/Google.Api.Gax.Tests.csproj
+++ b/Google.Api.Gax.Tests/Google.Api.Gax.Tests.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\CommonProperties.Test.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
While we still support .NET Core 3.1 on a best-effort basis, it isn't supported by MS any more, and I'd rather not install an unsupported runtime where possible.

(This is the first step; we can do the same for google-cloud-dotnet afterwards, but this is much smaller.)