### PR TITLE
chore: Pause automatic requests to MDS Universe Domain endpoint.

### DIFF
--- a/Google.Api.Gax.Grpc/GoogleCredentialExtensions.cs
+++ b/Google.Api.Gax.Grpc/GoogleCredentialExtensions.cs
@@ -56,7 +56,13 @@ internal static class GoogleCredentialExtensions
 
         private async Task UniverseDomainsMatchCheckUncached()
         {
-            string credentialUniverseDomain = await (_underlying as GoogleCredential).GetUniverseDomainAsync(default).ConfigureAwait(false);
+            GoogleCredential googleCredential = _underlying as GoogleCredential;
+            // b/377378462 Temporarily avoid automatic requests to the MDS UniverseDomain endpoint.
+            if (googleCredential.UnderlyingCredential is ComputeCredential)
+            {
+                return;
+            }
+            string credentialUniverseDomain = await (googleCredential).GetUniverseDomainAsync(default).ConfigureAwait(false);
             if (credentialUniverseDomain != _universeDomain)
             {
                 throw new InvalidOperationException(


### PR DESCRIPTION
This applies to GAPIC based libraries only. Discovery based libraries are handled in https://github.com/googleapis/google-api-dotnet-client/pull/2871.

Towards b/371768149