### PR TITLE
feat: add new CloudRunJob platform

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/MonitoringResourceBuilderTest.cs
@@ -80,6 +80,21 @@ namespace Google.Api.Gax.Grpc.Tests
         }
 
         [Fact]
+        public void CloudRunJobPlatform()
+        {
+            var details = new CloudRunJobPlatformDetails("json", "projectId", "us-central1-1", "job");
+            var resource = MonitoredResourceBuilder.FromPlatform(new Platform(details));
+            Assert.Equal("cloud_run_job", resource.Type);
+            Assert.Equal(new Dictionary<string, string>
+            {
+                { "project_id", "projectId" },
+                // Note this is the region, not the zone
+                { "location", "us-central1" },
+                { "job_name", "job" }
+            }, resource.Labels);
+        }
+
+        [Fact]
         public void GkePlatform()
         {
             const string metadataJson = @"

--- a/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
+++ b/Google.Api.Gax.Grpc/MonitoredResourceBuilder.cs
@@ -111,6 +111,18 @@ namespace Google.Api.Gax.Grpc
                             { "configuration_name", cloudRun.ConfigurationName }
                         }
                     };
+                case PlatformType.CloudRunJob:
+                    var cloudRunJob = platform.CloudRunJobDetails;
+                    return new MonitoredResource
+                    {
+                        Type = "cloud_run_job",
+                        Labels =
+                        {
+                            { "project_id", cloudRunJob.ProjectId },
+                            { "job_name", cloudRunJob.JobName },
+                            { "location", cloudRunJob.Region }
+                        }
+                    };
 
                 default:
                     // This isn't great, but is better than throwing an exception.

--- a/Google.Api.Gax.Tests/PlatformTest.cs
+++ b/Google.Api.Gax.Tests/PlatformTest.cs
@@ -86,6 +86,26 @@ namespace Google.Api.Gax.Tests
         }
 
         [Fact]
+        public void CloudRunJob_Valid()
+        {
+            var details = new CloudRunJobPlatformDetails("json", "project", "us-central1-1", "job");
+            Assert.Equal("json", details.MetadataJson);
+            Assert.Equal("project", details.ProjectId);
+            Assert.Equal("us-central1-1", details.Zone);
+            Assert.Equal("us-central1", details.Region);
+            Assert.Equal("job", details.JobName);
+        }
+
+        [Fact]
+        public void CloudRunJob_Invalid()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CloudRunJobPlatformDetails(null, "", "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunJobPlatformDetails("", null, "", ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunJobPlatformDetails("", "", null, ""));
+            Assert.Throws<ArgumentNullException>(() => new CloudRunJobPlatformDetails("", "", "", null));
+        }
+
+        [Fact]
         public void Gke_NoData()
         {
             Assert.Throws<ArgumentNullException>(() => GkePlatformDetails.TryLoad(null, new GkePlatformDetails.KubernetesData()));
@@ -278,6 +298,14 @@ namespace Google.Api.Gax.Tests
             var details = new CloudRunPlatformDetails("json", "cr-project", "us-central1-1", "service", "revision", "configuration");
             var platform = new Platform(details);
             Assert.Equal("cr-project", platform.ProjectId);
+        }
+
+        [Fact]
+        public void Project_CloudRunJob()
+        {
+            var details = new CloudRunJobPlatformDetails("json", "crj-project", "us-central1-1", "job");
+            var platform = new Platform(details);
+            Assert.Equal("crj-project", platform.ProjectId);
         }
 
         [Fact]

