### PR TITLE
Copy Google.Api.CommonProtos.targets to buildTransitive

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -18,6 +18,6 @@
     <PackageReference Include="Google.Protobuf" Version="[3.25.0, 4.0.0)" />
     <None Remove="proto-header.txt" />
     <None Include="protos\**\*.proto" Pack="true" PackagePath="content/protos" />
-    <None Include="build\*.targets" Pack="true" PackagePath="build" />
+    <None Include="build\*.targets" Pack="true" PackagePath="build;buildTransitive" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix auto import of proto files when Google.Api.CommonProtos is a [transitive reference](https://github.com/NuGet/Home/wiki/Allow-package--authors-to-define-build-assets-transitive-behavior).