### PR TITLE
feat: Universe domain support for Discovery based libraries.

### DIFF
--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
     <PackageReference Include="Grpc.Auth" Version="[2.60.0, 3.0.0)" />
-    <PackageReference Include="Google.Apis.Auth" Version="[1.67.00-beta01, 2.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.67.00, 2.0.0)" />
     <PackageReference Include="Grpc.Core.Api" Version="[2.60.0, 3.0.0)" />
     <PackageReference Include="Grpc.Net.Client" Version="[2.60.0, 3.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/Google.Api.Gax.Rest.IntegrationTests/ClientBuilderBaseTest.cs
+++ b/Google.Api.Gax.Rest.IntegrationTests/ClientBuilderBaseTest.cs
@@ -134,6 +134,14 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         }
 
         [Fact]
+        public async Task UniverseDomain()
+        {
+            string universeDomain = "custom.domain";
+            var builder = new SampleClientBuilder { UniverseDomain = universeDomain };
+            await ValidateResultAsync(builder, initializer => Assert.Equal(universeDomain, initializer.UniverseDomain));
+        }
+
+        [Fact]
         public async Task ApplicationNameUnspecified()
         {
             var builder = new SampleClientBuilder();

--- a/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.Defaults.cs
+++ b/Google.Api.Gax.Rest.Tests/ClientBuilderBaseTest.Defaults.cs
@@ -19,6 +19,7 @@ public partial class ClientBuilderBaseTest
     {
         var builder = new DefaultsTestBuilder();
         Assert.False(builder.UseJwtAccessWithScopes);
+        Assert.Null(builder.UniverseDomain);
     }
 
     /// <summary>

--- a/Google.Api.Gax.Rest/ClientBuilderBase.cs
+++ b/Google.Api.Gax.Rest/ClientBuilderBase.cs
@@ -46,6 +46,25 @@ namespace Google.Api.Gax.Rest
         public string BaseUri { get; set; }
 
         /// <summary>
+        /// The universe domain to connect to, or null to use the default universe domain.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="UniverseDomain"/> is used to build the base URI to connect to, unless <see cref="BaseUri"/>
+        /// is set, in which case <see cref="BaseUri"/> will be used without further modification.
+        /// </para>
+        /// <para>
+        /// If default credentials or one of <see cref="GoogleCredential"/>, <see cref="CredentialsPath"/> or <see cref="JsonCredentials"/>
+        /// is used, <see cref="GoogleCredential.GetUniverseDomain"/> should be:
+        /// <list type="bullet">
+        /// <item>The same as <see cref="UniverseDomain"/> if <see cref="UniverseDomain"/> has been set.</item>
+        /// <item>The default universe domain otherwise.</item>
+        /// </list>
+        /// </para>
+        /// </remarks>
+        public string UniverseDomain { get; set; }
+
+        /// <summary>
         /// The credential to use for authentication. This cannot be specified alongside other authentication properties.
         /// Note that scopes are not automatically applied to this credential; if a scoped credential is required, the
         /// scoping must be applied by the calling code.
@@ -165,6 +184,7 @@ namespace Google.Api.Gax.Rest
                 ApiKey = ApiKey,
                 ApplicationName = ApplicationName ?? GetDefaultApplicationName(),
                 BaseUri = BaseUri,
+                UniverseDomain = UniverseDomain,
                 HttpClientFactory = HttpClientFactory
             };
             initializer.VersionHeaderBuilder

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Google.Api.Gax\Google.Api.Gax.csproj" />
 
-    <PackageReference Include="Google.Apis.Auth" Version="[1.66.0, 2.0.0)" />
+    <PackageReference Include="Google.Apis.Auth" Version="[1.67.0, 2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This has a dependency on https://github.com/googleapis/google-api-dotnet-client/pull/2675 because we use properties dfined there. This PR's presubmits won't be green until we have merged and released https://github.com/googleapis/google-api-dotnet-client/pull/2675.