### PR TITLE
fix: Validate path parameters against path traversal dot segments

### DIFF
--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -95,7 +95,23 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             {
                 request = new RuleTestRequest { X = xValue };
             }
-            Assert.Throws<ArgumentException>(() => rulePathPattern.TryFormat(request));
+            var exception = Assert.Throws<ArgumentException>(() => rulePathPattern.TryFormat(request));
+            string unescaped = Uri.UnescapeDataString(xValue);
+            bool hasDoubleDot = false;
+            bool hasSingleDot = false;
+            foreach (var segment in unescaped.Split('/'))
+            {
+                if (segment == "..") hasDoubleDot = true;
+                if (segment == ".") hasSingleDot = true;
+            }
+            if (hasDoubleDot)
+            {
+                Assert.Contains("contains invalid segment '..'", exception.Message);
+            }
+            else if (hasSingleDot)
+            {
+                Assert.Contains("contains invalid segment '.'", exception.Message);
+            }
         }
 
         [Theory]

--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -70,8 +70,6 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
         // Dialogflow session (standard single-wildcard segment)
         [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/..")]
         [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/.")]
-        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1?key=val")]
-        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1#frag")]
         // Firestore documents (reserved double-wildcard path)
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../default")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../../../../../../escape-db")]
@@ -98,12 +96,6 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             var exception = Assert.Throws<ArgumentException>(() => rulePathPattern.TryFormat(request));
             string unescaped = Uri.UnescapeDataString(xValue);
 
-            if (unescaped.Contains("?") || unescaped.Contains("#"))
-            {
-                Assert.StartsWith($"Path parameter 'x' contains invalid character", exception.Message);
-                return;
-            }
-
             bool isReserved = pattern.Contains("**");
             bool hasDoubleDot = false;
             bool hasSingleDot = false;
@@ -127,9 +119,13 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
 
         [Theory]
         [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1", "v3/projects/p/locations/l/agents/a/sessions/s1:detectIntent")]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1?key=val", "v3/projects/p/locations/l/agents/a/sessions/s1%3Fkey%3Dval:detectIntent")]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1#frag", "v3/projects/p/locations/l/agents/a/sessions/s1%23frag:detectIntent")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1", "v1/projects/sys-prod-123/databases/default/documents/doc-1/indexes")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/my-file.txt", "v1/projects/sys-prod-123/databases/default/documents/my-file.txt/indexes")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/my-file..txt", "v1/projects/sys-prod-123/databases/default/documents/my-file..txt/indexes")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc?key=val", "v1/projects/sys-prod-123/databases/default/documents/doc%3Fkey%3Dval/indexes")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc#frag", "v1/projects/sys-prod-123/databases/default/documents/doc%23frag/indexes")]
         public void ValidRealisticPatterns_Succeed(string pattern, string xValue, string expectedFormatResult)
         {
             var rulePathPattern = ParsePattern(pattern);

--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -76,6 +76,8 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../default")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../../../../../../escape-db")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e/escape-db")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/..%2f..%2fescape-db")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e%2f%2e%2e%2fescape-db")]
         [InlineData("v1/{x=**}/indexes", "../escape-db")]
         [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/./child")]
         // Webhooks (multiple standard wildcards)

--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -66,6 +66,49 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             Assert.Throws<ArgumentException>(() => HttpRulePathPattern.Parse(pattern, RuleTestRequest.Descriptor));
         }        
 