--- a/Google.Api.Gax/CloudRunJobPlatformDetails.cs
+++ b/Google.Api.Gax/CloudRunJobPlatformDetails.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+
+namespace Google.Api.Gax;
+
+/// <summary>
+/// Google Cloud Run Job details.
+/// </summary>
+public sealed class CloudRunJobPlatformDetails
+{
+    /// <summary>
+    /// Builds a <see cref="CloudRunJobPlatformDetails"/> from the given metadata
+    /// and Cloud Run Job environment variables.
+    /// The metadata is normally retrieved from the GCE metadata server.
+    /// </summary>
+    /// <param name="metadataJson">JSON metadata, normally retrieved from the GCE metadata server.
+    /// Must not be <c>null</c>.</param>
+    /// <returns>A populated <see cref="CloudRunJobPlatformDetails"/> if the metadata represents a Cloud Run Job;
+    /// <c>null</c> otherwise.</returns>
+    public static CloudRunJobPlatformDetails TryLoad(string metadataJson)
+    {
+        // Check environment variables first, to avoid more expensive JSON parsing.
+        string jobName = Environment.GetEnvironmentVariable("CLOUD_RUN_JOB");
+        if (jobName is null)
+        {
+            return null;
+        }
+
+        GaxPreconditions.CheckNotNull(metadataJson, nameof(metadataJson));
+        JObject metadata;
+        try
+        {
+            metadata = JObject.Parse(metadataJson);
+        }
+        catch
+        {
+            return null;
+        }
+
+        var projectId = metadata["project"]?["projectId"]?.ToString();
+        var zoneName = metadata["instance"]?["zone"]?.ToString();
+        if (projectId == null || zoneName == null || !Platform.s_zoneTemplate.TryParseName(zoneName, out var zoneResourceName))
+        {
+            return null;
+        }
+        string zone = zoneResourceName[1];
+        return new CloudRunJobPlatformDetails(metadataJson, projectId, zone, jobName);
+    }
+
+    /// <summary>
+    /// Constructs details of a Google Cloud Run job execution.
+    /// </summary>
+    /// <param name="metadataJson">JSON metadata, normally retrieved from the GCE metadata server.
+    /// Must not be <c>null</c>.</param>
+    /// <param name="projectId">The project ID. Must not be null.</param>
+    /// <param name="zone">The zone in which the job code is running. Must not be null.</param>
+    /// <param name="jobName">The name of the job. Must not be null.</param>
+    public CloudRunJobPlatformDetails(string metadataJson, string projectId, string zone, string jobName)
+    {
+        MetadataJson = GaxPreconditions.CheckNotNull(metadataJson, nameof(metadataJson));
+        ProjectId = GaxPreconditions.CheckNotNull(projectId, nameof(projectId));
+        Zone = GaxPreconditions.CheckNotNull(zone, nameof(zone));
+        Region = string.Join("-", Zone.Split('-').Take(2));
+        JobName = GaxPreconditions.CheckNotNull(jobName, nameof(jobName));
+    }
+
+    /// <summary>
+    /// The full JSON string retrieved from the metadata server. This is never null.
+    /// </summary>
+    public string MetadataJson { get; }
+
+    /// <summary>
+    /// The Project ID under which this service is running. This is never null.
+    /// </summary>
+    public string ProjectId { get; }
+
+    /// <summary>
+    /// The zone of the service, e.g. "us-central1-1". This is never null.
+    /// </summary>
+    public string Zone { get; }
+
+    /// <summary>
+    /// The region part of the zone. For example, a zone of "us-central1-1" has a region
+    /// of "us-central1".
+    /// </summary>
+    public string Region { get; }
+
+    /// <summary>
+    /// The name of the Cloud Run job being run. This is never null.
+    /// </summary>
+    public string JobName { get; }
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"[Cloud Run Job: ProjectId='{ProjectId}', Zone='{Zone}', JobName='{JobName}']";
+}

--- a/Google.Api.Gax/Platform.cs
+++ b/Google.Api.Gax/Platform.cs
@@ -164,6 +164,11 @@ namespace Google.Api.Gax
                 {
                     return new Platform(cloudRunDetails);
                 }
+                CloudRunJobPlatformDetails cloudRunJobDetails = CloudRunJobPlatformDetails.TryLoad(metadataJson);
+                if (cloudRunJobDetails != null)
+                {
+                    return new Platform(cloudRunJobDetails);
+                }
                 GcePlatformDetails gceDetails = GcePlatformDetails.TryLoad(metadataJson);
                 if (gceDetails != null)
                 {
@@ -218,6 +223,15 @@ namespace Google.Api.Gax
         }
 
         /// <summary>
