### PR TITLE
Release Google.Api.CommonProtos version 2.15.0

### DIFF
--- a/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
+++ b/Google.Api.CommonProtos/Google.Api.CommonProtos.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <Version>2.14.0</Version>
+    <Version>2.15.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Changes since 2.14.0:

- Add ServiceOption extension for api_version
- Add LOCATION_POLICY_VIOLATED ErrorReason enum value
- Add rest_reference_documentation_uri for Publishing
- Minor tweaks to existing comments