+        [Theory]
+        // Dialogflow session (standard single-wildcard segment)
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/..")]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/.")]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1?key=val")]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1#frag")]
+        // Firestore documents (reserved double-wildcard path)
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../default")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/../../../../../../../escape-db")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e/escape-db")]
+        [InlineData("v1/{x=**}/indexes", "../escape-db")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1/./child")]
+        // Webhooks (multiple standard wildcards)
+        [InlineData("v3/projects/{x}/webhooks/{nested.a}", "..")]
+        [InlineData("v3/projects/{x}/webhooks/{nested.a}", ".")]
+        public void PathTraversalAndInjection_ThrowsArgumentException(string pattern, string xValue)
+        {
+            var rulePathPattern = ParsePattern(pattern);
+            RuleTestRequest request;
+            if (pattern.Contains("nested.a"))
+            {
+                request = new RuleTestRequest { X = "p1", Nested = new RuleTestRequest.Types.Nested { A = xValue } };
+            }
+            else
+            {
+                request = new RuleTestRequest { X = xValue };
+            }
+            Assert.Throws<ArgumentException>(() => rulePathPattern.TryFormat(request));
+        }
+
+        [Theory]
+        [InlineData("v3/{x=projects/*/locations/*/agents/*/sessions/*}:detectIntent", "projects/p/locations/l/agents/a/sessions/s1", "v3/projects/p/locations/l/agents/a/sessions/s1:detectIntent")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/doc-1", "v1/projects/sys-prod-123/databases/default/documents/doc-1/indexes")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/my-file.txt", "v1/projects/sys-prod-123/databases/default/documents/my-file.txt/indexes")]
+        [InlineData("v1/{x=projects/*/databases/*/documents/**}/indexes", "projects/sys-prod-123/databases/default/documents/my-file..txt", "v1/projects/sys-prod-123/databases/default/documents/my-file..txt/indexes")]
+        public void ValidRealisticPatterns_Succeed(string pattern, string xValue, string expectedFormatResult)
+        {
+            var rulePathPattern = ParsePattern(pattern);
+            var request = new RuleTestRequest { X = xValue };
+            string actualFormatResult = rulePathPattern.TryFormat(request);
+            Assert.Equal(expectedFormatResult, actualFormatResult);
+        }
+
         private static HttpRulePathPattern ParsePattern(string pattern) =>
             HttpRulePathPattern.Parse(pattern, RuleTestRequest.Descriptor);
     }

--- a/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
+++ b/Google.Api.Gax.Grpc.Tests/Rest/HttpRulePathPatternTest.cs
@@ -97,6 +97,14 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
             }
             var exception = Assert.Throws<ArgumentException>(() => rulePathPattern.TryFormat(request));
             string unescaped = Uri.UnescapeDataString(xValue);
+
+            if (unescaped.Contains("?") || unescaped.Contains("#"))
+            {
+                Assert.StartsWith($"Path parameter 'x' contains invalid character", exception.Message);
+                return;
+            }
+
+            bool isReserved = pattern.Contains("**");
             bool hasDoubleDot = false;
             bool hasSingleDot = false;
             foreach (var segment in unescaped.Split('/'))
@@ -104,13 +112,16 @@ namespace Google.Api.Gax.Grpc.Rest.Tests
                 if (segment == "..") hasDoubleDot = true;
                 if (segment == ".") hasSingleDot = true;
             }
-            if (hasDoubleDot)
+
+            string paramName = pattern.Contains("nested.a") ? "nested.a" : "x";
+            if (!isReserved)
             {
-                Assert.Contains("contains invalid segment '..'", exception.Message);
+                string matchedDot = hasDoubleDot ? ".." : (hasSingleDot ? "." : "");
+                Assert.StartsWith($"Invalid value '{matchedDot}' for {paramName}", exception.Message);
             }
-            else if (hasSingleDot)
+            else
             {
-                Assert.Contains("contains invalid segment '.'", exception.Message);
+                Assert.StartsWith($"Value for {paramName} must not contain segments that are exactly . or ..", exception.Message);
             }
         }
 

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -259,22 +259,66 @@ internal sealed class HttpRulePathPattern
             // Reject query (?) or fragment (#) injections as defense-in-depth.
             // Although segment-level Uri.EscapeDataString escapes these characters, this check
             // guarantees explicit validation if the escaping behavior is modified in the future.
-            if (result.Contains("?") || result.Contains("#"))
+            if (result.IndexOf('?') != -1 || result.IndexOf('#') != -1)
             {
                 throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid characters '?' or '#': '{result}'");
             }