+        /// Construct with details of Google Cloud Run Job.
+        /// </summary>
+        /// <param name="cloudRunJobDetails">Details of Google Cloud Run Job.</param>
+        public Platform(CloudRunJobPlatformDetails cloudRunJobDetails)
+        {
+            CloudRunJobDetails = GaxPreconditions.CheckNotNull(cloudRunJobDetails, nameof(cloudRunJobDetails));
+        }
+
+        /// <summary>
         /// Google App Engine (GAE) platform details.
         /// <c>null</c> if not executing on GAE.
         /// </summary>
@@ -225,21 +239,27 @@ namespace Google.Api.Gax
 
         /// <summary>
         /// Google Compute Engine (GCE) platform details.
-        /// <c>null</c> if not executing on GCE. 
+        /// <c>null</c> if not executing on GCE.
         /// </summary>
         public GcePlatformDetails GceDetails { get; }
 
         /// <summary>
         /// Google Container (Kubernetes) Engine (GKE) platform details.
-        /// <c>null</c> if not executing on GKE. 
+        /// <c>null</c> if not executing on GKE.
         /// </summary>
         public GkePlatformDetails GkeDetails { get; }
 
         /// <summary>
         /// Google Cloud Run platform details.
-        /// <c>null</c> if not executing on Google Cloud Run. 
+        /// <c>null</c> if not executing on Google Cloud Run.
         /// </summary>
         public CloudRunPlatformDetails CloudRunDetails { get; }
+
+        /// <summary>
+        /// Google Cloud Run Job platform details.
+        /// <c>null</c> if not executing on Google Cloud Run Job.
+        /// </summary>
+        public CloudRunJobPlatformDetails CloudRunJobDetails { get; }
 
         /// <summary>
         /// The current execution platform.
@@ -249,6 +269,7 @@ namespace Google.Api.Gax
             GceDetails != null ? PlatformType.Gce :
             GkeDetails != null ? PlatformType.Gke :
             CloudRunDetails != null ? PlatformType.CloudRun :
+            CloudRunJobDetails != null ? PlatformType.CloudRunJob :
             PlatformType.Unknown;
 
         /// <summary>
@@ -259,7 +280,8 @@ namespace Google.Api.Gax
             GaeDetails?.ProjectId ??
             GceDetails?.ProjectId ??
             GkeDetails?.ProjectId ??
-            CloudRunDetails?.ProjectId;
+            CloudRunDetails?.ProjectId ??
+            CloudRunJobDetails?.ProjectId;
 
         /// <inheritdoc/>
         public override string ToString()
@@ -274,6 +296,8 @@ namespace Google.Api.Gax
                     return GkeDetails.ToString();
                 case PlatformType.CloudRun:
                     return CloudRunDetails.ToString();
+                case PlatformType.CloudRunJob:
+                    return CloudRunJobDetails.ToString();
                 case PlatformType.Unknown:
                     return "[Unknown platform]";
                 default:

--- a/Google.Api.Gax/PlatformType.cs
+++ b/Google.Api.Gax/PlatformType.cs
@@ -35,6 +35,11 @@ namespace Google.Api.Gax
         /// <summary>
         /// Execution platform is Google Cloud Run.
         /// </summary>
-        CloudRun = 4
+        CloudRun = 4,
+
+        /// <summary>
+        /// Execution platform is Google Cloud Run Job.
+        /// </summary>
+        CloudRunJob = 5
     }
 }


### PR DESCRIPTION
# Context

I use the https://github.com/manigandham/serilog-sinks-googlecloudlogging lib to push logs to Cloud Logging. The lib is able to infer the runtime context to enrich logs with attributes about the execution environment. It does so using the `MonitoredResourceBuilder`. 

It appears the class has no platform for Cloud Run Job, but only Cloud Run services.

I would like to add a `CloudRunJob` platform to enrich logs with the job name, execution name, and resource type.