### PR TITLE
chore: Comment on failing integration test

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/GrpcAdapterTest.cs
@@ -22,6 +22,11 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
         [Fact]
         public void CreateChannelMakeCall()
         {
+            // Note: this test fails under .NET Framework on some versions of Windows, when it's using the WinHttpHandler.
+            // (WinHttpException: Error 12152 calling WINHTTP_CALLBACK_STATUS_REQUEST_ERROR)
+            // We believe this is due to talking to a server hosted by Grpc.Net.Client with insecure channel credentials.
+            // As far as we're aware it's fine talking to real services using HTTPS (otherwise all our integration
+            // tests in google-cloud-dotnet would fail), and the same tests currently pass on CI.
             var adapter = GrpcAdapter.GetFallbackAdapter(TestServiceMetadata.TestService);
             var channel = adapter.CreateChannel(TestServiceMetadata.TestService, _fixture.Endpoint, ChannelCredentials.Insecure, GrpcChannelOptions.Empty);
             var client = new TestServiceClient(channel);

--- a/Google.Api.Gax.Grpc.IntegrationTests/TestServiceFixture.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/TestServiceFixture.cs
@@ -28,9 +28,6 @@ namespace Google.Api.Gax.Grpc.IntegrationTests
 
         public TestServiceFixture()
         {
-#if NETCOREAPP3_1
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-#endif
             _server = new Server
             {
                 Services = { TestService.BindService(new TestServiceImpl()) },


### PR DESCRIPTION
We're going to leave the test present, but this commit adds a comment to explain it as best we understand it.

Additionally, removed code that was conditional to the now obsolete .NET Core 3.1.

Addresses #828.