### PR TITLE
feat: Make CallSettings.FromGoogleRequestParamsHeader public

### DIFF
--- a/Google.Api.Gax.Grpc/CallSettings.cs
+++ b/Google.Api.Gax.Grpc/CallSettings.cs
@@ -242,21 +242,31 @@ namespace Google.Api.Gax.Grpc
         /// Creates a <see cref="CallSettings"/> which applies an x-goog-request-params header with the specified
         /// parameter name and value.
         /// </summary>
-        /// <remarks>The value is URL-encoded; it is expected that <paramref name="parameterName"/> is already URL-encoded.</remarks>
+        /// <remarks>
+        /// <para>
+        /// The value is URL-encoded; it is expected that <paramref name="parameterName"/> is already URL-encoded.
+        /// </para>
+        /// <para>
+        /// This method is intended to be called from API-specific client libraries; it would be very unusual
+        /// for it to be appropriate to call from application code.
+        /// </para>
+        /// </remarks>
         /// <param name="parameterName">The name of the parameter. Must not be null.</param>
         /// <param name="value">The value of the parameter, which may be null. A null value is equivalent to providing an empty string.</param>
         /// <returns>A <see cref="CallSettings"/> which applies the appropriate header with a single parameter.</returns>
-        internal static CallSettings FromGoogleRequestParamsHeader(string parameterName, string value) =>
+        public static CallSettings FromGoogleRequestParamsHeader(string parameterName, string value) =>
             FromHeader(RequestParamsHeader, parameterName + "=" + Uri.EscapeDataString(value ?? ""));
 
         /// <summary>
         /// Creates a <see cref="CallSettings"/> which applies an x-goog-request-params header with the specified
         /// escaped header value.
         /// </summary>
+        /// <remarks>This method is intended to be called from API-specific client libraries; it would be very unusual
+        /// for it to be appropriate to call from application code.</remarks>
         /// <param name="escapedHeaderValue">The value of the x-goog-request-params header.
         /// Must be escaped. Must not be null or empty.</param>
         /// <returns>A <see cref="CallSettings"/> which applies the appropriate header.</returns>
-        internal static CallSettings FromGoogleRequestParamsHeader(string escapedHeaderValue) =>
+        public static CallSettings FromGoogleRequestParamsHeader(string escapedHeaderValue) =>
             FromHeader(RequestParamsHeader, GaxPreconditions.CheckNotNullOrEmpty(escapedHeaderValue, nameof(escapedHeaderValue)));
 
         /// <summary>


### PR DESCRIPTION
Fixes #733.

We don't validate that parameters have already been URI-encoded, but that's probably okay - if callers pass in bad data, we'll just be sending bad headers, which could be done by callers anyway. In reality, we're not expecting this to be used outside our own client libraries, as noted in remarks.