### PR TITLE
fix: Stop checking returned page size against requested page size.

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/PageStreamingTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/PageStreamingTest.cs
@@ -289,7 +289,7 @@ namespace Google.Api.Gax.Grpc.Tests
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest { PageSize = 0 };
             var paged = server.PagedSync(null, null, request);
-            Assert.Throws<NotSupportedException>(() => paged.ReadPage(1));
+            Assert.NotEqual(0, paged.Count());
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace Google.Api.Gax.Grpc.Tests
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest { PageSize = 0 };
             var paged = server.PagedAsync(null, null, request);
-            await Assert.ThrowsAsync<NotSupportedException>(() => paged.ReadPageAsync(1));
+            Assert.NotEqual(0, await paged.CountAsync());
         }
     }
 }

--- a/Google.Api.Gax.Grpc/GrpcPagedAsyncEnumerable.cs
+++ b/Google.Api.Gax.Grpc/GrpcPagedAsyncEnumerable.cs
@@ -6,9 +6,7 @@
  */
 
 using Google.Protobuf;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -155,12 +153,6 @@ namespace Google.Api.Gax.Grpc
 
                 var current = await _apiCall.Async(request, effectiveCallSettings).ConfigureAwait(false);
                 items.AddRange(current);
-                if (items.Count > pageSize)
-                {
-                    // TODO: Better exception type?
-                    throw new NotSupportedException("Invalid server response: " +
-                        $"requested {requestCount} items, received {current.Count()} items");
-                }
                 nextPageToken = current.NextPageToken;
                 if (nextPageToken == "")
                 {

--- a/Google.Api.Gax.Grpc/GrpcPagedEnumerable.cs
+++ b/Google.Api.Gax.Grpc/GrpcPagedEnumerable.cs
@@ -6,8 +6,6 @@
  */
 
 using Google.Protobuf;
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -77,11 +75,6 @@ namespace Google.Api.Gax.Grpc
                 request.PageSize = requestSize;
                 var current = _apiCall.Sync(request, _callSettings);
                 items.AddRange(current);
-                if (items.Count > pageSize)
-                {
-                    throw new NotSupportedException("Invalid server response: " +
-                        $"requested {requestSize} items, received {current.Count()} items");
-                }
                 nextPageToken = current.NextPageToken;                
                 if (nextPageToken == "")
                 {

--- a/Google.Api.Gax.Rest.Tests/PageStreamingTest.cs
+++ b/Google.Api.Gax.Rest.Tests/PageStreamingTest.cs
@@ -293,7 +293,7 @@ namespace Google.Api.Gax.Rest
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest(server) { PageSize = 0 };
             var paged = server.PagedSync(request);
-            Assert.Throws<NotSupportedException>(() => paged.ReadPage(1));
+            Assert.NotEqual(0, paged.Count());
         }
 
         [Fact]
@@ -302,7 +302,7 @@ namespace Google.Api.Gax.Rest
             var server = new FakeServer(s_resourceA, 1);
             var request = new PageStreamingRequest(server) { PageSize = 0 };
             var paged = server.PagedAsync(request);
-            await Assert.ThrowsAsync<NotSupportedException>(() => paged.ReadPageAsync(1));
+            Assert.NotEqual(0, await paged.CountAsync());
         }
 
         private class PageStreamingRequest : IClientServiceRequest<PageStreamingResponse>

--- a/Google.Api.Gax.Rest/RestPagedAsyncEnumerable.cs
+++ b/Google.Api.Gax.Rest/RestPagedAsyncEnumerable.cs
@@ -8,7 +8,6 @@
 using Google.Apis.Requests;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -153,11 +152,6 @@ namespace Google.Api.Gax.Rest
                 var current = await request.ExecuteAsync(cancellationToken).ConfigureAwait(false);
                 var resources = _pageManager.GetResourcesEmptyIfNull(current);
                 items.AddRange(resources);
