### PR TITLE
fix: Use ordinal string operations

### DIFF
--- a/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
+++ b/Google.Api.Gax.Grpc/Rest/ReadHttpResponseMessage.cs
@@ -112,7 +112,7 @@ namespace Google.Api.Gax.Grpc.Rest
                 // Error response messages for streaming APIs are embedded within arrays.
                 // If we detect that the content looks like a JSON array, extract it and parse
                 // expecting a single object.
-                if (content.StartsWith("[") && content.EndsWith("]"))
+                if (content.StartsWith("[", StringComparison.Ordinal) && content.EndsWith("]", StringComparison.Ordinal))
                 {
                     content = content.Substring(1, content.Length - 2);
                 }

--- a/Google.Api.Gax.Grpc/Rest/RestChannel.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestChannel.cs
@@ -45,7 +45,8 @@ namespace Google.Api.Gax.Grpc.Rest
             // Reuse a single CallInvoker however many times CreateCallInvoker is called.
             _callInvoker = new RestCallInvoker(this);
             // TODO: Handle endpoints better...
-            var endpointWithScheme = endpoint.StartsWith("https://") || endpoint.StartsWith("http://")
+            var endpointWithScheme =
+                endpoint.StartsWith("https://", StringComparison.Ordinal) || endpoint.StartsWith("http://", StringComparison.Ordinal)
                 ? endpoint
                 : $"https://{endpoint}";
             var baseAddress = new Uri(endpointWithScheme);

--- a/Google.Api.Gax/PathTemplate.cs
+++ b/Google.Api.Gax/PathTemplate.cs
@@ -235,7 +235,7 @@ namespace Google.Api.Gax
         {
             GaxPreconditions.CheckNotNull(name, nameof(name));
             string serviceName = null;
-            if (name.StartsWith("//"))
+            if (name.StartsWith("//", StringComparison.Ordinal))
             {
                 int nameEnd = name.IndexOf('/', 2);
                 // Can't call ValidateServiceName as we don't want to throw...
@@ -371,7 +371,7 @@ namespace Google.Api.Gax
                     case SegmentKind.Literal:
                         throw new InvalidOperationException("Values cannot be specified for literal segments");
                     case SegmentKind.PathWildcard:
-                        if (value.StartsWith("/") || value.EndsWith("/"))
+                        if (value.StartsWith("/", StringComparison.Ordinal) || value.EndsWith("/", StringComparison.Ordinal))
                         {
                             throw new ArgumentException("Path wildcard values must not start or end with /", nameof(value));
                         }
@@ -403,8 +403,8 @@ namespace Google.Api.Gax
                 {
                     return s_unnamedPathWildcard;
                 }
-                bool startsWithBrace = segment.StartsWith("{");
-                bool endsWithBrace = segment.EndsWith("}");
+                bool startsWithBrace = segment.StartsWith("{", StringComparison.Ordinal);
+                bool endsWithBrace = segment.EndsWith("}", StringComparison.Ordinal);
                 if (startsWithBrace != endsWithBrace)
                 {
                     throw new ArgumentException($"Invalid template segment: {segment}", nameof(segment));


### PR DESCRIPTION
Checked:

- IndexOf
- StartsWith
- EndsWith
- OrderBy
- Sort
- Compare

(Annoyingly, for StartsWith and EndsWith there are various single-character cases where a character literal would do the right thing - but those overloads aren't supported on .NET Framework.)