### PR TITLE
Release Google.Api.CommonProtos version 2.12.0

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <Version>2.11.0</Version>
+    <Version>2.12.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Changes since 2.11.0:

- The package contains the original protos, in contents/protos. Build targets in the package set the `GoogleApiCommonProtos_ProtosPath` msbuild property, and if `IncludeGoogleApiCommonProtos` is set to the value `true` in the project, the `Protobuf_StandardImportsPath` property is updated to include it before the `Protobuf_BeforeCompile` target is executed. (This should make the package easier to work with from Grpc.Tools.)