### PR TITLE
Release Google.Api.CommonProtos version 2.13.0

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <Version>2.12.0</Version>
+    <Version>2.13.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Changes since 2.12.0:

- Update protoc and Google.Protobuf to 3.25.0
- Additional methods for Google.Rpc.Status to retrieve details