### PR TITLE
docs: Clarify that FlowControlSettings have a context-sensitive meaning.

### DIFF
--- a/Google.Api.Gax/FlowControlSettings.cs
+++ b/Google.Api.Gax/FlowControlSettings.cs
@@ -10,6 +10,13 @@ namespace Google.Api.Gax
     /// <summary>
     /// Settings used to control data flow.
     /// </summary>
+    /// <remarks>
+    /// The precise meaning of the settings in this class
+    /// is context-sensitive. For example, when used by a library which creates multiple
+    /// streams of data, the flow control settings may restrict flow on a per-stream basis,
+    /// or on an aggregate basis. Please consult the documentation of the library that consumes
+    /// these settings for more details on how they're used in that context.
+    /// </remarks>
     public sealed class FlowControlSettings
     {
         /// <summary>


### PR DESCRIPTION
(A follow-up PR in google-cloud-dotnet will clarify the meaning for Pub/Sub.)

This aims to help with the docs side of https://github.com/googleapis/google-cloud-dotnet/issues/10358