-                if (items.Count > pageSize)
-                {
-                    throw new NotSupportedException("Invalid server response: " +
-                        $"requested {requestCount} items, received {resources.Count()} items");
-                }
                 nextPageToken = _pageManager.GetNextPageToken(current);
                 if (nextPageToken == null)
                 {

--- a/Google.Api.Gax.Rest/RestPagedEnumerable.cs
+++ b/Google.Api.Gax.Rest/RestPagedEnumerable.cs
@@ -7,7 +7,6 @@
 
 using Google.Apis.Requests;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -76,11 +75,6 @@ namespace Google.Api.Gax.Rest
                 var current = request.Execute();
                 var resources = _pageManager.GetResourcesEmptyIfNull(current);
                 items.AddRange(resources);
-                if (items.Count > pageSize)
-                {
-                    throw new NotSupportedException("Invalid server response: " +
-                        $"requested {requestCount} items, received {resources.Count()} items");
-                }
                 nextPageToken = _pageManager.GetNextPageToken(current);
                 if (nextPageToken == null)
                 {

--- a/Google.Api.Gax/PagedAsyncEnumerable.cs
+++ b/Google.Api.Gax/PagedAsyncEnumerable.cs
@@ -33,8 +33,23 @@ namespace Google.Api.Gax
         }
 
         /// <summary>
-        /// Eagerly (but asynchronously) reads a single page of results with a fixed maximum size. The returned page is guaranteed
-        /// to have that many results, unless there is no more data available.
+        /// Eagerly reads a single page of results with a fixed maximum size. The returned page is not guaranteed
+        /// to have that many results:
+        /// <list type="bullet">
+        /// <item>
+        /// The resulting page may contain fewer than <paramref name="pageSize"/> items if there were not that many items available.
+        /// </item>
+        /// <item>
+        /// The resulting page may contain more than <paramref name="pageSize"/> items,
+        /// if <typeparamref name="TResource"/> is a key-value pair, where the value is itself a collection of items.
+        /// In such cases, an arbitrary number of keys may appear, including keys with an empty collection value.
+        /// The underlying API should guarantee that the number of elements across all value collections is <paramref name="pageSize"/>
+        /// at most.
+        /// </item>
+        /// <item>
+        /// Otherwise, the underlying API should guarantee that the return page contains exactly <paramref name="pageSize"/> items.
+        /// </item>
+        /// </list>
         /// </summary>
         /// <remarks>
         /// "Natural" pages returned by the API may contain a smaller number of resources than requested.

--- a/Google.Api.Gax/PagedEnumerable.cs
+++ b/Google.Api.Gax/PagedEnumerable.cs
@@ -32,8 +32,23 @@ namespace Google.Api.Gax
         }
 
         /// <summary>
-        /// Eagerly reads a single page of results with a fixed maximum size. The returned page is guaranteed
-        /// to have that many results, unless there is no more data available.
+        /// Eagerly reads a single page of results with a fixed maximum size. The returned page is not guaranteed
+        /// to have that many results:
+        /// <list type="bullet">
+        /// <item>
+        /// The resulting page may contain fewer than <paramref name="pageSize"/> items if there were not that many items available.
+        /// </item>
+        /// <item>
+        /// The resulting page may contain more than <paramref name="pageSize"/> items,
+        /// if <typeparamref name="TResource"/> is a key-value pair, where the value is itself a collection of items.
+        /// In such cases, an arbitrary number of keys may appear, including keys with an empty collection value.
+        /// The underlying API should guarantee that the number of elements across all value collections is <paramref name="pageSize"/>
+        /// at most.
+        /// </item>
+        /// <item>
+        /// Otherwise, the underlying API should guarantee that the return page contains exactly <paramref name="pageSize"/> items.
+        /// </item>
+        /// </list>
         /// </summary>
         /// <remarks>
         /// "Natural" pages returned by the API may contain a smaller number of resources than requested.


### PR DESCRIPTION
This relies on the API to do the right thing and avoids breaking Compute's Aggregate pagination methods. See b/481247371.