-            // Unescape the entire value first and split by '/' to prevent bypasses using URL-encoded slashes (e.g. %2f).
+
+            // Unescape the entire value first to prevent bypasses using URL-encoded slashes (e.g. %2f).
             string unescapedVal = Uri.UnescapeDataString(result);
-            string[] segments = unescapedVal.Split('/');
-            foreach (var segment in segments)
+            // Scan for '.' and '..' segments in place using char-index scanning to avoid heap allocations.
+            int valStart = 0;
+            while (valStart < unescapedVal.Length)
             {
-                if (segment == "." || segment == "..")
+                int nextSlash = unescapedVal.IndexOf('/', valStart);
+                int segmentLength = nextSlash == -1 ? unescapedVal.Length - valStart : nextSlash - valStart;
+
+                if (segmentLength == 1 && unescapedVal[valStart] == '.')
                 {
                     throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
                 }
+                if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
+                {
+                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
+                }
+
+                if (nextSlash == -1)
+                {
+                    break;
+                }
+                valStart = nextSlash + 1;
             }
-            // Escape everything except slashes
-            return string.Join("/", result.Split('/').Select(segment => Uri.EscapeDataString(segment)));
+
+            // Escape everything except slashes.
+            // If the parameter contains no slashes, we can avoid splitting/rebuilding entirely.
+            int firstSlash = result.IndexOf('/');
+            if (firstSlash == -1)
+            {
+                return Uri.EscapeDataString(result);
+            }
+
+            // Otherwise, rebuild the string escaping each segment manually.
+            var builder = new StringBuilder(result.Length * 2);
+            int start = 0;
+            while (start < result.Length)
+            {
+                int nextSlash = result.IndexOf('/', start);
+                int length = nextSlash == -1 ? result.Length - start : nextSlash - start;
+
+                if (length > 0)
+                {
+                    builder.Append(Uri.EscapeDataString(result.Substring(start, length)));
+                }
+
+                if (nextSlash == -1)
+                {
+                    break;
+                }
+
+                builder.Append('/');
+                start = nextSlash + 1;
+            }
+            return builder.ToString();
         }
     }
 

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -127,6 +127,7 @@ internal sealed class HttpRulePathPattern
 
         private readonly Regex _validationRegex;
         private readonly Func<IMessage, string> _propertyAccessor;
+        private readonly bool _isReserved;
 
         /// <summary>
         /// Creates a segment representing the given field text, with respect to
@@ -144,6 +145,7 @@ internal sealed class HttpRulePathPattern
             string fieldPath = bits[0];
             string pattern = bits.Length == 2 ? bits[1] : "*";
             _validationRegex = ConvertPatternForValidation(pattern);
+            _isReserved = pattern.Contains("**");
 
             string[] fieldNames = fieldPath.Split(s_fieldPathSeparator);
 
@@ -275,11 +277,25 @@ internal sealed class HttpRulePathPattern
 
                 if (segmentLength == 1 && unescapedVal[valStart] == '.')
                 {
-                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.': '{result}'");
+                    if (!_isReserved)
+                    {
+                        throw new ArgumentException($"Invalid value '.' for {JsonFieldPath}");
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Value for {JsonFieldPath} must not contain segments that are exactly . or ..");
+                    }
                 }
                 if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
                 {
-                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '..': '{result}'");
+                    if (!_isReserved)
+                    {
+                        throw new ArgumentException($"Invalid value '..' for {JsonFieldPath}");
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Value for {JsonFieldPath} must not contain segments that are exactly . or ..");
+                    }
                 }
 
                 if (nextSlash == -1)

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -275,11 +275,11 @@ internal sealed class HttpRulePathPattern
 
                 if (segmentLength == 1 && unescapedVal[valStart] == '.')
                 {
-                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
+                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.': '{result}'");
                 }
                 if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
                 {
-                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
+                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '..': '{result}'");
                 }
 
                 if (nextSlash == -1)

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -263,13 +263,12 @@ internal sealed class HttpRulePathPattern
             {
                 throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid characters '?' or '#': '{result}'");
             }
