### PR TITLE
fix: Return default response if http content is empty

### DIFF
--- a/Google.Api.Gax.Grpc.IntegrationTests/Rest/RestChannelTest.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/Rest/RestChannelTest.cs
@@ -65,6 +65,14 @@ public class RestChannelTest
         Assert.Equal("Error details", exception.Status.Detail);
     }
 
+    [Fact]
+    public void HttpOkStatusWithEmptyResponse()
+    {
+        var client = CreateClient();
+        var response = client.FetchEmptyResponse(new SimpleRequest { Name = "emptyResponse" });
+        Assert.Null(response);
+    }
+
     private TestServiceClient CreateClient()
     {
         var metadata = TestServiceMetadata.ApiMetadata;
@@ -79,6 +87,7 @@ public class RestChannelTest
         private const string SimplePathPrefix = "/v1/simple/";
         private const string ServerStreamingPathPrefix = "/v1/serverStreaming/";
         private const string CustomPathPrefix = "/v1/custom:";
+        private const string EmptyResponsePathPrefix = "/v1/emptyResponse/";
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -88,6 +97,7 @@ public class RestChannelTest
                 path.StartsWith(SimplePathPrefix) ? GetSimpleResponse(request)
                 : path.StartsWith(ServerStreamingPathPrefix) ? GetStreamingResponse(request)
                 : path.StartsWith(CustomPathPrefix) ? GetCustomMethod(request)
+                : path.StartsWith(EmptyResponsePathPrefix) ? GetEmptyResponse(request)
                 : new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
             return Task.FromResult(response);
         }
@@ -125,6 +135,11 @@ public class RestChannelTest
         private HttpResponseMessage GetCustomMethod(HttpRequestMessage request)
         {
             return new HttpResponseMessage { StatusCode = HttpStatusCode.NotImplemented };
+        }
+
+        private HttpResponseMessage GetEmptyResponse(HttpRequestMessage request)
+        {
+            return CreateSuccessResponseMessage("");
         }
 
         private static HttpResponseMessage CreateSuccessResponseMessage(object message)

--- a/Google.Api.Gax.Grpc.IntegrationTests/TestService.g.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/TestService.g.cs
@@ -34,7 +34,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
             "dWUYASABKAwSEwoLc3RyaW5nVmFsdWUYAiABKAkadgoMSGVhZGVyc0VudHJ5",
             "EgsKA2tleRgBIAEoCRJVCgV2YWx1ZRgCIAEoCzJGLmdvb2dsZS5hcGkuZ2F4",
             "LmdycGMuaW50ZWdyYXRpb25fdGVzdHMuRWNob0hlYWRlcnNSZXNwb25zZS5I",
-            "ZWFkZXJWYWx1ZToCOAEy8AMKC1Rlc3RTZXJ2aWNlEpIBCghEb1NpbXBsZRI0",
+            "ZWFkZXJWYWx1ZToCOAEylgUKC1Rlc3RTZXJ2aWNlEpIBCghEb1NpbXBsZRI0",
             "Lmdvb2dsZS5hcGkuZ2F4LmdycGMuaW50ZWdyYXRpb25fdGVzdHMuU2ltcGxl",
             "UmVxdWVzdBo1Lmdvb2dsZS5hcGkuZ2F4LmdycGMuaW50ZWdyYXRpb25fdGVz",
             "dHMuU2ltcGxlUmVzcG9uc2UiGYLT5JMCExIRL3YxL3NpbXBsZS97bmFtZX0S",
@@ -45,7 +45,11 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
             "cnMSOS5nb29nbGUuYXBpLmdheC5ncnBjLmludGVncmF0aW9uX3Rlc3RzLkVj",
             "aG9IZWFkZXJzUmVxdWVzdBo6Lmdvb2dsZS5hcGkuZ2F4LmdycGMuaW50ZWdy",
             "YXRpb25fdGVzdHMuRWNob0hlYWRlcnNSZXNwb25zZSIegtPkkwIYIhYvdjEv",
-            "Y3VzdG9tOmVjaG9IZWFkZXJzYgZwcm90bzM="));
+            "Y3VzdG9tOmVjaG9IZWFkZXJzEqMBChJGZXRjaEVtcHR5UmVzcG9uc2USNC5n",
+            "b29nbGUuYXBpLmdheC5ncnBjLmludGVncmF0aW9uX3Rlc3RzLlNpbXBsZVJl",
+            "cXVlc3QaNS5nb29nbGUuYXBpLmdheC5ncnBjLmludGVncmF0aW9uX3Rlc3Rz",
+            "LlNpbXBsZVJlc3BvbnNlIiCC0+STAhoSGC92MS9lbXB0eVJlc3BvbnNlL3tu",
+            "YW1lfWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {

--- a/Google.Api.Gax.Grpc.IntegrationTests/TestServiceGrpc.g.cs
+++ b/Google.Api.Gax.Grpc.IntegrationTests/TestServiceGrpc.g.cs
@@ -85,6 +85,14 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
         __Marshaller_google_api_gax_grpc_integration_tests_EchoHeadersRequest,
         __Marshaller_google_api_gax_grpc_integration_tests_EchoHeadersResponse);
 
