### PR TITLE
chore: Update packaging to use PackageLicenseExpression

### DIFF
--- a/CommonProperties.xml
+++ b/CommonProperties.xml
@@ -16,7 +16,7 @@
     <!-- Packaging information -->
     <Copyright>Copyright 2020 Google LLC</Copyright>
     <Authors>Google LLC</Authors>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/googleapis/gax-dotnet</PackageProjectUrl>
     <PackageTags>Google</PackageTags>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
We still include the license file within the package, so we continue to meet all obligations, but this is easier for customers to validate.

(Non-urgent to review.)