### PR TITLE
feat: Update grpc and Google.Apis.Auth dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,17 +11,17 @@
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     
     <!-- Google/gRPC packages -->
-    <PackageVersion Include="Grpc.Auth" Version="[2.60.0, 3.0.0)" />
-    <PackageVersion Include="Google.Apis.Auth" Version="[1.67.0, 2.0.0)" />
+    <PackageVersion Include="Grpc.Auth" Version="2.66.0" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.68.0" />
     <PackageVersion Include="Google.Protobuf" Version="[3.28.2, 4.0.0)" />
     <PackageVersion Include="Grpc.Core" Version="[2.46.6, 3.0.0)" />
-    <PackageVersion Include="Grpc.Core.Api" Version="[2.60.0, 3.0.0)" />
-    <PackageVersion Include="Grpc.Net.Client" Version="[2.60.0, 3.0.0)" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
 
     <!-- Microsoft/System packages -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />   
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
This is listed as a feature rather than a chore as Grpc.Net.Client v2.66.0 introduces new features to address known customer issues.