### PR TITLE
feat: Start implementing OpenTelemetry support

### DIFF
--- a/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiBidirectionalStreamingCall.cs
@@ -8,6 +8,7 @@
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 
 namespace Google.Api.Gax.Grpc
 {
@@ -83,5 +84,9 @@ namespace Google.Api.Gax.Grpc
                 ? this
                 : new ApiBidirectionalStreamingCall<TRequest, TResponse>(_methodName, _call.WithLogging(logger, _methodName), BaseCallSettings, StreamingSettings);
 
+        internal ApiBidirectionalStreamingCall<TRequest, TResponse> WithTracing(ActivitySource activitySource) =>
+            activitySource is null
+                ? this
+                : new ApiBidirectionalStreamingCall<TRequest, TResponse>(_methodName, _call.WithTracing(activitySource, _methodName), BaseCallSettings, StreamingSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ApiCall.cs
+++ b/Google.Api.Gax.Grpc/ApiCall.cs
@@ -9,6 +9,7 @@ using Google.Protobuf;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Google.Api.Gax.Grpc
@@ -171,6 +172,14 @@ namespace Google.Api.Gax.Grpc
                 : new ApiCall<TRequest, TResponse>(
                     _methodName, _asyncCall.WithLogging(logger, _methodName),
                     _syncCall.WithLogging(logger, _methodName),
+                    BaseCallSettings);
+
+        internal ApiCall<TRequest, TResponse> WithTracing(ActivitySource activitySource) =>
+            activitySource is null
+                ? this
+                : new ApiCall<TRequest, TResponse>(
+                    _methodName, _asyncCall.WithTracing(activitySource, _methodName),
+                    _syncCall.WithTracing(activitySource, _methodName),
                     BaseCallSettings);
 
         /// <summary>

--- a/Google.Api.Gax.Grpc/ApiCallTracingExtensions.cs
+++ b/Google.Api.Gax.Grpc/ApiCallTracingExtensions.cs
@@ -1,0 +1,51 @@
+﻿/*  
+ * Copyright 2024 Google LLC All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Grpc.Core;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Api.Gax.Grpc;
+
+/// <summary>
+/// Extension methods to provide tracing via <see cref="ActivitySource"/>.
+/// </summary>
+internal static class ApiCallTracingExtensions
+{
+    // Unary async
+    internal static Func<TRequest, CallSettings, Task<TResponse>> WithTracing<TRequest, TResponse>(
+        this Func<TRequest, CallSettings, Task<TResponse>> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+
+    // Unary sync
+    internal static Func<TRequest, CallSettings, TResponse> WithTracing<TRequest, TResponse>(
+        this Func<TRequest, CallSettings, TResponse> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+
+    // Server-streaming async
+    internal static Func<TRequest, CallSettings, Task<AsyncServerStreamingCall<TResponse>>> WithTracing<TRequest, TResponse>(
+        this Func<TRequest, CallSettings, Task<AsyncServerStreamingCall<TResponse>>> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+
+    // Server-streaming sync
+    internal static Func<TRequest, CallSettings, AsyncServerStreamingCall<TResponse>> WithTracing<TRequest, TResponse>(
+        this Func<TRequest, CallSettings, AsyncServerStreamingCall<TResponse>> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+
+    // Client-streaming
+    internal static Func<CallSettings, AsyncClientStreamingCall<TRequest, TResponse>> WithTracing<TRequest, TResponse>(
+        this Func<CallSettings, AsyncClientStreamingCall<TRequest, TResponse>> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+
+    // Bidi-streaming
+    internal static Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> WithTracing<TRequest, TResponse>(
+        this Func<CallSettings, AsyncDuplexStreamingCall<TRequest, TResponse>> fn, ActivitySource activitySource, string methodName) =>
+        fn;
+}

--- a/Google.Api.Gax.Grpc/ApiClientStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiClientStreamingCall.cs
@@ -8,6 +8,7 @@
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 
 namespace Google.Api.Gax.Grpc
 {
@@ -80,5 +81,10 @@ namespace Google.Api.Gax.Grpc
             logger is null
                 ? this
                 : new ApiClientStreamingCall<TRequest, TResponse>(_methodName, _call.WithLogging(logger, _methodName), BaseCallSettings, StreamingSettings);
+
+        internal ApiClientStreamingCall<TRequest, TResponse> WithTracing(ActivitySource activitySource) =>
+            activitySource is null
+                ? this
+                : new ApiClientStreamingCall<TRequest, TResponse>(_methodName, _call.WithTracing(activitySource, _methodName), BaseCallSettings, StreamingSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
+++ b/Google.Api.Gax.Grpc/ApiServerStreamingCall.cs
@@ -8,6 +8,7 @@
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Google.Api.Gax.Grpc
@@ -143,6 +144,15 @@ namespace Google.Api.Gax.Grpc
                     _methodName,
                     _asyncCall.WithLogging(logger, _methodName),
                     _syncCall.WithLogging(logger, _methodName),
+                    BaseCallSettings);
+
+        internal ApiServerStreamingCall<TRequest, TResponse> WithTracing(ActivitySource activitySource) =>
+            activitySource is null
+                ? this
+                : new ApiServerStreamingCall<TRequest, TResponse>(
+                    _methodName,
+                    _asyncCall.WithTracing(activitySource, _methodName),
+                    _syncCall.WithTracing(activitySource, _methodName),
                     BaseCallSettings);
     }
 }

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -9,6 +9,7 @@ using Google.Protobuf;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 
 namespace Google.Api.Gax.Grpc
 {
@@ -27,6 +28,8 @@ namespace Google.Api.Gax.Grpc
         /// optionally the API version (x-goog-api-version).
         /// </summary>
         private readonly CallSettings _versionCallSettings;
+
+        private readonly ActivitySource _activitySource;
 
         /// <summary>
         /// Constructs a helper from the given settings.
@@ -61,6 +64,7 @@ namespace Google.Api.Gax.Grpc
             {
                 _versionCallSettings = _versionCallSettings.WithHeader(ApiVersionHeaderName, options.ApiVersion);
             }
+            _activitySource = options.ActivitySource;
         }
 
         /// <summary>
@@ -105,6 +109,7 @@ namespace Google.Api.Gax.Grpc
             // I.e. Version header is added first, then retry is performed.
             return ApiCall.Create(methodName, asyncGrpcCall, syncGrpcCall, baseCallSettings, Clock)
                 .WithLogging(Logger)
+                .WithTracing(_activitySource)
                 .WithRetry(Clock, Scheduler, Logger)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
@@ -129,6 +134,7 @@ namespace Google.Api.Gax.Grpc
             // I.e. Version header is added first, then retry is performed.
             return ApiServerStreamingCall.Create(methodName, grpcCall, baseCallSettings, Clock)
                 .WithLogging(Logger)
+                .WithTracing(_activitySource)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -153,6 +159,7 @@ namespace Google.Api.Gax.Grpc
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiBidirectionalStreamingCall.Create(methodName, grpcCall, baseCallSettings, streamingSettings, Clock)
                 .WithLogging(Logger)
+                .WithTracing(_activitySource)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -177,6 +184,7 @@ namespace Google.Api.Gax.Grpc
             CallSettings baseCallSettings = _clientCallSettings.MergedWith(perMethodCallSettings);
             return ApiClientStreamingCall.Create(methodName, grpcCall, baseCallSettings, streamingSettings, Clock)
                 .WithLogging(Logger)
+                .WithTracing(_activitySource)
                 .WithMergedBaseCallSettings(_versionCallSettings);
         }
 
@@ -204,6 +212,12 @@ namespace Google.Api.Gax.Grpc
             /// The API version to send in the x-goog-api-version header, if any. This may be null.
             /// </summary>
             public string ApiVersion { get; set; }
+
+            /// <summary>
+            /// The activity source to use for tracing, if any. This may be null.
+            /// Note: currently internal until we're ready to roll out OpenTelemetry support "properly".
+            /// </summary>
+            internal ActivitySource ActivitySource { get; set; }
         }
     }
 }

--- a/Google.Api.Gax.Grpc/ClientHelper.cs
+++ b/Google.Api.Gax.Grpc/ClientHelper.cs
@@ -64,7 +64,7 @@ namespace Google.Api.Gax.Grpc
             {
                 _versionCallSettings = _versionCallSettings.WithHeader(ApiVersionHeaderName, options.ApiVersion);
             }
-            _activitySource = options.ActivitySource;
+            _activitySource = settings.ActivitySource ?? options.ActivitySource;
         }
 
         /// <summary>
@@ -214,7 +214,8 @@ namespace Google.Api.Gax.Grpc
             public string ApiVersion { get; set; }
 
             /// <summary>
-            /// The activity source to use for tracing, if any. This may be null.
+            /// The activity source to use for tracing, if any. This may be null. This is ignored
+            /// if <see cref="Settings"/> specifies an activity source.
             /// Note: currently internal until we're ready to roll out OpenTelemetry support "properly".
             /// </summary>
             internal ActivitySource ActivitySource { get; set; }

--- a/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
+++ b/Google.Api.Gax.Grpc/ServiceSettingsBase.cs
@@ -7,6 +7,7 @@
 
 using Grpc.Core;
 using Grpc.Core.Interceptors;
+using System.Diagnostics;
 
 namespace Google.Api.Gax.Grpc
 {
@@ -42,6 +43,7 @@ namespace Google.Api.Gax.Grpc
             Scheduler = existing.Scheduler;
             VersionHeaderBuilder = existing.VersionHeaderBuilder.Clone();
             Interceptor = existing.Interceptor;
+            ActivitySource = existing.ActivitySource;
         }
 
         /// <summary>
@@ -84,5 +86,12 @@ namespace Google.Api.Gax.Grpc
         /// on or after that date are aware of this property.
         /// </summary>
         public Interceptor Interceptor { get; set; }
+
+        /// <summary>
+        /// An optional <see cref="ActivitySource"/>, which can override the default activity source used for tracing
+        /// calls from this client.
+        /// Note: currently internal until we're ready to roll out OpenTelemetry support "properly".
+        /// </summary>
+        internal ActivitySource ActivitySource { get; set; }
     }
 }

--- a/Google.Api.Gax.Tests/ActivitySourcesTest.cs
+++ b/Google.Api.Gax.Tests/ActivitySourcesTest.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Copyright 2024 Google LLC All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Xunit;
+
+namespace Google.Api.Gax.Tests;
+
+public class ActivitySourcesTest
+{
+    [Fact]
+    public void NameIsType()
+    {
+        var source = ActivitySources.FromType<ActivitySourcesTest>();
+        // Hard-coded to makeit obvious in the test what the value will actually look like.
+        Assert.Equal("Google.Api.Gax.Tests.ActivitySourcesTest", source.Name);
+    }
+
+    [Fact]
+    public void Caching()
+    {
+        var source1 = ActivitySources.FromType<ActivitySourcesTest>();
+        var source2 = ActivitySources.FromType<ActivitySourcesTest>();
+        var source3 = ActivitySources.FromType(typeof(ActivitySourcesTest));
+        var source4 = ActivitySources.FromType<PollingTest>();
+
+        Assert.Same(source1, source2);
+        Assert.Same(source1, source3);
+        Assert.NotSame(source1, source4);
+    }
+
+    [Fact]
+    public void Version_VersionedAssembly()
+    {
+        // Deliberately use a type in the main assembly, so that it's got a real version.
+        var source = ActivitySources.FromType<Expiration>();
+        Assert.NotEmpty(source.Version);
+        // We don't try to parse this as a System.Version, as that would fail for betas etc.
+        var majorVersion = int.Parse(source.Version.Split('.')[0]);
+        // This doesn't need to be changed when we bump the version of GAX - it's just checking
+        // that we've got a real version rather than a default of 1.0.
+        Assert.True(majorVersion >= 4);
+    }
+}

--- a/Google.Api.Gax/ActivitySources.cs
+++ b/Google.Api.Gax/ActivitySources.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * Copyright 2024 Google LLC All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Google.Api.Gax;
+
+// Note: currently internal until we're ready to roll out OpenTelemetry support "properly".
+
+/// <summary>
+/// Helper methods for obtaining <see cref="ActivitySource"/> values.
+/// Note that while some conventions suggest a single activity source per assembly, libraries for Google Cloud APIs
+/// use an activity source per client type, for simpler filtering. These can easily be obtained via the static
+/// properties on the client type itself, but this class allows a more generic approach where necessary.
+/// </summary>
+internal static class ActivitySources
+{
+    private static readonly ConcurrentDictionary<System.Type, ActivitySource> s_activitySources = new();
+
+    /// <summary>
+    /// Returns an <see cref="ActivitySource"/> named after the given type (typically an API client).
+    /// </summary>
+    /// <remarks>
+    /// Multiple calls to this method (or <see cref="FromType{T}()"/>) for the same
+    /// type will return the same cached activity source.
+    /// </remarks>
+    /// <param name="type">The client type to obtain an activity source for. Must not be null.</param>
+    /// <returns>An <see cref="ActivitySource"/> named after the given client type.</returns>
+    public static ActivitySource FromType(System.Type type)
+    {
+        GaxPreconditions.CheckNotNull(type, nameof(type));
+        return s_activitySources.GetOrAdd(type, CreateActivitySource);
+    }
+
+    /// <summary>
+    /// Returns an <see cref="ActivitySource"/> named after the given type (typically an API client).
+    /// </summary>
+    /// <remarks>
+    /// Multiple calls to this method (or <see cref="FromType(System.Type)"/>) for the same
+    /// type will return the same cached activity source.
+    /// </remarks>
+    /// <typeparam name="T">The type to obtain an activity source for.</typeparam>
+    /// <returns>An <see cref="ActivitySource"/> named after the given type.</returns>
+    public static ActivitySource FromType<T>() => FromType(typeof(T));
+
+    private static ActivitySource CreateActivitySource(System.Type type) =>
+        // TODO: Move FormatAssemblyVersion to a separate type? It's odd to call into VersionHeaderBuilder here.
+        new ActivitySource(type.FullName, VersionHeaderBuilder.FormatAssemblyVersion(type));
+}

--- a/Google.Api.Gax/Google.Api.Gax.csproj
+++ b/Google.Api.Gax/Google.Api.Gax.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/Google.Api.Gax/VersionHeaderBuilder.cs
+++ b/Google.Api.Gax/VersionHeaderBuilder.cs
@@ -93,7 +93,10 @@ namespace Google.Api.Gax
             }
         }
         
-        private static string FormatAssemblyVersion(System.Type type)
+        /// <summary>
+        /// Formats the version of the assembly containing the specified type, in a "generally informative" way.
+        /// </summary>
+        internal static string FormatAssemblyVersion(System.Type type)
         {
             // Prefer AssemblyInformationalVersion, then AssemblyFileVersion,
             // then AssemblyVersion.


### PR DESCRIPTION
This is all internal at the moment - the only public-facing change is the dependency on System.Diagnostics.DiagnosticSource. Still, that *is* public so we may not want to merge this. Happy to chat.