### PR TITLE
fix: Encode unknown enums as numeric values for REGAPIC paths and query parameters, and routing headers

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/ProtobufUtilitiesTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/ProtobufUtilitiesTest.cs
@@ -85,6 +85,7 @@ public class ProtobufUtilitiesTest
     [InlineData(123.45d, "123.45")]
     [InlineData(SampleEnum.Unspecified, "SAMPLE_ENUM_UNSPECIFIED")]
     [InlineData(SampleEnum.FirstValue, "FIRST_VALUE")]
+    [InlineData((SampleEnum) 123, "123")]
     [MemberData(nameof(ComplexFormatTestData))]
     public void FormatValueAsJson(object value, string expectedText)
     {

--- a/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
+++ b/Google.Api.Gax.Grpc.Tests/Rest/transcoder_tests.json
@@ -318,6 +318,22 @@
       }
     },
     {
+      "name": "ComplexQuery_UnknownEnumValues",
+      "details": "Unknown enum values are represented numerically",
+      "inlineRule": {
+        "get": "/abc/{in_path}"
+      },
+      "requestMessageName": "QueryTestMessage",
+      "request": {
+        "enumField": 123,
+        "inPath": "def"
+      },
+      "success": {
+        "method": "GET",
+        "uri": "/abc/def?enumField=123&requiredInteger=0"
+      }
+    },
+    {
       "name": "NamedBodyExcludedFromQuery",
       "details": "When the body is a specific field, that field should not be included in the query",
       "inlineRule": {

--- a/Google.Api.Gax.Grpc/ProtobufUtilities.cs
+++ b/Google.Api.Gax.Grpc/ProtobufUtilities.cs
@@ -72,7 +72,7 @@ internal static class ProtobufUtilities
         {
             null => null,
             bool b => b ? "true" : "false",
-            System.Enum enumValue => OriginalEnumValueHelper.GetOriginalName(enumValue),
+            System.Enum enumValue => OriginalEnumValueHelper.GetOriginalName(enumValue) ?? ((int) value).ToString(CultureInfo.InvariantCulture),
             StringValue stringValue => stringValue.Value,
             Timestamp or Duration or FieldMask or Int64Value or UInt64Value or DoubleValue or FloatValue or BytesValue =>
                 RemoveWellKnownTypeQuotes(value),
@@ -107,7 +107,10 @@ internal static class ProtobufUtilities
         private static readonly ConcurrentDictionary<System.Type, Dictionary<object, string>> _dictionaries
             = new ConcurrentDictionary<System.Type, Dictionary<object, string>>();
 
-        internal static string GetOriginalName(object value)
+        /// <summary>
+        /// Returns the original name of the given enum value, or null if the value is unknown.
+        /// </summary>
+        internal static string GetOriginalName(System.Enum value)
         {
             var enumType = value.GetType();
             Dictionary<object, string> nameMapping = _dictionaries.GetOrAdd(enumType, type => GetNameMapping(type));


### PR DESCRIPTION
To explain how routing headers are affected by this: ProtobufUtilities.FormatValueAsJsonPrimitive is called by RoutingHeaderExtractor.FormatRoutingHeaderValue, which is called by the generated code.

Fixes #716.