### PR TITLE
Release Google.Api.CommonProtos version 2.8.0

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Changes since 2.7.0:

- Updated to protobuf runtime 3.22.0
- New protos google/rpc/http.proto and google/rpc/context/audit_context.proto
- Updates to existing protos