-            // Split path parameter value by '/' and reject any standalone dot (.) or double-dot (..) segments
-            // (either literal or URL-encoded) to prevent path traversal exploits.
-            string[] segments = result.Split('/');
+            // Unescape the entire value first and split by '/' to prevent bypasses using URL-encoded slashes (e.g. %2f).
+            string unescapedVal = Uri.UnescapeDataString(result);
+            string[] segments = unescapedVal.Split('/');
             foreach (var segment in segments)
             {
-                string unescaped = Uri.UnescapeDataString(segment);
-                if (unescaped == "." || unescaped == "..")
+                if (segment == "." || segment == "..")
                 {
                     throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
                 }

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2020 Google LLC
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file or at
@@ -255,6 +255,19 @@ internal sealed class HttpRulePathPattern
             if (result is null || !_validationRegex.IsMatch(result))
             {
                 return null;
+            }
+            // Reject query (?) or fragment (#) injections as defense-in-depth.
+            // Although segment-level Uri.EscapeDataString escapes these characters, this check
+            // guarantees explicit validation if the escaping behavior is modified in the future.
+            if (result.Contains("?") || result.Contains("#"))
+            {
+                throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid characters '?' or '#': '{result}'");
+            }
+            // Split path parameter value by '/' and reject any standalone dot (.) or double-dot (..) segments
+            // (either literal or URL-encoded) to prevent path traversal exploits.
+            if (result.Split('/').Select(segment => Uri.UnescapeDataString(segment)).Any(s => s == "." || s == ".."))
+            {
+                throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
             }
             // Escape everything except slashes
             return string.Join("/", result.Split('/').Select(segment => Uri.EscapeDataString(segment)));

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -258,14 +258,6 @@ internal sealed class HttpRulePathPattern
             {
                 return null;
             }
-            // Reject query (?) or fragment (#) injections as defense-in-depth.
-            // Although segment-level Uri.EscapeDataString escapes these characters, this check
-            // guarantees explicit validation if the escaping behavior is modified in the future.
-            if (result.IndexOf('?') != -1 || result.IndexOf('#') != -1)
-            {
-                throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid characters '?' or '#': '{result}'");
-            }
-
             // Unescape the entire value first to prevent bypasses using URL-encoded slashes (e.g. %2f).
             string unescapedVal = Uri.UnescapeDataString(result);
             // Scan for '.' and '..' segments in place using char-index scanning to avoid heap allocations.

--- a/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
+++ b/Google.Api.Gax.Grpc/Rest/HttpRulePathPattern.cs
@@ -265,9 +265,14 @@ internal sealed class HttpRulePathPattern
             }
             // Split path parameter value by '/' and reject any standalone dot (.) or double-dot (..) segments
             // (either literal or URL-encoded) to prevent path traversal exploits.
-            if (result.Split('/').Select(segment => Uri.UnescapeDataString(segment)).Any(s => s == "." || s == ".."))
+            string[] segments = result.Split('/');
+            foreach (var segment in segments)
             {
-                throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
+                string unescaped = Uri.UnescapeDataString(segment);
+                if (unescaped == "." || unescaped == "..")
+                {
+                    throw new ArgumentException($"Path parameter '{JsonFieldPath}' contains invalid segment '.' or '..': '{result}'");
+                }
             }
             // Escape everything except slashes
             return string.Join("/", result.Split('/').Select(segment => Uri.EscapeDataString(segment)));


### PR DESCRIPTION
Validates and encodes path parameters in gRPC-REST path transcoding.

* Rejects '.' and '..' path segments in both single-segment and multi-segment parameters to prevent path traversal (CWE-22).
* Percent-encodes each individual path segment to prevent parameter injection (CWE-88) while preserving '/' separators for multi-segment parameters.
* Unescapes input before segment evaluation to prevent percent-encoded delimiter bypasses.
* Added unit tests for path traversal validation and segment-level escaping.

b/529889305