### PR TITLE
feat: Target netstandard2.0 in GAX

### DIFF
--- a/Google.Api.Gax.Grpc.Testing/Google.Api.Gax.Grpc.Testing.csproj
+++ b/Google.Api.Gax.Grpc.Testing/Google.Api.Gax.Grpc.Testing.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Packaging information -->

--- a/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
+++ b/Google.Api.Gax.Grpc/Google.Api.Gax.Grpc.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
+++ b/Google.Api.Gax.Rest/Google.Api.Gax.Rest.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Google.Api.Gax.Testing/Google.Api.Gax.Testing.csproj
+++ b/Google.Api.Gax.Testing/Google.Api.Gax.Testing.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Packaging information -->

--- a/Google.Api.Gax/GkePlatformDetails.cs
+++ b/Google.Api.Gax/GkePlatformDetails.cs
@@ -95,7 +95,7 @@ namespace Google.Api.Gax
                 kubernetesToken = File.ReadAllText("/var/run/secrets/kubernetes.io/serviceaccount/token");
                 // On Windows GKE, we currently fail to load this certificate - so just skipping even an attempt
                 // when on .NET Framework seems reasonable.
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER
                 kubernetesCaCert = new X509Certificate2("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
 #elif NET462
 #else
@@ -132,7 +132,7 @@ namespace Google.Api.Gax
                     return chain.Build(cert) && chain.ChainElements[chain.ChainElements.Count - 1].Certificate.Thumbprint == kubernetesCaCert.Thumbprint;
                 };
             var handler = new HttpClientHandler();
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER
             handler.ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback;
 #elif NET462
             // .NET 4.6.2 supposedly supports .NET Standard (which defines HttpClientHandler.ServerCertificateCustomValidationCallback),

--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\CommonProperties.xml" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This will allow us to target netstandard2.0 in client libraries as well. This is experimental at this stage - we're likely to release a beta with these targets, and then release a beta client library targeting netstandard2.0 with the GAX beta as a dependency, but a GA GAX release targeting netstandard2.0 is further out.

Note: the [compatibility tester](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/baseline-version-validator) currently complains about various members, but I *believe* that's a bug in the tester - see https://github.com/dotnet/sdk/issues/39629 for details. We should at least confirm that it's a bug before doing a GA release, but I think an alpha or beta would be okay before then.