### PR TITLE
chore: Remove some duplication of status handling

### DIFF
--- a/Google.Api.Gax.Grpc/RpcExceptionExtensions.cs
+++ b/Google.Api.Gax.Grpc/RpcExceptionExtensions.cs
@@ -6,7 +6,6 @@
  */
 
 using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Google.Rpc;
 using Grpc.Core;
 using System.Linq;
@@ -60,19 +59,9 @@ namespace Google.Api.Gax.Grpc
         public static T GetStatusDetail<T>(this RpcException ex) where T : class, IMessage<T>, new()
         {
             var status = GetRpcStatus(ex);
-            if (status is null)
-            {
-                return null;
-            }
-            var expectedName = new T().Descriptor.FullName;
-            var any = status.Details.FirstOrDefault(a => Any.GetTypeName(a.TypeUrl) == expectedName);
-            if (any is null)
-            {
-                return null;
-            }
             try
             {
-                return any.Unpack<T>();
+                return status.GetDetail<T>();
             }
             catch
             {


### PR DESCRIPTION
We can't make this entirely pass-through, as we have different semantics in terms of handling details that can't be deserialized.

We might want to look at *all* this again in the next major version.