### PR TITLE
chore: Update renovate to best-practices preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,12 @@
 {
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":disableDependencyDashboard"
   ],
-  "ignorePresets": [":ignoreModulesAndTests"],
+  "ignorePresets": [
+    ":ignoreModulesAndTests",
+    ":maintainLockFilesWeekly"
+  ],
   "ignorePaths": [
     "Google.Api.CommonProtos/**",
     "Google.Api.Gax/**",


### PR DESCRIPTION
b/529786849

Opening up the renovate changes here first just so we have an idea of what kind of noise might come. Renovate does not define it's meaning of `massaging` but I understand that Renovate has under the hood been running `base` as `recommended` for some time now. The differences between `recommended` and `best-practices` can be seen [here](https://docs.renovatebot.com/presets-config/#configbest-practices).

Most changes are version pinning which will be good to help maintain the zizmor work.

`:configMigration` Will suggest updates to the renovate config itself as new features are added or deprecated. This should be fine as is for all our repos except `google-cloud-dotnet`, where the PR changes will need to be manually ported over to `generator-input/renovate-template.json`

I've ignored the `:maintainLockFilesWeekly` preset since we don't use them