+    [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+    static readonly grpc::Method<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest, global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse> __Method_FetchEmptyResponse = new grpc::Method<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest, global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse>(
+        grpc::MethodType.Unary,
+        __ServiceName,
+        "FetchEmptyResponse",
+        __Marshaller_google_api_gax_grpc_integration_tests_SimpleRequest,
+        __Marshaller_google_api_gax_grpc_integration_tests_SimpleResponse);
+
     /// <summary>Service descriptor</summary>
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
     {
@@ -109,6 +117,12 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
 
       [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
       public virtual global::System.Threading.Tasks.Task<global::Google.Api.Gax.Grpc.IntegrationTests.EchoHeadersResponse> EchoHeaders(global::Google.Api.Gax.Grpc.IntegrationTests.EchoHeadersRequest request, grpc::ServerCallContext context)
+      {
+        throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
+      }
+
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::System.Threading.Tasks.Task<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse> FetchEmptyResponse(global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest request, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -192,6 +206,26 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
       {
         return CallInvoker.AsyncUnaryCall(__Method_EchoHeaders, null, options, request);
       }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse FetchEmptyResponse(global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return FetchEmptyResponse(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse FetchEmptyResponse(global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest request, grpc::CallOptions options)
+      {
+        return CallInvoker.BlockingUnaryCall(__Method_FetchEmptyResponse, null, options, request);
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncUnaryCall<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse> FetchEmptyResponseAsync(global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return FetchEmptyResponseAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncUnaryCall<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse> FetchEmptyResponseAsync(global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest request, grpc::CallOptions options)
+      {
+        return CallInvoker.AsyncUnaryCall(__Method_FetchEmptyResponse, null, options, request);
+      }
       /// <summary>Creates a new instance of client from given <c>ClientBaseConfiguration</c>.</summary>
       [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
       protected override TestServiceClient NewInstance(ClientBaseConfiguration configuration)
@@ -208,7 +242,8 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
       return grpc::ServerServiceDefinition.CreateBuilder()
           .AddMethod(__Method_DoSimple, serviceImpl.DoSimple)
           .AddMethod(__Method_ServerStreaming, serviceImpl.ServerStreaming)
-          .AddMethod(__Method_EchoHeaders, serviceImpl.EchoHeaders).Build();
+          .AddMethod(__Method_EchoHeaders, serviceImpl.EchoHeaders)
+          .AddMethod(__Method_FetchEmptyResponse, serviceImpl.FetchEmptyResponse).Build();
     }
 
     /// <summary>Register service method with a service binder with or without implementation. Useful when customizing the service binding logic.
@@ -221,6 +256,7 @@ namespace Google.Api.Gax.Grpc.IntegrationTests {
       serviceBinder.AddMethod(__Method_DoSimple, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest, global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse>(serviceImpl.DoSimple));
       serviceBinder.AddMethod(__Method_ServerStreaming, serviceImpl == null ? null : new grpc::ServerStreamingServerMethod<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest, global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse>(serviceImpl.ServerStreaming));
       serviceBinder.AddMethod(__Method_EchoHeaders, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Google.Api.Gax.Grpc.IntegrationTests.EchoHeadersRequest, global::Google.Api.Gax.Grpc.IntegrationTests.EchoHeadersResponse>(serviceImpl.EchoHeaders));
+      serviceBinder.AddMethod(__Method_FetchEmptyResponse, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Google.Api.Gax.Grpc.IntegrationTests.SimpleRequest, global::Google.Api.Gax.Grpc.IntegrationTests.SimpleResponse>(serviceImpl.FetchEmptyResponse));
     }
 
   }

--- a/Google.Api.Gax.Grpc.IntegrationTests/test_service.proto
+++ b/Google.Api.Gax.Grpc.IntegrationTests/test_service.proto
@@ -29,6 +29,12 @@ service TestService {
       post: "/v1/custom:echoHeaders"
     };
   }
+
+  rpc FetchEmptyResponse(SimpleRequest) returns (SimpleResponse) {
+    option (google.api.http) = {
+      get: "/v1/emptyResponse/{name}"
+    };
+  }
 }
 
 message SimpleRequest {

--- a/Google.Api.Gax.Grpc/Rest/RestMethod.cs
+++ b/Google.Api.Gax.Grpc/Rest/RestMethod.cs
@@ -96,7 +96,12 @@ internal class RestMethod
         {
             throw new RpcException(status, httpResponse.GetTrailers());
         }
-        return ParseJson<TResponse>(httpResponse.Content);
+
+        string jsonToParse = httpResponse.Content;
+
+        // See b/436913122#comment13. Returns the default value on an empty response
+        // instead of converting to an empty JSON element string ("{}") to prevent JSON parsing issues.
+        return string.IsNullOrEmpty(jsonToParse) ? default : ParseJson<TResponse>(jsonToParse);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-dotnet/issues/15025